### PR TITLE
fix: restore LICENSE, add a working conduct contact

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -59,11 +59,11 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement through GitHub's
-private reporting route:
-<https://github.com/Vladimir-Human/ru-marketplace-mcp/security/advisories/new>,
-or by contacting the maintainer directly at <https://github.com/Vladimir-Human>.
-All complaints will be reviewed and investigated promptly and fairly.
+reported to the maintainer by email at <info@feargt.work.gd>. All complaints
+will be reviewed and investigated promptly and fairly.
+
+Security vulnerabilities go through a separate private route, described in
+[SECURITY.md](SECURITY.md) — please do not use the address above for those.
 
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.


### PR DESCRIPTION
LICENSE потерял переносы строк и получил BOM, из-за чего GitHub перестал распознавать лицензию и показывает Other; текст восстановлен из тега v1.2.1, изменена только строка копирайта. В CODE_OF_CONDUCT.md заявленный приватный канал вёл на страницу профиля, откуда написать нельзя — заменён на почту, уязвимости отправлены в SECURITY.md.