### PR TITLE
docs: credit @Xpos587 for the MPStats connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@
 опционален: без `MPSTATS_MP_AUTH` сервер запускается, инструменты отвечают
 `auth_missing`, а остальные двенадцать серверов работают как прежде.
 
+Первоначальный код коннектора прислал [@Xpos587](https://github.com/Xpos587) в
+[PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5). Здесь он
+переработан под инварианты, которых держится остальной проект, но идея, разбор
+API плагина и структура парсеров — его.
+
 ### Добавлено
 
 **Новый сервер `mpstats-mcp` (3 инструмента)**
@@ -521,6 +526,11 @@ server worked over anonymous scrape endpoints with no keys; MPStats is a
 different kind: an analytics layer over Ozon/Wildberries with a quota and an
 account. It is optional: without `MPSTATS_MP_AUTH` the server boots, the tools
 answer `auth_missing`, and the other twelve servers behave exactly as before.
+
+The connector's original code came from [@Xpos587](https://github.com/Xpos587) in
+[PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5). It was
+reworked here for the invariants the rest of the project holds to, but the idea,
+the plugin API work and the parser structure are his.
 
 ### Added
 

--- a/README.md
+++ b/README.md
@@ -515,6 +515,12 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 Вопрос «кто набрал текст» кажется мне менее интересным, чем вопрос «чем это
 проверено». Второй здесь задокументирован, и проверить его может любой.
 
+## Спасибо
+
+[@Xpos587](https://github.com/Xpos587) — коннектор MPStats
+([PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5)):
+разбор API плагина, структура парсеров и первая рабочая версия.
+
 ## Лицензия
 
 MIT, файл [LICENSE](LICENSE).
@@ -872,6 +878,12 @@ compared against live pages by hand and which were left unverified.
 
 Who typed the text seems a less interesting question than what checks it survived.
 The second one is documented here, and anyone can re-run it.
+
+## Thanks
+
+[@Xpos587](https://github.com/Xpos587) for the MPStats connector
+([PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5)): the
+plugin API work, the parser structure and the first working version.
 
 ## License
 


### PR DESCRIPTION
Коннектор MPStats вышел в v1.3.0, но PR #5 смержить было нельзя — его ветка старше двух релизов. Указание автора добавлено в CHANGELOG (обе секции) и в раздел «Спасибо» README, чтобы оно жило в репозитории, а не только на странице релиза.