### PR TITLE
fix: hardening — DOM extractors, currency glyphs, card fixtures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,7 +85,7 @@ jobs:
         run: uv run python scripts/check_test_count.py
 
       - name: One version, everywhere
-        # A release version is written down in fifty-nine places. Preparing
+        # A release version is written down in seventy-two places. Preparing
         # 1.2.1 moved fourteen pyproject.toml files and left thirteen
         # __version__ strings behind — installed packages would have reported
         # the previous release. Nothing was comparing them; now something is.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         pass_filenames: false
 
       - id: check-versions
-        # Version strings live in fifty-nine places and are edited by hand at
+        # Version strings live in seventy-two places and are edited by hand at
         # release time; the one that gets missed is silent.
         name: one version, everywhere
         entry: python scripts/check_versions.py

--- a/README.md
+++ b/README.md
@@ -22,20 +22,20 @@
 
 ## Что внутри
 
-| Сервер | Инструментов | Что нужно, чтобы читалось | Что умеет |
-|---|---|---|---|
-| **Wildberries** | 9 | анонимный HTTP | Поиск, карточки, отзывы, вопросы о товаре, реквизиты продавца, каталог и товары категории |
-| **Яндекс Маркет** | 3 | анонимный HTTP | Цены разных продавцов, разбивка оценок по звёздам, отзывы |
-| **Детский мир** | 4 | анонимный HTTP | Детские товары, наличие в офлайн-магазинах, категории |
-| **Ozon** | 4 | ваш Chrome; с домашнего IP часто и без него | Поиск, карточки, отзывы |
-| **Авито** | 4 | ваш Chrome + российский домашний IP и запросы вразрядку — иначе блок по IP | Поиск объявлений, карточки, репутация продавца |
-| **Taobao** | 3 | ваш Chrome с активным входом в Taobao | Поиск и карточки, цены в юанях |
-| **Мегамаркет** | 3 | ваш Chrome с активным входом — анонимной сессии API отдаёт пусто | Поиск и карточки через мобильный API |
-| **Lamoda** | 3 | карточки анонимно (GraphQL), поиск — ваш Chrome | Поиск, карточки с размерами |
-| **DNS** | 3 | ваш Chrome (Qrator) | Поиск и карточки электроники |
-| **Ситилинк** | 3 | ваш Chrome (Qrator) | Поиск и карточки электроники |
-| **Сравнение** | 2 | опрашивает всё перечисленное | «Где дешевле?» одним вызовом |
-| **MPStats** | 3 | платный аккаунт MPStats, cookie `mp_auth` (опционально) | Продажи/остатки/графики за 30 дней по SKU Ozon/WB, остатки по складам (FBS/FBO) |
+| Сервер            | Инструментов | Что нужно, чтобы читалось                                                  | Что умеет                                                                                 |
+| ----------------- | ------------ | -------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------- |
+| **Wildberries**   | 9            | анонимный HTTP                                                             | Поиск, карточки, отзывы, вопросы о товаре, реквизиты продавца, каталог и товары категории |
+| **Яндекс Маркет** | 3            | анонимный HTTP                                                             | Цены разных продавцов, разбивка оценок по звёздам, отзывы                                 |
+| **Детский мир**   | 4            | анонимный HTTP                                                             | Детские товары, наличие в офлайн-магазинах, категории                                     |
+| **Ozon**          | 4            | ваш Chrome; с домашнего IP часто и без него                                | Поиск, карточки, отзывы                                                                   |
+| **Авито**         | 4            | ваш Chrome + российский домашний IP и запросы вразрядку — иначе блок по IP | Поиск объявлений, карточки, репутация продавца                                            |
+| **Taobao**        | 3            | ваш Chrome с активным входом в Taobao                                      | Поиск и карточки, цены в юанях                                                            |
+| **Мегамаркет**    | 3            | ваш Chrome с активным входом — анонимной сессии API отдаёт пусто           | Поиск и карточки через мобильный API                                                      |
+| **Lamoda**        | 3            | карточки анонимно (GraphQL), поиск — ваш Chrome                            | Поиск, карточки с размерами                                                               |
+| **DNS**           | 3            | ваш Chrome (Qrator)                                                        | Поиск и карточки электроники                                                              |
+| **Ситилинк**      | 3            | ваш Chrome (Qrator)                                                        | Поиск и карточки электроники                                                              |
+| **Сравнение**     | 2            | опрашивает всё перечисленное                                               | «Где дешевле?» одним вызовом                                                              |
+| **MPStats**       | 3            | платный аккаунт MPStats, cookie `mp_auth` (опционально)                    | Продажи/остатки/графики за 30 дней по SKU Ozon/WB, остатки по складам (FBS/FBO)           |
 
 Читается анонимно, без браузера: Wildberries, Яндекс Маркет, Детский мир и
 карточки Lamoda. Остальным нужен ваш залогиненный Chrome (CDP). Taobao и
@@ -66,7 +66,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 948 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 980 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -98,9 +98,9 @@ macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
   "mcpServers": {
     "marketplace": {
       "command": "uv",
-      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "marketplace-mcp"]
-    }
-  }
+      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "marketplace-mcp"],
+    },
+  },
 }
 ```
 
@@ -117,17 +117,17 @@ macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
   "mcpServers": {
     "wildberries": {
       "command": "uv",
-      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "wb-mcp"]
+      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "wb-mcp"],
     },
     "ozon": {
       "command": "uv",
-      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "ozon-mcp"]
+      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "ozon-mcp"],
     },
     "compare-prices": {
       "command": "uv",
-      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "compare-mcp"]
-    }
-  }
+      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "compare-mcp"],
+    },
+  },
 }
 ```
 
@@ -135,6 +135,7 @@ macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 команд — `wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `avito-mcp`,
 `taobao-mcp`, `megamarket-mcp`, `lamoda-mcp`, `dns-mcp`, `citilink-mcp`,
 `compare-mcp`, `marketplace-mcp`.
+
 </details>
 
 <details>
@@ -147,6 +148,7 @@ claude mcp add detsky-mir -- uv run --directory /путь/к/ru-marketplace-mcp 
 claude mcp add ozon -- uv run --directory /путь/к/ru-marketplace-mcp ozon-mcp
 claude mcp add compare-prices -- uv run --directory /путь/к/ru-marketplace-mcp compare-mcp
 ```
+
 </details>
 
 <details>
@@ -157,11 +159,12 @@ claude mcp add compare-prices -- uv run --directory /путь/к/ru-marketplace-
   "mcpServers": {
     "compare-prices": {
       "command": "uv",
-      "args": ["run", "--directory", "/путь/к/ru-marketplace-mcp", "compare-mcp"]
-    }
-  }
+      "args": ["run", "--directory", "/путь/к/ru-marketplace-mcp", "compare-mcp"],
+    },
+  },
 }
 ```
+
 </details>
 
 <details>
@@ -171,6 +174,7 @@ claude mcp add compare-prices -- uv run --directory /путь/к/ru-marketplace-
 `wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `compare-mcp`. Серверы говорят по
 JSON-RPC через stdin и stdout, диагностику пишут в stderr. Опциональный
 `mpstats-mcp` запускается так же, с `MPSTATS_MP_AUTH` в окружении.
+
 </details>
 
 После подключения перезапустите клиент и попросите агента вызвать `wb_selfcheck`. Он
@@ -181,17 +185,17 @@ JSON-RPC через stdin и stdout, диагностику пишут в stderr
 
 ### Wildberries — `wb_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `wb_search(query, page)` | Поиск по тексту, до 100 товаров на страницу с ценами и остатками |
-| `wb_card(nm_ids)` | Пакетный запрос до 100 известных SKU |
-| `wb_root_info(nm_id)` | Находит `imt_id` (нужен для отзывов) и цветовые варианты |
-| `wb_reviews(imt_id, limit, sort)` | Пул отзывов. Ключ — `imt_id`, а не `nm_id` |
-| `wb_questions(imt_id, limit, skip, answered_only)` | Вопросы покупателей и ответы продавца. Тоже по `imt_id` |
-| `wb_seller(supplier_id)` | Юрлицо, ИНН, КПП, ОГРН, юридический адрес |
-| `wb_categories(root, max_depth)` | Дерево каталога с шардами и запросами самого WB |
-| `wb_category_products(shard, query, page, sort, dest)` | Товары категории по `shard` и `query` из `wb_categories` |
-| `wb_selfcheck()` | Канарейка на дрейф формата |
+| Инструмент                                             | Что делает                                                       |
+| ------------------------------------------------------ | ---------------------------------------------------------------- |
+| `wb_search(query, page)`                               | Поиск по тексту, до 100 товаров на страницу с ценами и остатками |
+| `wb_card(nm_ids)`                                      | Пакетный запрос до 100 известных SKU                             |
+| `wb_root_info(nm_id)`                                  | Находит `imt_id` (нужен для отзывов) и цветовые варианты         |
+| `wb_reviews(imt_id, limit, sort)`                      | Пул отзывов. Ключ — `imt_id`, а не `nm_id`                       |
+| `wb_questions(imt_id, limit, skip, answered_only)`     | Вопросы покупателей и ответы продавца. Тоже по `imt_id`          |
+| `wb_seller(supplier_id)`                               | Юрлицо, ИНН, КПП, ОГРН, юридический адрес                        |
+| `wb_categories(root, max_depth)`                       | Дерево каталога с шардами и запросами самого WB                  |
+| `wb_category_products(shard, query, page, sort, dest)` | Товары категории по `shard` и `query` из `wb_categories`         |
+| `wb_selfcheck()`                                       | Канарейка на дрейф формата                                       |
 
 `wb_seller` отвечает на вопрос, который карточка товара скрывает: кто на самом деле
 продаёт? Возвращает зарегистрированное юрлицо и налоговые номера. Так отличают
@@ -210,11 +214,11 @@ JSON-RPC через stdin и stdout, диагностику пишут в stderr
 
 ### Яндекс Маркет — `yandex_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `yandex_search(query, page, limit)` | Поиск с обеими ценами, рейтингами, продавцами |
+| Инструмент                                 | Что делает                                     |
+| ------------------------------------------ | ---------------------------------------------- |
+| `yandex_search(query, page, limit)`        | Поиск с обеими ценами, рейтингами, продавцами  |
 | `yandex_card(product_id, include_reviews)` | Карточка целиком: разбивка по звёздам и отзывы |
-| `yandex_selfcheck()` | Канарейка на дрейф формата |
+| `yandex_selfcheck()`                       | Канарейка на дрейф формата                     |
 
 **Две цены, всегда.** `price_rub` платит любой покупатель. `price_with_plus`
 требует подписку Яндекс Плюс и обычно на 25–30% ниже. Интерфейс Яндекса показывает
@@ -226,12 +230,12 @@ JSON-RPC через stdin и stdout, диагностику пишут в stderr
 
 ### Детский мир — `detmir_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `detmir_categories(parent, limit, region)` | Дерево каталога. Начинать отсюда |
-| `detmir_category(alias, limit, offset, region)` | Товары категории с настоящим счётчиком |
-| `detmir_card(product_id, region)` | Цена, рейтинг, наличие онлайн и в магазинах |
-| `detmir_selfcheck()` | Канарейка на дрейф формата |
+| Инструмент                                      | Что делает                                  |
+| ----------------------------------------------- | ------------------------------------------- |
+| `detmir_categories(parent, limit, region)`      | Дерево каталога. Начинать отсюда            |
+| `detmir_category(alias, limit, offset, region)` | Товары категории с настоящим счётчиком      |
+| `detmir_card(product_id, region)`               | Цена, рейтинг, наличие онлайн и в магазинах |
+| `detmir_selfcheck()`                            | Канарейка на дрейф формата                  |
 
 **Регион задаётся на каждый вызов.** Цены и особенно наличие в офлайн-магазинах
 сильно зависят от города: один и тот же товар лежал в 152 магазинах Москвы, 37
@@ -246,12 +250,12 @@ JSON-RPC через stdin и stdout, диагностику пишут в stderr
 
 ### Ozon — `ozon_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `ozon_search(query)` | Поиск по тексту |
-| `ozon_card(sku_or_path)` | Карточка товара |
-| `ozon_reviews(sku_or_path, limit, sort)` | Отзывы |
-| `ozon_selfcheck()` | Канарейка на дрейф формата |
+| Инструмент                               | Что делает                 |
+| ---------------------------------------- | -------------------------- |
+| `ozon_search(query)`                     | Поиск по тексту            |
+| `ozon_card(sku_or_path)`                 | Карточка товара            |
+| `ozon_reviews(sku_or_path, limit, sort)` | Отзывы                     |
+| `ozon_selfcheck()`                       | Канарейка на дрейф формата |
 
 Ozon отклоняет датацентровый трафик, поэтому коннектор двухуровневый. Сначала
 TLS-имперсонация. Если Cloudflare выдаёт челлендж, запрос выполняется внутри вашего
@@ -263,12 +267,12 @@ TLS-имперсонация. Если Cloudflare выдаёт челлендж,
 
 ### Авито — `avito_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `avito_search(query, page, location_id, category_id)` | Поиск объявлений через внутренний `js/items` API |
-| `avito_card(item_id_or_url)` | Одно объявление: цена, описание, просмотры, продавец |
-| `avito_seller(seller_id_or_url)` | Рейтинг продавца, число отзывов, активные объявления |
-| `avito_selfcheck()` | Канарейка на дрейф формата |
+| Инструмент                                            | Что делает                                           |
+| ----------------------------------------------------- | ---------------------------------------------------- |
+| `avito_search(query, page, location_id, category_id)` | Поиск объявлений через внутренний `js/items` API     |
+| `avito_card(item_id_or_url)`                          | Одно объявление: цена, описание, просмотры, продавец |
+| `avito_seller(seller_id_or_url)`                      | Рейтинг продавца, число отзывов, активные объявления |
+| `avito_selfcheck()`                                   | Канарейка на дрейф формата                           |
 
 Авито — это объявления, а не каталог: пула отзывов на товар нет, репутация
 продавца и есть сигнал доверия. Бесплатное/обменное объявление приходит с
@@ -278,11 +282,11 @@ TLS-имперсонация. Если Cloudflare выдаёт челлендж,
 
 ### Taobao — `taobao_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `taobao_search(query, page)` | Поиск по каталогу Taobao |
-| `taobao_card(item_id_or_url)` | Карточка товара |
-| `taobao_selfcheck()` | Канарейка на дрейф формата |
+| Инструмент                    | Что делает                 |
+| ----------------------------- | -------------------------- |
+| `taobao_search(query, page)`  | Поиск по каталогу Taobao   |
+| `taobao_card(item_id_or_url)` | Карточка товара            |
+| `taobao_selfcheck()`          | Канарейка на дрейф формата |
 
 Поиск Taobao — клиентское React-приложение с подписанным mtop API: каждый запрос
 требует `sign`, вычисленный из cookie-токена, поэтому анонимного пути нет.
@@ -307,10 +311,10 @@ Lamoda.
 
 ### Сравнение цен — `compare_*`
 
-| Инструмент | Что делает |
-|---|---|
-| `compare_prices(query, per_source_limit, sources)` | Все маркетплейсы сразу, с ранжированием |
-| `compare_sources()` | Какие маркетплейсы доступны в этой установке |
+| Инструмент                                         | Что делает                                   |
+| -------------------------------------------------- | -------------------------------------------- |
+| `compare_prices(query, per_source_limit, sources)` | Все маркетплейсы сразу, с ранжированием      |
+| `compare_sources()`                                | Какие маркетплейсы доступны в этой установке |
 
 ```
 compare_prices("кроссовки мужские")
@@ -348,11 +352,11 @@ compare_prices("кроссовки мужские")
 инструменты возвращают `auth_missing`, а сервер запускается как обычно — ни на
 что другое это не влияет.
 
-| Инструмент | Что делает |
-|---|---|
+| Инструмент                               | Что делает                                                                                 |
+| ---------------------------------------- | ------------------------------------------------------------------------------------------ |
 | `mpstats_item(skus, place, oz_fbs=True)` | Аналитика за 30 дней по до 100 SKU: заказы, цена, остатки, графики по дням, продавец/бренд |
-| `mpstats_warehouses(skus, place)` | Остатки по складам: FBS (склад продавца) и FBO (склад маркетплейса), `last_update` |
-| `mpstats_selfcheck()` | Канарейка: `success` / `drift_detected` / `inconclusive` |
+| `mpstats_warehouses(skus, place)`        | Остатки по складам: FBS (склад продавца) и FBO (склад маркетплейса), `last_update`         |
+| `mpstats_selfcheck()`                    | Канарейка: `success` / `drift_detected` / `inconclusive`                                   |
 
 `place` — `ozon` или `wildberries`. Графики длиной 30, от старых к новым:
 последняя ненулевая ячейка — текущая цена или остаток. Цена и остаток при
@@ -372,21 +376,21 @@ compare_prices("кроссовки мужские")
 источник вообще браться, чего у источника нет, и каким его ответам нельзя верить
 без второго взгляда.
 
-| Навык | Сервер |
-|---|---|
-| `skills/wb-connector` | `wb-mcp` |
-| `skills/ozon-connector` | `ozon-mcp` |
-| `skills/yandex-connector` | `yandex-mcp` |
-| `skills/detmir-connector` | `detmir-mcp` |
-| `skills/avito-connector` | `avito-mcp` |
-| `skills/taobao-connector` | `taobao-mcp` |
-| `skills/megamarket-connector` | `megamarket-mcp` |
-| `skills/lamoda-connector` | `lamoda-mcp` |
-| `skills/dns-connector` | `dns-mcp` |
-| `skills/citilink-connector` | `citilink-mcp` |
-| `skills/compare-prices` | `compare-mcp` |
-| `skills/mpstats-connector` | `mpstats-mcp` |
-| `skills/marketplace` | `marketplace-mcp` |
+| Навык                         | Сервер            |
+| ----------------------------- | ----------------- |
+| `skills/wb-connector`         | `wb-mcp`          |
+| `skills/ozon-connector`       | `ozon-mcp`        |
+| `skills/yandex-connector`     | `yandex-mcp`      |
+| `skills/detmir-connector`     | `detmir-mcp`      |
+| `skills/avito-connector`      | `avito-mcp`       |
+| `skills/taobao-connector`     | `taobao-mcp`      |
+| `skills/megamarket-connector` | `megamarket-mcp`  |
+| `skills/lamoda-connector`     | `lamoda-mcp`      |
+| `skills/dns-connector`        | `dns-mcp`         |
+| `skills/citilink-connector`   | `citilink-mcp`    |
+| `skills/compare-prices`       | `compare-mcp`     |
+| `skills/mpstats-connector`    | `mpstats-mcp`     |
+| `skills/marketplace`          | `marketplace-mcp` |
 
 `mcp-core` — общий рантайм под остальными серверами. Своего навыка у него нет.
 
@@ -405,21 +409,21 @@ compare_prices("кроссовки мужские")
 Все параметры задаются переменными окружения с префиксом коннектора. Все
 необязательные.
 
-| Префикс | Основные параметры |
-|---|---|
-| `WB_` | `TIMEOUT`, `MIN_GAP`, `DEFAULT_DEST`, `NET_RETRIES`, `MAX_BODY_BYTES`, `CACHE_TTL`, `PROXY` |
-| `YANDEX_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `DETMIR_` | `REGION` (`RU-MOW`, `RU-SPE` и другие), `CACHE_TTL`, `PROXY` |
-| `OZON_` | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY` |
-| `AVITO_` | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID` |
-| `TAOBAO_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `MEGAMARKET_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL` |
-| `LAMODA_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL` |
-| `CHROME_` | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH` |
-| `COMPARE_` | `SOURCE_TIMEOUT` |
-| `MPSTATS_` | `MP_AUTH` (единственный обязательный — без него инструменты отвечают `auth_missing`), `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `MCP_` | `TRANSPORT` (`stdio` по умолчанию, либо `http`), `HTTP_HOST`, `HTTP_PORT` |
+| Префикс              | Основные параметры                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| `WB_`                | `TIMEOUT`, `MIN_GAP`, `DEFAULT_DEST`, `NET_RETRIES`, `MAX_BODY_BYTES`, `CACHE_TTL`, `PROXY`                                      |
+| `YANDEX_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                       |
+| `DETMIR_`            | `REGION` (`RU-MOW`, `RU-SPE` и другие), `CACHE_TTL`, `PROXY`                                                                     |
+| `OZON_`              | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`                                                                        |
+| `AVITO_`             | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID`                                                         |
+| `TAOBAO_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                       |
+| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                                |
+| `LAMODA_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                       |
+| `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                                |
+| `CHROME_`            | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH`                                                      |
+| `COMPARE_`           | `SOURCE_TIMEOUT`                                                                                                                 |
+| `MPSTATS_`           | `MP_AUTH` (единственный обязательный — без него инструменты отвечают `auth_missing`), `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
+| `MCP_`               | `TRANSPORT` (`stdio` по умолчанию, либо `http`), `HTTP_HOST`, `HTTP_PORT`                                                        |
 
 `CHROME_CDP_HOST` указывает, куда дозвониться CDP-клиенту (по умолчанию
 `127.0.0.1`). Из контейнера ставьте `chrome` (сайдкар) или `host.docker.internal`
@@ -447,14 +451,14 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 948 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 980 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
 uv run mypy                                   # что проверять — в [tool.mypy] files
 uv run mypy --platform win32                  # ловит ошибки, видимые только на Windows
 uv run python scripts/check_no_print.py       # запись в stdout ломает JSON-RPC
-uv run python scripts/check_versions.py       # одна версия во всех 59 местах
+uv run python scripts/check_versions.py       # одна версия во всех 72 местах
 ```
 
 Часть тестов прогоняет **настоящий JS-экстрактор коннектора** по снятой разметке
@@ -507,7 +511,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 948 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 980 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -541,20 +545,20 @@ it every other server is unaffected.
 
 ## What you get
 
-| Server | Tools | What it takes to read | Notes |
-|---|---|---|---|
-| **Wildberries** | 9 | anonymous HTTP | Search, cards, reviews, buyer questions, seller legal identity, catalog tree and category listings |
-| **Yandex Market** | 3 | anonymous HTTP | Multi-seller prices, star distribution, reviews |
-| **Detsky Mir** | 4 | anonymous HTTP | Kids' goods, offline store stock, category listings |
-| **Ozon** | 4 | your Chrome; often no browser from a residential IP | Search, cards, reviews |
-| **Avito** | 4 | your Chrome + a Russian residential IP and spaced requests — else an IP block | Classified search, cards, seller reputation |
-| **Taobao** | 3 | your Chrome with an active Taobao login | Search and cards, prices in yuan |
-| **Megamarket** | 3 | your Chrome with an active login — an anonymous session reads empty | Search and cards via the mobile API |
-| **Lamoda** | 3 | cards anonymous (GraphQL), search via your Chrome | Search, cards with sizes |
-| **DNS** | 3 | your Chrome (Qrator) | Electronics search and cards |
-| **Citilink** | 3 | your Chrome (Qrator) | Electronics search and cards |
-| **Compare** | 2 | aggregates the above | "Where is this cheapest?" in one call |
-| **MPStats** | 3 | paid MPStats account, `mp_auth` cookie (optional) | 30-day sales/stock graphs per Ozon/WB SKU, warehouse split (FBS/FBO) |
+| Server            | Tools | What it takes to read                                                         | Notes                                                                                              |
+| ----------------- | ----- | ----------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| **Wildberries**   | 9     | anonymous HTTP                                                                | Search, cards, reviews, buyer questions, seller legal identity, catalog tree and category listings |
+| **Yandex Market** | 3     | anonymous HTTP                                                                | Multi-seller prices, star distribution, reviews                                                    |
+| **Detsky Mir**    | 4     | anonymous HTTP                                                                | Kids' goods, offline store stock, category listings                                                |
+| **Ozon**          | 4     | your Chrome; often no browser from a residential IP                           | Search, cards, reviews                                                                             |
+| **Avito**         | 4     | your Chrome + a Russian residential IP and spaced requests — else an IP block | Classified search, cards, seller reputation                                                        |
+| **Taobao**        | 3     | your Chrome with an active Taobao login                                       | Search and cards, prices in yuan                                                                   |
+| **Megamarket**    | 3     | your Chrome with an active login — an anonymous session reads empty           | Search and cards via the mobile API                                                                |
+| **Lamoda**        | 3     | cards anonymous (GraphQL), search via your Chrome                             | Search, cards with sizes                                                                           |
+| **DNS**           | 3     | your Chrome (Qrator)                                                          | Electronics search and cards                                                                       |
+| **Citilink**      | 3     | your Chrome (Qrator)                                                          | Electronics search and cards                                                                       |
+| **Compare**       | 2     | aggregates the above                                                          | "Where is this cheapest?" in one call                                                              |
+| **MPStats**       | 3     | paid MPStats account, `mp_auth` cookie (optional)                             | 30-day sales/stock graphs per Ozon/WB SKU, warehouse split (FBS/FBO)                               |
 
 Anonymous, no browser: Wildberries, Yandex Market, Detsky Mir and Lamoda cards.
 The rest need your logged-in Chrome (CDP). Taobao and Megamarket additionally need
@@ -585,7 +589,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 948 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 980 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -604,17 +608,17 @@ family and reports `success`, `drift_detected`, or `inconclusive`.
 
 ### Wildberries — `wb_*`
 
-| Tool | What it does |
-|---|---|
-| `wb_search(query, page)` | Text search, up to 100 products/page with prices and stock |
-| `wb_card(nm_ids)` | Batch lookup for up to 100 known SKUs |
-| `wb_root_info(nm_id)` | Resolves `imt_id` (needed for reviews) plus colour variants |
-| `wb_reviews(imt_id, limit, sort)` | Review pool, keyed by `imt_id`, not `nm_id` |
-| `wb_questions(imt_id, limit, skip, answered_only)` | Buyer questions with seller answers, also keyed by `imt_id` |
-| `wb_seller(supplier_id)` | Registered entity, INN, KPP, OGRN, legal address |
-| `wb_categories(root, max_depth)` | Catalog tree with WB's own shard/query selectors |
-| `wb_category_products(shard, query, page, sort, dest)` | Products in a category, using those selectors |
-| `wb_selfcheck()` | Drift canary |
+| Tool                                                   | What it does                                                |
+| ------------------------------------------------------ | ----------------------------------------------------------- |
+| `wb_search(query, page)`                               | Text search, up to 100 products/page with prices and stock  |
+| `wb_card(nm_ids)`                                      | Batch lookup for up to 100 known SKUs                       |
+| `wb_root_info(nm_id)`                                  | Resolves `imt_id` (needed for reviews) plus colour variants |
+| `wb_reviews(imt_id, limit, sort)`                      | Review pool, keyed by `imt_id`, not `nm_id`                 |
+| `wb_questions(imt_id, limit, skip, answered_only)`     | Buyer questions with seller answers, also keyed by `imt_id` |
+| `wb_seller(supplier_id)`                               | Registered entity, INN, KPP, OGRN, legal address            |
+| `wb_categories(root, max_depth)`                       | Catalog tree with WB's own shard/query selectors            |
+| `wb_category_products(shard, query, page, sort, dest)` | Products in a category, using those selectors               |
+| `wb_selfcheck()`                                       | Drift canary                                                |
 
 `wb_seller` answers the question a listing hides: who actually ships this? It returns
 the registered legal entity and tax ids, which is how you distinguish an official
@@ -633,11 +637,11 @@ feed at all; the tool says so instead of returning an empty list.
 
 ### Yandex Market — `yandex_*`
 
-| Tool | What it does |
-|---|---|
-| `yandex_search(query, page, limit)` | Search with both prices, ratings, sellers |
+| Tool                                       | What it does                                |
+| ------------------------------------------ | ------------------------------------------- |
+| `yandex_search(query, page, limit)`        | Search with both prices, ratings, sellers   |
 | `yandex_card(product_id, include_reviews)` | Full detail plus star breakdown and reviews |
-| `yandex_selfcheck()` | Drift canary |
+| `yandex_selfcheck()`                       | Drift canary                                |
 
 **Two prices, always.** `price_rub` is what anyone pays. `price_with_plus` needs a
 paid Yandex Plus subscription and runs 25–30% lower. Yandex leads with the subscriber
@@ -648,12 +652,12 @@ That reveals whether a 4.8 average is earned or hides a cluster of complaints.
 
 ### Detsky Mir — `detmir_*`
 
-| Tool | What it does |
-|---|---|
-| `detmir_categories(parent, limit, region)` | Catalog tree, start here |
-| `detmir_category(alias, limit, offset, region)` | Products in a category, with real totals |
-| `detmir_card(product_id, region)` | Price, rating, online and offline store stock |
-| `detmir_selfcheck()` | Drift canary |
+| Tool                                            | What it does                                  |
+| ----------------------------------------------- | --------------------------------------------- |
+| `detmir_categories(parent, limit, region)`      | Catalog tree, start here                      |
+| `detmir_category(alias, limit, offset, region)` | Products in a category, with real totals      |
+| `detmir_card(product_id, region)`               | Price, rating, online and offline store stock |
+| `detmir_selfcheck()`                            | Drift canary                                  |
 
 **Region is per call.** Prices and especially offline availability swing by city —
 one item sat in 152 Moscow stores, 37 in St Petersburg, 2 in Khabarovsk. The
@@ -667,12 +671,12 @@ wrong products, so discovery goes through categories instead. See
 
 ### Ozon — `ozon_*`
 
-| Tool | What it does |
-|---|---|
-| `ozon_search(query)` | Text search |
-| `ozon_card(sku_or_path)` | Product detail |
-| `ozon_reviews(sku_or_path, limit, sort)` | Reviews |
-| `ozon_selfcheck()` | Drift canary |
+| Tool                                     | What it does   |
+| ---------------------------------------- | -------------- |
+| `ozon_search(query)`                     | Text search    |
+| `ozon_card(sku_or_path)`                 | Product detail |
+| `ozon_reviews(sku_or_path, limit, sort)` | Reviews        |
+| `ozon_selfcheck()`                       | Drift canary   |
 
 Ozon rejects datacenter traffic, so this connector is two-tier: TLS impersonation
 first, then a fetch inside your own logged-in Chrome over the DevTools Protocol when
@@ -683,10 +687,10 @@ From a Russian residential IP the first tier usually works and no browser is nee
 
 ### Cross-marketplace — `compare_*`
 
-| Tool | What it does |
-|---|---|
-| `compare_prices(query, per_source_limit, sources)` | Every marketplace at once, ranked |
-| `compare_sources()` | Which marketplaces this install can query |
+| Tool                                               | What it does                              |
+| -------------------------------------------------- | ----------------------------------------- |
+| `compare_prices(query, per_source_limit, sources)` | Every marketplace at once, ranked         |
+| `compare_sources()`                                | Which marketplaces this install can query |
 
 ```
 compare_prices("кроссовки мужские")
@@ -722,11 +726,11 @@ MPStats account**: auth is a single `mp_auth` cookie (JWT from a logged-in plugi
 session at mpstats.io), set via the `MPSTATS_MP_AUTH` env var. Without it the tools
 return `auth_missing` while the server boots normally — nothing else is affected.
 
-| Tool | What it does |
-|---|---|
+| Tool                                     | What it does                                                                            |
+| ---------------------------------------- | --------------------------------------------------------------------------------------- |
 | `mpstats_item(skus, place, oz_fbs=True)` | 30-day analytics for up to 100 SKUs: orders, price, stock, per-day graphs, seller/brand |
-| `mpstats_warehouses(skus, place)` | Warehouse split: FBS (seller's warehouse) vs FBO (marketplace warehouse), `last_update` |
-| `mpstats_selfcheck()` | Tri-state canary: `success` / `drift_detected` / `inconclusive` |
+| `mpstats_warehouses(skus, place)`        | Warehouse split: FBS (seller's warehouse) vs FBO (marketplace warehouse), `last_update` |
+| `mpstats_selfcheck()`                    | Tri-state canary: `success` / `drift_detected` / `inconclusive`                         |
 
 `place` is `ozon` or `wildberries`. Graphs are length 30, oldest first: the last
 non-zero cell is the current price or stock. The two differ on purpose when the
@@ -745,21 +749,21 @@ servers. A skill is not a restatement of this README: it tells the agent when to
 reach for that source at all, what the source does not have, and which of its
 answers should not be trusted without a second look.
 
-| Skill | Server |
-|---|---|
-| `skills/wb-connector` | `wb-mcp` |
-| `skills/ozon-connector` | `ozon-mcp` |
-| `skills/yandex-connector` | `yandex-mcp` |
-| `skills/detmir-connector` | `detmir-mcp` |
-| `skills/avito-connector` | `avito-mcp` |
-| `skills/taobao-connector` | `taobao-mcp` |
-| `skills/megamarket-connector` | `megamarket-mcp` |
-| `skills/lamoda-connector` | `lamoda-mcp` |
-| `skills/dns-connector` | `dns-mcp` |
-| `skills/citilink-connector` | `citilink-mcp` |
-| `skills/compare-prices` | `compare-mcp` |
-| `skills/mpstats-connector` | `mpstats-mcp` |
-| `skills/marketplace` | `marketplace-mcp` |
+| Skill                         | Server            |
+| ----------------------------- | ----------------- |
+| `skills/wb-connector`         | `wb-mcp`          |
+| `skills/ozon-connector`       | `ozon-mcp`        |
+| `skills/yandex-connector`     | `yandex-mcp`      |
+| `skills/detmir-connector`     | `detmir-mcp`      |
+| `skills/avito-connector`      | `avito-mcp`       |
+| `skills/taobao-connector`     | `taobao-mcp`      |
+| `skills/megamarket-connector` | `megamarket-mcp`  |
+| `skills/lamoda-connector`     | `lamoda-mcp`      |
+| `skills/dns-connector`        | `dns-mcp`         |
+| `skills/citilink-connector`   | `citilink-mcp`    |
+| `skills/compare-prices`       | `compare-mcp`     |
+| `skills/mpstats-connector`    | `mpstats-mcp`     |
+| `skills/marketplace`          | `marketplace-mcp` |
 
 `mcp-core` is the shared runtime rather than a server, so it has no skill.
 
@@ -778,21 +782,21 @@ packages. Installing from PyPI means fetching the skills from the repo separatel
 
 Every setting is an environment variable with a per-connector prefix. All optional.
 
-| Prefix | Common knobs |
-|---|---|
-| `WB_` | `TIMEOUT`, `MIN_GAP`, `DEFAULT_DEST`, `NET_RETRIES`, `MAX_BODY_BYTES`, `CACHE_TTL`, `PROXY` |
-| `YANDEX_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `DETMIR_` | `REGION` (`RU-MOW`, `RU-SPE`, and others), `CACHE_TTL`, `PROXY` |
-| `OZON_` | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY` |
-| `AVITO_` | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID` |
-| `TAOBAO_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `MEGAMARKET_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL` |
-| `LAMODA_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL` |
-| `CHROME_` | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH` |
-| `COMPARE_` | `SOURCE_TIMEOUT` |
-| `MPSTATS_` | `MP_AUTH` (the only required one — without it the tools return `auth_missing`), `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
-| `MCP_` | `TRANSPORT` (`stdio` default, or `http`), `HTTP_HOST`, `HTTP_PORT` |
+| Prefix               | Common knobs                                                                                                               |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `WB_`                | `TIMEOUT`, `MIN_GAP`, `DEFAULT_DEST`, `NET_RETRIES`, `MAX_BODY_BYTES`, `CACHE_TTL`, `PROXY`                                |
+| `YANDEX_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                 |
+| `DETMIR_`            | `REGION` (`RU-MOW`, `RU-SPE`, and others), `CACHE_TTL`, `PROXY`                                                            |
+| `OZON_`              | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`                                                                  |
+| `AVITO_`             | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID`                                                   |
+| `TAOBAO_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                 |
+| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                          |
+| `LAMODA_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                 |
+| `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                          |
+| `CHROME_`            | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH`                                                |
+| `COMPARE_`           | `SOURCE_TIMEOUT`                                                                                                           |
+| `MPSTATS_`           | `MP_AUTH` (the only required one — without it the tools return `auth_missing`), `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY` |
+| `MCP_`               | `TRANSPORT` (`stdio` default, or `http`), `HTTP_HOST`, `HTTP_PORT`                                                         |
 
 `*_CACHE_TTL=0` disables caching. `*_PROXY` overrides the standard
 `HTTPS_PROXY`/`ALL_PROXY` — seven connectors carry one: `WB_`, `YANDEX_`, `DETMIR_`,
@@ -813,14 +817,14 @@ commits.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 948 offline tests
+uv run pytest -q -m "not live and not cdp"    # 980 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
 uv run mypy                                   # the tree lives in [tool.mypy] files
 uv run mypy --platform win32                  # catches Windows-only type errors
 uv run python scripts/check_no_print.py       # a print() breaks JSON-RPC
-uv run python scripts/check_versions.py       # one version across all 59 places
+ uv run python scripts/check_versions.py       # one version across all 72 places
 ```
 
 Some tests execute a connector's **real extractor JavaScript** against captured
@@ -871,7 +875,7 @@ request rate.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 948 offline
+are confidently wrong, so the project is arranged around verification: 980 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-948 offline tests, no network required. Three flavours:
+980 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/RELEASE_CHECKLIST.md
+++ b/docs/RELEASE_CHECKLIST.md
@@ -71,9 +71,10 @@ npm install jsdom
 
 ## 2. Консистентность версий
 
-Одна версия живёт в пятидесяти девяти местах: пятнадцать `pyproject.toml`,
-четырнадцать `__version__`, тринадцать `SERVER_VERSION`, `server.json` и теги
-образа в `docker-compose.yml` и `docs/DEPLOYMENT.md`. Вручную такое не
+Одна версия живёт в семидесяти двух местах: пятнадцать `pyproject.toml`,
+четырнадцать `__version__`, тринадцать `SERVER_VERSION`, тринадцать пинов
+`mcp-core==` в `pyproject.toml` коннекторов, `server.json` и шестнадцать
+тегов образа в `docker-compose.yml` и `docs/DEPLOYMENT.md`. Вручную такое не
 сверяется — при подготовке 1.2.1 тринадцать `__version__` остались на прошлой
 версии и никто этого не заметил. Поэтому сверяет скрипт, он входит в гейт:
 
@@ -238,9 +239,10 @@ install, image build or CI is red.
    on the live pacer or reaching for Chrome. `npm install jsdom` to also run the
    extractor checks against captured markup.
 2. **Version consistency** — `scripts/check_versions.py` compares all
-   fifty-nine declarations (fifteen `pyproject.toml`, fourteen `__version__`,
-   thirteen `SERVER_VERSION`, `server.json`, image tags) against the root
-   `pyproject.toml`; `e2e_stdio_check.py` then reports what the running servers
+   seventy-two declarations (fifteen `pyproject.toml`, fourteen `__version__`,
+   thirteen `SERVER_VERSION`, thirteen `mcp-core==` pins, sixteen image tags
+   and `server.json`) against the root `pyproject.toml`;
+   `e2e_stdio_check.py` then reports what the running servers
    actually say.
 3. **Live checks from the operator's machine** — seven sources refuse datacenter
    addresses, so this is the only place they are exercised at all. Run each

--- a/packages/citilink-connector/tests/fixtures/card.html
+++ b/packages/citilink-connector/tests/fixtures/card.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+<meta charset="utf-8">
+<title>Смартфон Apple iPhone 16 128Gb чёрный — купить в интернет-магазине Ситилинк</title>
+</head>
+<body>
+<main>
+  <h1 class="app-catalog-3v9x2k e1ubbx7u0">Смартфон Apple iPhone 16 128Gb чёрный</h1>
+  <div data-meta-name="ProductHeader">
+    <div class="ProductHeader__price-block">
+      <span data-meta-name="ProductPrice__price" data-meta-price="79990"><span>79 990</span><span>₽</span></span>
+      <s data-meta-name="ProductPrice__old-price">89 990</s>
+      <div class="ProductHeader__instalment">от 6 665 ₽/мес. в рассрочку</div>
+      <div class="ProductHeader__bonus">начислим 798 бонусов</div>
+    </div>
+    <div class="ProductHeader__availability">В наличии</div>
+    <button type="button">В корзину</button>
+  </div>
+  <div class="recommended">Дополнительные товары: Чехол для iPhone 1 999 ₽</div>
+  <div class="reviews">Рейтинг 4.8 (отзывов: 132)</div>
+</main>
+</body>
+</html>

--- a/packages/citilink-connector/tests/test_card_extractor_dom.py
+++ b/packages/citilink-connector/tests/test_card_extractor_dom.py
@@ -1,0 +1,80 @@
+"""Regression tests for the Citilink card extractor on captured card markup.
+
+The search extractor got a fixture when the July-2026 audit found the split
+currency glyph; the card extractor reads the same ``data-meta-*`` contract and
+scopes its price hunt to the buy block, but had no DOM-level test — markup
+drift on the product page would have surfaced only live, from the operator's
+Chrome.
+
+``fixtures/card.html`` models the rendered product card: title in ``h1``, the
+current price as digits and glyph in *separate sibling spans* (Citilink's
+signature shape), an exact ``data-meta-price="79990"`` attribute, a bare
+strikethrough ``89 990``, an instalment line, a bonus line, and a recommended
+product priced ``1 999 ₽`` *outside* the buy block — three numbers that must
+never be read as the price.
+
+Ground truth on the fixture: 79 990 ₽ now (meta exact), 89 990 crossed out,
+in stock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from citilink_connector import server
+from mcp_core.dom import prices_from_tile
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+
+FIXTURE = Path(__file__).parent / "fixtures" / "card.html"
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(
+            js_source, FIXTURE, page_url="https://www.citilink.ru/product/smartfon-apple-iphone-16-128gb-2038477/"
+        )
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+def test_card_extractor_reads_the_product_card() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    assert payload["title"] == "Смартфон Apple iPhone 16 128Gb чёрный"
+    assert payload["price_meta"] == "79990"
+    # The digits and the glyph are adjacent sibling spans, so textContent glues
+    # them with no space — that glued shape is exactly what coerce_price handles.
+    assert payload["price_text"] == "79 990₽"
+    assert payload["old_price_text"] == "89 990"
+    assert payload["is_available"] is True
+
+
+def test_exact_meta_price_attribute_is_preferred() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    price, old_price = prices_from_tile(payload)
+    assert price == 79990.0
+    assert old_price == 89990.0
+
+
+def test_split_glyph_price_still_parses_when_the_meta_attribute_goes_away() -> None:
+    """The day data-meta-price disappears, the sibling-span pair must carry the price."""
+    payload = _extract(server._CARD_EXTRACT_JS)
+    stripped = {**payload, "price_meta": None, "price_text": None}
+    price, old_price = prices_from_tile(stripped)
+    assert price == 79990.0
+    assert old_price == 89990.0
+
+
+def test_instalment_bonuses_and_recommended_products_are_never_prices() -> None:
+    """«от 6 665 ₽/мес.», «798 бонусов» and the 1 999 ₽ add-on must not be candidates."""
+    payload = _extract(server._CARD_EXTRACT_JS)
+    candidates = payload["price_texts"]["attached"] + payload["price_texts"]["other"]
+    assert all("6 665" not in c for c in candidates), "the instalment leaked into the candidates"
+    assert all("798" not in c for c in candidates), "the bonus amount leaked into the candidates"
+    assert all("1 999" not in c for c in candidates), "a recommended product leaked into the buy-block scope"
+
+
+def test_availability_is_read_from_text_content_not_inner_text() -> None:
+    code = "\n".join(line.split("//")[0] for line in server._CARD_EXTRACT_JS.splitlines())
+    assert "innerText" not in code, "card extractor went back to innerText"
+    assert "textContent" in code

--- a/packages/dns-connector/src/dns_connector/server.py
+++ b/packages/dns-connector/src/dns_connector/server.py
@@ -287,10 +287,18 @@ _CARD_EXTRACT_TEMPLATE = """
     if (availText) {
         available = !/Нет в наличии|Под заказ|Закончился/i.test(availText);
     } else if (document.body) {
-        const body = document.body.innerText || '';
+        // Fallback scan of body text. textContent, not innerText: innerText
+        // depends on layout visibility, is unavailable in jsdom, and this
+        // fallback exists so the DOM fixture can assert on it.
+        const body = (document.body.textContent || '').replace(/\\s+/g, ' ');
+
+
         if (/Нет в наличии|Под заказ|Закончился/i.test(body)) available = false;
         else if (/В наличии/i.test(body)) available = true;
     }
+
+
+
 
     return JSON.stringify({
         title: title,

--- a/packages/dns-connector/tests/fixtures/card.html
+++ b/packages/dns-connector/tests/fixtures/card.html
@@ -1,0 +1,29 @@
+<!doctype html>
+<html lang="ru">
+    <head>
+        <meta charset="utf-8" />
+        <title>Ноутбук HUAWEI MateBook D 16 2024 MCLF-X серый — DNS</title>
+    </head>
+    <body>
+        <div class="product-card-top">
+            <h1>Ноутбук HUAWEI MateBook D 16 2024 MCLF-X серый</h1>
+        </div>
+
+        <div class="product-buy">
+            <div class="product-buy__price">
+                <span class="product-buy__prev">62 999</span>
+                <span class="product-buy__price-current">58 999&nbsp;₽</span>
+                <div class="product-buy__sub">кредит от 5 751&nbsp;₽/мес.</div>
+            </div>
+        </div>
+
+        <div class="order-avail-wrap">
+            <div class="available">В наличии</div>
+        </div>
+
+        <div class="catalog-product">
+            <span class="product-detail-card__block-title">Характеристики</span>
+            <span class="product-card-description">Дополнительные товары: сумка 1 499&nbsp;₽</span>
+        </div>
+    </body>
+</html>

--- a/packages/dns-connector/tests/test_card_extractor_dom.py
+++ b/packages/dns-connector/tests/test_card_extractor_dom.py
@@ -1,0 +1,72 @@
+"""Regression tests for the DNS card extractor on a real captured DOM.
+
+The card extractor's availability fallback read ``document.body.innerText``.
+The page's *price* nodes are read via named selectors, but the availability
+fallback scanned the whole body — and ``innerText`` depends on layout and CSS,
+differs between a warm tab and a freshly navigated one, and does not exist in
+jsdom. The shared helpers already read ``textContent`` for exactly that reason;
+this test pins the card fallback to the same rule so the jsdom layer can
+assert on it at all.
+
+``fixtures/card.html`` models a rendered product card page: title in ``h1``,
+current price in ``.product-buy__price`` with a strikethrough sibling and a
+"кредит от 5 751 ₽/мес." instalment line, explicit ``В наличии`` availability,
+and a stray "Дополнительные товары: сумка 1 499 ₽" block that must never be
+read as the product price.
+
+Ground truth on the fixture: 58 999 ₽ (was 62 999), in stock.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from dns_connector import server
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+
+FIXTURE = Path(__file__).parent / "fixtures" / "card.html"
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(
+            js_source, FIXTURE, page_url="https://www.dns-shop.ru/product/b7a1667f9b19ed20/noutbuk-huawei/"
+        )
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+def test_card_extractor_reads_the_product_card() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    assert payload["title"] == "Ноутбук HUAWEI MateBook D 16 2024 MCLF-X серый"
+    assert payload["price_text"] == "58 999 ₽"
+    assert payload["old_price_text"] == "62 999"
+    assert payload["is_available"] is True
+
+
+def test_card_mapping_produces_the_wire_shape() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    price = server.R.price_from_texts(payload.get("price_text"))
+    old_price = server.R.price_from_texts(payload.get("old_price_text"))
+    assert price == 58999.0
+    assert old_price == 62999.0
+
+
+def test_the_instalment_line_is_never_the_card_price() -> None:
+    """«кредит от 5 751 ₽/мес.» must not become the price."""
+    payload = _extract(server._CARD_EXTRACT_JS)
+    assert payload["price_text"] != "кредит от 5 751 ₽/мес."
+    assert payload["price_text"] == "58 999 ₽"
+
+
+def test_a_stray_price_block_is_not_picked_up() -> None:
+    """«Дополнительные товары: сумка 1 499 ₽» is a recommendation, not the price."""
+    payload = _extract(server._CARD_EXTRACT_JS)
+    assert payload["price_text"] != "1 499 ₽"
+
+
+def test_availability_fallback_reads_text_content_not_inner_text() -> None:
+    code = "\n".join(line.split("//")[0] for line in server._CARD_EXTRACT_JS.splitlines())
+    assert "innerText" not in code, "card extractor went back to innerText"
+    assert "textContent" in code

--- a/packages/lamoda-connector/tests/fixtures/search_grid.html
+++ b/packages/lamoda-connector/tests/fixtures/search_grid.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="ru">
+    <head>
+        <meta charset="utf-8" />
+        <title>кроссовки — купить в Lamoda</title>
+    </head>
+    <body>
+        <div class="d-card">
+            <a href="/p/mp002xm1rmm3/" class="d-card__image-link">
+                <img src="/media/x-200.jpg" alt="" />
+            </a>
+            <div class="d-card__title">
+                <a href="/p/mp002xm1rmm3/">Кроссовки Nike Air Max 270</a>
+            </div>
+            <div class="d-card__old-price">7 990</div>
+            <div class="d-card__price">
+                <span class="d-card__current-price">5 990&nbsp;₽</span>
+            </div>
+        </div>
+
+        <div class="d-card">
+            <a href="/p/mp002xm7abc2/" class="d-card__image-link">
+                <img src="/media/y-200.jpg" alt="" />
+            </a>
+            <div class="d-card__title">
+                <a href="/p/mp002xm7abc2/">Кроссовки Adidas Ultraboost</a>
+            </div>
+            <div class="d-card__promo">Скидка -30%</div>
+            <div class="d-card__price">
+                <span class="d-card__current-price">8 490&nbsp;₽</span>
+            </div>
+            <div class="d-card__badge">4.9</div>
+            <div class="d-card__reviews">отзывов: 128</div>
+        </div>
+    </body>
+</html>

--- a/packages/lamoda-connector/tests/test_search_extractor_dom.py
+++ b/packages/lamoda-connector/tests/test_search_extractor_dom.py
@@ -1,0 +1,102 @@
+"""Regression tests for the Lamoda search extractor on a real captured DOM.
+
+Lamoda is the last CDP search source without a jsdom fixture. This closes the
+same hole DNS and Citilink already plug: the extractor JS runs against the
+actual tile markup, not against a mocked render call, so a broken selector
+reads as a failing assertion instead of a silent ``price_rub: null``.
+
+``fixtures/search_grid.html`` models a rendered search grid: two cards, each
+with an empty image/overlay link first and a text-bearing product link next, a
+current price in its own node, and one card carrying a strikethrough old price,
+a ``-30%`` promo badge, a rating and a review-count line — all numbers that are
+not prices.
+
+Ground truth on the fixture: Nike 5 990 ₽ (was 7 990), Adidas 8 490 ₽.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from lamoda_connector import server
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_grid.html"
+
+# (sku, title, current price, strikethrough) exactly as the page displays them.
+# SKUs come back lowercase because they are read from the URL, where Lamoda
+# renders them lowercased; the GraphQL path normalises to uppercase separately.
+EXPECTED = [
+    ("mp002xm1rmm3", "Кроссовки Nike Air Max 270", 5990.0, 7990.0),
+    ("mp002xm7abc2", "Кроссовки Adidas Ultraboost", 8490.0, None),
+]
+
+
+# Numbers that live in these cards but are not prices: the promo badge, the
+# rating and the review count. A regression that promotes any of them is the
+# dangerous kind — it validates and looks plausible.
+NON_PRICE_NUMBERS = {30.0, 4.9, 128.0}
+
+
+def _items() -> list[dict]:
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+    return payload["items"]
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(
+            js_source,
+            FIXTURE,
+            page_url="https://www.lamoda.ru/catalogsearch/result/?q=%D0%BA%D1%80%D0%BE%D1%81%D1%81%D0%BE%D0%B2%D0%BA%D0%B8",
+        )
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+def test_search_extractor_reads_the_real_grid() -> None:
+    """Both cards are found, deduplicated by SKU, with their names intact."""
+    items = _items()
+    assert len(items) == 2, f"expected both cards, got {len(items)}"
+    assert len({it["sku"] for it in items}) == 2, "a SKU appeared twice"
+    for got, (sku, title, _price, _old) in zip(items, EXPECTED, strict=True):
+        assert got["sku"] == sku
+        assert got["title"] == title
+
+
+def test_prices_are_read_from_the_price_node_not_the_promo_badge() -> None:
+    """-30%, 4.9 and «отзывов: 128» must never become the price."""
+    for tile, (_sku, _title, expected_price, _old) in zip(_items(), EXPECTED, strict=True):
+        price, _old_price = server.prices_from_tile(tile)
+        assert price == expected_price, f"expected {expected_price}, got {price}"
+        assert price not in NON_PRICE_NUMBERS
+
+
+def test_strikethrough_is_reported_as_the_old_price() -> None:
+    for tile, (_sku, _title, expected_price, expected_old) in zip(_items(), EXPECTED, strict=True):
+        price, old = server.prices_from_tile(tile)
+        assert price == expected_price
+        assert old == expected_old
+
+
+def test_items_carry_the_wire_shape() -> None:
+    """Extractor JS -> Python mapping -> LamodaSearchItemOut wire shape."""
+    items = [server._search_item_from_tile(t) for t in _items()]
+    for got, (sku, title, expected_price, expected_old) in zip(items, EXPECTED, strict=True):
+        assert got.sku == sku
+        assert got.title == title
+        assert got.price_rub == expected_price
+        assert got.old_price_rub == expected_old
+        assert got.url and "/p/" in got.url
+
+
+def test_the_extractor_uses_shared_helpers_not_legacy_heuristics() -> None:
+    """Guard against a regression back to closest()/innerText/parseFloat/Math.min."""
+    code = "\n".join(line.split("//")[0] for line in server._SEARCH_EXTRACT_JS.splitlines())
+    assert ".closest(" not in code, "tile resolution went back to closest()"
+    assert "innerText" not in code, "extractor went back to innerText"
+    assert "parseFloat" not in code, "price parsing went back to parseFloat"
+    assert "Math.min" not in code, "price picking went back to Math.min"
+    assert "tileRootFor" in code, "shared tileRootFor vanished from the extractor"
+    assert "priceTextsIn" in code, "shared priceTextsIn vanished from the extractor"

--- a/packages/mcp-core/src/mcp_core/dom.py
+++ b/packages/mcp-core/src/mcp_core/dom.py
@@ -91,10 +91,47 @@ def _decoy_regex_literal() -> str:
     return f"/{escaped}/i"
 
 
+# Currency glyphs that attach a number to a price: the rouble sign, the rouble
+# word, and the two yuan signs (full- and half-width) used by Taobao. ONE list,
+# and the JavaScript regex below is generated from it — for the same reason
+# DECOY_MARKERS is: editing a glyph here but not in the JS would read as a
+# mysterious null price on the site that uses it.
+_PRICE_GLYPHS: tuple[str, ...] = ("₽", "руб", "¥", "￥")
+
+
+def _price_glyph_literal() -> str:
+    """The _PRICE_GLYPHS as a JavaScript regex literal, escaped like the decoys."""
+    escaped = "|".join(re.escape(glyph) for glyph in _PRICE_GLYPHS)
+    return f"/{escaped}/i"
+
+
+def _glyph_remainder_literal() -> str:
+    """JavaScript regex for the sibling-text check: what remains next to the
+    digits is only the currency glyph.
+
+    Covers both shapes in _PRICE_GLYPHS: single-character glyphs (``₽ ¥ ￥``)
+    as a character class, and the ``руб``/``руб.`` word with an optional
+    trailing dot. Generated from the same list as HAS_GLYPH so the two cannot
+    silently disagree about what a price is.
+    """
+    single = "".join(glyph for glyph in _PRICE_GLYPHS if len(glyph) == 1)
+    words = [glyph for glyph in _PRICE_GLYPHS if len(glyph) > 1]
+    alternatives: list[str] = []
+    if single:
+        alternatives.append(f"^[{re.escape(single)}\\s.]*$")
+    for word in words:
+        alternatives.append(f"^{re.escape(word)}\\.?$")
+    return "|".join(alternatives)
+
+
 JS_HELPERS = (
     """
     const DECOY_RE = __DECOY_RE__;
+    const HAS_GLYPH = __HAS_GLYPH__;
+    const GLYPHS_REMAINDER = /__GLYPHS_REMAINDER__/i;
 """.replace("__DECOY_RE__", _decoy_regex_literal())
+    .replace("__HAS_GLYPH__", _price_glyph_literal())
+    .replace("__GLYPHS_REMAINDER__", _glyph_remainder_literal())
     + r"""
 
     const cleanText = (el) => {
@@ -102,6 +139,8 @@ JS_HELPERS = (
         const t = (el.textContent || '').replace(/\s+/g, ' ').trim();
         return t || null;
     };
+
+
 
     const cleanTextWithout = (el, dropSelectors) => {
         if (!el) return null;
@@ -154,10 +193,11 @@ JS_HELPERS = (
     // through is how a delivery estimate becomes a product price.
     const priceTextsIn = (root) => {
         if (!root) return {attached: [], other: []};
-        const HAS_GLYPH = /₽|руб/i;
         const attached = [];
         const other = [];
         const nodes = [root, ...root.querySelectorAll('*')];
+
+
         for (const el of nodes) {
             // Leaf-ish nodes only: a container repeats its children's digits and
             // would produce an ambiguous multi-number blob.
@@ -175,7 +215,9 @@ JS_HELPERS = (
                 // Strip this node's text once; whatever remains must be only the
                 // glyph for the pair to count as a single price.
                 const remainder = parentText.replace(raw, '').replace(/\s+/g, ' ').trim();
-                parentGlyph = HAS_GLYPH.test(parentText) && /^[₽\s.]*$|^руб\.?$/i.test(remainder);
+                parentGlyph = HAS_GLYPH.test(parentText) && GLYPHS_REMAINDER.test(remainder);
+
+
             }
             const digits = (raw.match(/\d/g) || []).length;
             if (!ownGlyph && !parentGlyph && digits < 3) continue;

--- a/packages/mcp-core/src/mcp_core/domtest.py
+++ b/packages/mcp-core/src/mcp_core/domtest.py
@@ -103,7 +103,6 @@ def _resolve_jsdom() -> str | None:
         probe = subprocess.run(
             [node, "-e", "process.stdout.write(require.resolve('jsdom'))"],
             capture_output=True,
-            text=True,
             timeout=30,
             env=dict(os.environ),
         )
@@ -111,7 +110,7 @@ def _resolve_jsdom() -> str | None:
         return None
     if probe.returncode != 0 or not probe.stdout.strip():
         return None
-    entry = Path(probe.stdout.strip())
+    entry = Path(probe.stdout.decode("utf-8").strip())
     for parent in entry.parents:
         if parent.name == "node_modules":
             return str(parent)
@@ -161,17 +160,21 @@ def run_extractor(
         extractor.write_text(js_source, encoding="utf-8")
         runner = tmp_path / "runner.js"
         runner.write_text(_RUNNER_JS, encoding="utf-8")
+        # Node emits UTF-8; `text=True` would decode it with the locale codec
+        # (cp1251 on Russian Windows) and choke on the Cyrillic prices. Capture
+        # bytes and decode explicitly so the harness behaves the same everywhere.
         result = subprocess.run(
             [node, str(runner), str(html_path), str(extractor), page_url],
             capture_output=True,
-            text=True,
             timeout=timeout_s,
             env=env,
         )
+        stdout = result.stdout.decode("utf-8", errors="replace")
+        stderr = result.stderr.decode("utf-8", errors="replace")
 
     if result.returncode != 0:  # pragma: no cover - surfaces a broken extractor loudly
-        raise AssertionError(f"extractor JS failed under jsdom:\n{result.stderr[:1500]}")
+        raise AssertionError(f"extractor JS failed under jsdom:\n{stderr[:1500]}")
     try:
-        return json.loads(result.stdout)
+        return json.loads(stdout)
     except json.JSONDecodeError as exc:  # pragma: no cover - malformed extractor output
-        raise AssertionError(f"extractor returned non-JSON output: {result.stdout[:400]!r}") from exc
+        raise AssertionError(f"extractor returned non-JSON output: {stdout[:400]!r}") from exc

--- a/packages/mcp-core/tests/fixtures/utf8_roundtrip.html
+++ b/packages/mcp-core/tests/fixtures/utf8_roundtrip.html
@@ -1,0 +1,6 @@
+<html><body>
+<div class="card">
+  <span class="title">Ноутбук Леново</span>
+  <span class="price">58 999 ₽</span>
+</div>
+</body></html>

--- a/packages/mcp-core/tests/test_dom.py
+++ b/packages/mcp-core/tests/test_dom.py
@@ -65,6 +65,45 @@ def test_the_shared_helpers_read_text_content_not_inner_text() -> None:
     assert "textContent" in code
 
 
+def test_the_price_glyph_regex_is_generated_from_the_python_list() -> None:
+    """One list of currency glyphs feeds HAS_GLYPH and the pixel check alike."""
+    from mcp_core.dom import _PRICE_GLYPHS
+
+    match = re.search(r"const HAS_GLYPH = /(.+?)/i;", JS_HELPERS)
+    assert match, "the shared helpers no longer define HAS_GLYPH"
+    alternatives = match.group(1).split("|")
+    assert len(alternatives) == len(_PRICE_GLYPHS), (
+        f"HAS_GLYPH has {len(alternatives)} alternatives but _PRICE_GLYPHS has {len(_PRICE_GLYPHS)}"
+    )
+    for glyph in _PRICE_GLYPHS:
+        assert re.escape(glyph) in alternatives, f"{glyph!r} is in _PRICE_GLYPHS but not in HAS_GLYPH"
+
+
+def test_the_price_glyph_list_covers_rouble_and_yuan() -> None:
+    """Rouble signs for DNS/Citilink/Lamoda, both yuan glyphs for Taobao."""
+    from mcp_core.dom import _PRICE_GLYPHS
+
+    assert "₽" in _PRICE_GLYPHS
+    assert "руб" in _PRICE_GLYPHS
+    assert "¥" in _PRICE_GLYPHS
+    assert "￥" in _PRICE_GLYPHS
+
+
+def test_yuan_glue_counts_as_a_price() -> None:
+    """Taobao renders "999¥" / "¥129.00" with the glyph glued to the digits."""
+    price, old = prices_from_tile({"price_text": "999¥"})
+    assert price == 999.0
+    assert old is None
+    assert prices_from_tile({"price_text": "¥129.00"})[0] == 129.0
+    assert prices_from_tile({"price_text": "￥1 299"})[0] == 1299.0
+
+
+def test_yuan_glyph_in_a_sibling_element_counts_as_a_price() -> None:
+    """The same split-glyph shape as Citilink: digits and ¥ rendered apart."""
+    price, _old = prices_from_tile({"price_texts": {"attached": ["59.90"], "other": []}})
+    assert price == 59.9
+
+
 # ---------------------------------------------------------------------------
 # Price selection. These are the strings the live sites actually serve.
 # ---------------------------------------------------------------------------

--- a/packages/mcp-core/tests/test_domtest_utf8.py
+++ b/packages/mcp-core/tests/test_domtest_utf8.py
@@ -1,0 +1,63 @@
+"""Guard the UTF-8 decoding between Python and Node in the DOM harness.
+
+On a Russian-Windows box the console code page is cp1251. ``subprocess.run``
+with ``text=True`` decodes Node's stdout through that codec, and the extractor
+output carries Cyrillic product titles — so every jsdom-based DOM test on the
+machine that most needs it died with ``UnicodeDecodeError`` while a clean CI
+never saw it. Plain bytes captured and decoded as UTF-8 behave identically
+everywhere.
+
+This file proves three things about :mod:`mcp_core.domtest`:
+
+* stdout with Cyrillic round-trips through ``run_extractor`` (the regression);
+* stderr with Cyrillic reaches an :class:`AssertionError` intact instead of
+  raising ``UnicodeDecodeError`` before the message can be built;
+* synthetic broken output is refused loudly, not silently coerced.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+
+_HERE = Path(__file__).parent
+_FIXTURE = _HERE / "fixtures" / "utf8_roundtrip.html"
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(js_source, _FIXTURE, page_url="https://example.test/")
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+# The extractors under test produce Cyrillic output through run_extractor.
+_SIMPLE_JS = (
+    "() => {\n"
+    "    const title = document.querySelector('.title');\n"
+    "    return JSON.stringify({title: title.textContent, price: 58999.0});\n"
+    "}"
+)
+
+
+def test_cyrillic_stdout_survives_the_run() -> None:
+    """The regression: cp1251 decoding used to kill jsdom tests on Windows."""
+    payload = _extract(_SIMPLE_JS)
+    assert payload["title"] == "Ноутбук Леново"
+    assert payload["price"] == 58999.0
+
+
+def test_cyrillic_stderr_reaches_the_assertion_intact() -> None:
+    """A throwing extractor must surface its Cyrillic message, not a decode error."""
+    js = "() => {\n    throw new Error('экстрактор упал на кириллице');\n}"
+    with pytest.raises(AssertionError, match="экстрактор упал на кириллице"):
+        _extract(js)
+
+
+def test_broken_json_is_refused_loudly() -> None:
+    """Non-JSON stdout must raise, never pass a silently-decoded blob."""
+    js = "() => {\n    return 'not-json-но-с-кириллицей';\n}"
+    with pytest.raises(AssertionError):
+        _extract(js)

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -34,6 +34,7 @@ from fastmcp.server.middleware.error_handling import RetryMiddleware
 from mcp.types import ToolAnnotations
 from mcp_core import resilience as R
 from mcp_core.cache import TTLCache
+from mcp_core.dom import JS_HELPERS, prices_from_tile
 from mcp_core.errors import (
     BadRequestError,
     NotFoundError,
@@ -134,63 +135,120 @@ def _extract_item_id(raw: str) -> str | None:
 # In-page extractor: walks the rendered search DOM and returns plain data.
 # Kept defensive — every panel is optional, because Taobao A/B tests layout
 # variants constantly and a missing shop block must not kill the item.
-_SEARCH_EXTRACT_JS = """
+# The shared helpers replace the per-connector heuristics that produced the
+# July-2026 class of bugs elsewhere (closest() resolving to an empty overlay,
+# Math.min picking the instalment, innerText absent in jsdom). Taobao tiles get
+# the same treatment: the extractor returns raw display text, and the price is
+# decided in Python by mcp_core.dom.prices_from_tile from glyph-attached
+# candidates — so a yuan-glued "999¥" is a price and a bare promo number is not.
+_SEARCH_EXTRACT_TEMPLATE = """
 () => {
+    //__SHARED_HELPERS__
+    const ID_RE = /[?&]id=(\\d{9,13})/;
     const out = [];
     const anchors = document.querySelectorAll('a[href*="item.taobao.com"], a[href*="//item.taobao.com"]');
     const seen = new Set();
     for (const a of anchors) {
         const href = a.href || '';
-        const m = href.match(/[?&]id=(\\d{9,13})/);
+        const m = href.match(ID_RE);
         if (!m || seen.has(m[1])) continue;
         seen.add(m[1]);
-        const card = a.closest('[class*="Card"], [class*="card"], [class*="item"], li, div') || a;
-        const text = (card.innerText || '').split('\\n').map(s => s.trim()).filter(Boolean);
-        const title = (a.innerText || '').trim() || text[0] || null;
-        let price = null;
-        const priceEl = card.querySelector('[class*="price"], [class*="Price"]');
-        if (priceEl) {
-            const pm = (priceEl.innerText || '').replace(/[^0-9.]/g, '');
-            if (pm) price = parseFloat(pm);
-        }
-        if (price === null) {
-            for (const line of text) {
-                const pm = line.match(/^[¥￥]?\\s*([0-9]+(?:\\.[0-9]+)?)$/);
-                if (pm) { price = parseFloat(pm[1]); break; }
+        // tileRootFor, not closest(): an anchor whose own class looks like a
+        // card must not become the tile. See mcp_core.dom.
+        const card = tileRootFor(a, ID_RE) || a;
+        // Prefer a text-bearing anchor; the image/overlay link carries no title.
+        let titleEl = cleanText(a) ? a : null;
+        if (!titleEl) {
+            for (const cand of card.querySelectorAll('[class*="title"], [class*="Title"], a[href*="item.taobao.com"]')) {
+                if (cleanText(cand)) { titleEl = cand; break; }
             }
         }
+        const title = cleanText(titleEl) || (a.getAttribute('title') || null);
+
         let shop = null, location = null, sales = null;
-        for (const line of text) {
-            if (/人付款|人收货|付款$/.test(line)) sales = sales || line;
+        const lines = (card.textContent || '').split('\\n').map(s => s.trim()).filter(Boolean);
+        for (const line of lines) {
+            if (/人付款|人收货|已售|约售|付款$/.test(line)) sales = sales || line;
             else if (/店$/.test(line)) shop = shop || line;
+            else if (/发货地|广东|浙江|江苏|上海|北京/.test(line)) location = location || line;
         }
-        out.push({item_id: m[1], title, price_cny: price, shop_name: shop, location, sales, url: href.split('?')[0] + '?id=' + m[1]});
+        out.push({
+            item_id: m[1],
+            title: title,
+            price_texts: priceTextsIn(card),
+            shop_name: shop,
+            location: location,
+            sales: sales,
+            url: href.split('?')[0] + '?id=' + m[1]
+        });
         if (out.length >= 48) break;
     }
     return JSON.stringify({items: out, title: document.title || ''});
 }
 """
 
-_CARD_EXTRACT_JS = """
+# Spliced like every other CDP source: one fix to tile resolution or price
+# selection lands on all four connectors at once.
+_SEARCH_EXTRACT_JS = _SEARCH_EXTRACT_TEMPLATE.replace("//__SHARED_HELPERS__", JS_HELPERS)
+
+
+_CARD_EXTRACT_TEMPLATE = """
 () => {
-    const text = (document.body.innerText || '').split('\\n').map(s => s.trim()).filter(Boolean);
-    const titleEl = document.querySelector('h1, [class*="title"], [class*="Title"]');
-    const title = titleEl ? (titleEl.innerText || '').trim() : (document.title || null);
-    let price = null;
-    const priceEl = document.querySelector('[class*="price"], [class*="Price"]');
-    if (priceEl) {
-        const pm = (priceEl.innerText || '').replace(/[^0-9.]/g, '');
-        if (pm) price = parseFloat(pm);
-    }
+    //__SHARED_HELPERS__
+    // title from the product heading; the generic [class*="title"] fallback
+    // could pick a section heading.
+    const titleEl = document.querySelector('h1')
+        || document.querySelector('[class*="title"], [class*="Title"]');
+    const title = cleanText(titleEl) || document.title || null;
+
+    // Price from named candidates, not a body scan: the page carries side
+    // offers and promo amounts that would be Math.min-ed into a wrong number.
+    // priceTextsIn collects glyph-attached candidates (yuan signs included);
+    // Python picks with mcp_core.dom.prices_from_tile.
+    const priceTexts = priceTextsIn(document.body);
+
     let shop = null, sales = null;
-    for (const line of text) {
+    const lines = (document.body.textContent || '').split('\\n').map(s => s.trim()).filter(Boolean);
+    for (const line of lines) {
         if (/人付款|人收货|已售/.test(line)) sales = sales || line;
         if (/店$/.test(line) && !shop) shop = line;
     }
     const imgs = document.querySelectorAll('[class*="desc"] img, [class*="Desc"] img, #description img');
-    return JSON.stringify({title, price_cny: price, shop_name: shop, sales, description_images: imgs.length, page_title: document.title || ''});
+    return JSON.stringify({
+        title: title,
+        price_texts: priceTexts,
+        shop_name: shop,
+        sales: sales,
+        description_images: imgs.length,
+        page_title: document.title || ''
+    });
 }
 """
+
+_CARD_EXTRACT_JS = _CARD_EXTRACT_TEMPLATE.replace("//__SHARED_HELPERS__", JS_HELPERS)
+
+
+def _search_item_from_tile(tile: dict[str, Any]) -> TaobaoSearchItemOut:
+    """Map one extracted tile onto the wire shape, parsing prices in Python.
+
+    Accepts BOTH shapes on purpose: the extractor now returns ``price_texts``,
+    but a payload cached by an older build still carries a numeric
+    ``price_cny``, and a cache entry outliving a deploy must not start
+    answering with nulls. The wire shape is unchanged: ``price_cny`` is a float
+    or None, never 0.
+    """
+    price, _old = prices_from_tile(tile)
+    if price is None:
+        price = R.coerce_price(tile.get("price_cny"))
+    return TaobaoSearchItemOut(
+        item_id=tile.get("item_id"),
+        title=R.flatten_text(tile.get("title")),
+        price_cny=price,
+        shop_name=R.flatten_text(tile.get("shop_name")),
+        location=R.flatten_text(tile.get("location")),
+        sales=R.flatten_text(tile.get("sales")),
+        url=tile.get("url"),
+    )
 
 
 async def _cdp_render(url: str, extract_js: str, wait_ms: int, ctx: Context | None) -> dict[str, Any]:
@@ -279,7 +337,7 @@ async def taobao_search(
                     "rendered search page yielded zero items — either the query genuinely matched nothing or the DOM shape moved; verify manually before quoting"
                 )
             )
-        items = [TaobaoSearchItemOut(**it) for it in items_raw if isinstance(it, dict)]
+        items = [_search_item_from_tile(it) for it in items_raw if isinstance(it, dict)]
         warnings: list[str] = []
         priceless = sum(1 for it in items if it.price_cny is None)
         if priceless == len(items):
@@ -354,9 +412,9 @@ async def taobao_card(
         page_title = str(payload.get("page_title") or "")
         if "不存在" in page_title or "很抱歉" in page_title:
             raise_tool_error(NotFoundError(f"Taobao item {item_id} reports itself gone ({page_title[:60]})."))
-        price = payload.get("price_cny")
-        if price is not None:
-            price = R.coerce_price(price)
+        price, _old = prices_from_tile(payload)
+        if price is None:
+            price = R.coerce_price(payload.get("price_cny"))
         if title is None and price is None:
             raise_tool_error(
                 ParserDriftError(

--- a/packages/taobao-connector/tests/fixtures/item_card.html
+++ b/packages/taobao-connector/tests/fixtures/item_card.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+<head>
+<meta charset="utf-8">
+<title>Apple iPhone 16 Pro Max 全网通5G手机 国行正品全新未拆封 官方标配-淘宝网</title>
+</head>
+<body>
+<div id="root">
+  <div class="ItemHeader--root">
+    <h1 class="ItemTitle--mainTitle">Apple iPhone 16 Pro Max 全网通5G手机 国行正品全新未拆封 官方标配</h1>
+  </div>
+  <div class="Price--root">
+    <div class="Price--current"><span class="Price--symbol">¥</span><span class="Price--priceText">7999</span></div>
+    <del class="Price--original">¥8999</del>
+    <div class="Price--coupon">券后价¥7899</div>
+  </div>
+  <div class="SalesDesc--root">
+    <span class="SalesDesc--sales">2000+人付款</span>
+  </div>
+  <div class="ShopHeader--root">
+    <a class="ShopHeader--name" href="https://shop.taobao.com/">苹果官方旗舰店</a>
+  </div>
+  <div class="Delivery--root">快递: 免运费 · 广东深圳</div>
+  <div class="desc-content">
+    <img src="https://img.alicdn.com/imgextra/desc-1.jpg" alt="">
+    <img src="https://img.alicdn.com/imgextra/desc-2.jpg" alt="">
+    <img src="https://img.alicdn.com/imgextra/desc-3.jpg" alt="">
+  </div>
+</div>
+</body>
+</html>

--- a/packages/taobao-connector/tests/fixtures/search_grid.html
+++ b/packages/taobao-connector/tests/fixtures/search_grid.html
@@ -1,0 +1,50 @@
+<!doctype html>
+<html lang="zh-CN">
+    <head>
+        <meta charset="utf-8" />
+        <title>手机-淘宝搜索</title>
+    </head>
+    <body>
+        <div class="Card--doubleCard--3ZAtbRt">
+            <a
+                href="//item.taobao.com/item.htm?id=123456789012&spm=a21n57.1"
+                class="Card--doubleCardWrapper--L2XFE73"
+            >
+                <img class="Card--pic--2rRslm5" src="//img.alicdn.com/x.jpg" alt="" />
+            </a>
+            <div class="Title--title--jCOPvpf">
+                <a href="//item.taobao.com/item.htm?id=123456789012&spm=a21n57.1"
+                    >Apple iPhone 16 Pro Max 全网通5G手机 官方标配</a
+                >
+            </div>
+            <div class="Price--priceWrapper--1mqYdBw">
+                <span class="Price--priceText--1rHc8YP">999¥</span>
+            </div>
+            <div class="Shop--shop--3U0n6Cb">
+                <a href="//shop123456.taobao.com">苹果官方旗舰店</a>
+            </div>
+            <div class="Sales--sales--3U0n6Cb">2000+人付款</div>
+        </div>
+
+        <div class="Card--doubleCard--3ZAtbRt">
+            <a
+                href="//item.taobao.com/item.htm?id=123456789013&spm=a21n57.1"
+                class="Card--doubleCardWrapper--L2XFE73"
+            >
+                <img class="Card--pic--2rRslm5" src="//img.alicdn.com/x.jpg" alt="" />
+            </a>
+            <div class="Title--title--jCOPvpf">
+                <a href="//item.taobao.com/item.htm?id=123456789013&spm=a21n57.1"
+                    >二手手机 便宜出</a
+                >
+            </div>
+            <div class="Price--priceWrapper--1mqYdBw">
+                <span class="Price--priceText--1rHc8YP">面议</span>
+            </div>
+            <div class="Shop--shop--3U0n6Cb">
+                <a href="//shop654321.taobao.com">二手优品店</a>
+            </div>
+            <div class="Sales--sales--3U0n6Cb">约售 12 件</div>
+        </div>
+    </body>
+</html>

--- a/packages/taobao-connector/tests/test_card_extractor_dom.py
+++ b/packages/taobao-connector/tests/test_card_extractor_dom.py
@@ -1,0 +1,76 @@
+"""Regression tests for the Taobao card extractor on a captured DOM.
+
+The search extractor got fixtures when it moved onto the shared helpers; the
+card extractor ships the same body-scan approach (``priceTextsIn`` over
+``document.body``, price picked in Python by ``mcp_core.dom.prices_from_tile``)
+and had no DOM-level test at all — markup drift on the item page would have
+surfaced only as a live failure on the operator's machine.
+
+``fixtures/item_card.html`` models the rendered item page shape: title in
+``h1``, the current price as a glyph+digits span pair (``¥7999``), a
+strikethrough original (``¥8999``), and a coupon line (``券后价¥7899``) that is
+glyph-attached and *below* the real price — the trap: it must become neither
+the price nor the strikethrough. Shop name ends in ``店``, the sales line
+matches ``人付款``, and three description images sit under a ``desc`` block.
+
+Ground truth on the fixture: ¥7999 now, ¥8999 crossed out, coupon ¥7899
+ignored, shop 苹果官方旗舰店, 2000+人付款, 3 description images.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mcp_core.dom import prices_from_tile
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+from taobao_connector import server
+
+FIXTURE = Path(__file__).parent / "fixtures" / "item_card.html"
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(js_source, FIXTURE, page_url="https://item.taobao.com/item.htm?id=123456789012")
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+def test_card_extractor_reads_the_item_page() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    assert payload["title"] == "Apple iPhone 16 Pro Max 全网通5G手机 国行正品全新未拆封 官方标配"
+    assert payload["shop_name"] == "苹果官方旗舰店"
+    assert payload["sales"] == "2000+人付款"
+    assert payload["description_images"] == 3
+
+
+def test_yuan_price_and_strikethrough_are_read() -> None:
+    payload = _extract(server._CARD_EXTRACT_JS)
+    price, old_price = prices_from_tile(payload)
+    assert price == 7999.0
+    assert old_price == 8999.0
+
+
+def test_the_coupon_price_is_never_the_price_or_the_strikethrough() -> None:
+    """«券后价¥7899» is glyph-attached but sits below the real price."""
+    payload = _extract(server._CARD_EXTRACT_JS)
+    price, old_price = prices_from_tile(payload)
+    assert price != 7899.0
+    assert old_price != 7899.0
+
+
+def test_a_login_wall_title_is_detected_without_a_render() -> None:
+    """The wall check is pure Python and must fire on both title fields."""
+    assert server._login_wall({"page_title": "淘宝网 - 登录页面"}) is True
+    assert server._login_wall({"title": "Sign in — Taobao Login"}) is True
+    assert server._login_wall({"page_title": "Apple iPhone 16 Pro Max-淘宝网"}) is False
+
+
+def test_the_card_extractor_uses_shared_helpers_not_legacy_heuristics() -> None:
+    """Guard against a regression back to closest()/innerText/parseFloat/Math.min."""
+    code = "\n".join(line.split("//")[0] for line in server._CARD_EXTRACT_JS.splitlines())
+    assert ".closest(" not in code, "tile resolution went back to closest()"
+    assert "innerText" not in code, "extractor went back to innerText"
+    assert "parseFloat" not in code, "price parsing went back to parseFloat"
+    assert "Math.min" not in code, "price picking went back to Math.min"
+    assert "priceTextsIn" in code, "shared priceTextsIn vanished from the extractor"

--- a/packages/taobao-connector/tests/test_search_extractor_dom.py
+++ b/packages/taobao-connector/tests/test_search_extractor_dom.py
@@ -1,0 +1,102 @@
+"""Regression tests for the Taobao search extractor on a real captured DOM.
+
+Taobao's grids are client-side React rendered over the signed mtop API; the
+extractor was the only layer of the connector no offline test touched, and it
+still carried the July-2026 legacy heuristics that DNS and Citilink abandoned:
+``closest()`` tile resolution, ``innerText`` line scans, ``parseFloat`` on
+digit-concatenated text and a DIY yuan regex. ``fixtures/search_grid.html`` is
+the tile markup shape Taobao serves, trimmed to two cards: one with a real
+yuan-glued price (``999¥``), one with a hidden price (``面议``, "price on
+request") that must read as None — never 0.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from mcp_core.domtest import JsdomUnavailable, run_extractor
+from taobao_connector import server
+
+FIXTURE = Path(__file__).parent / "fixtures" / "search_grid.html"
+
+# Ground truth on the fixture: first card priced 999 yuan, second card hides
+# its price.
+EXPECTED = [
+    {
+        "item_id": "123456789012",
+        "title": "Apple iPhone 16 Pro Max 全网通5G手机 官方标配",
+        "price_cny": 999.0,
+        "shop_name": "苹果官方旗舰店",
+        "sales": "2000+人付款",
+    },
+    {
+        "item_id": "123456789013",
+        "title": "二手手机 便宜出",
+        "price_cny": None,
+        "shop_name": "二手优品店",
+        "sales": "约售 12 件",
+    },
+]
+
+
+def _extract(js_source: str) -> dict:
+    try:
+        return run_extractor(js_source, FIXTURE, page_url="https://s.taobao.com/search?q=%E6%89%8B%E6%9C%BA")
+    except JsdomUnavailable as exc:
+        pytest.skip(str(exc))
+
+
+def test_search_extractor_reads_the_real_grid() -> None:
+    """Both cards are found, deduplicated by item id, with their data intact."""
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+    items = payload["items"]
+    assert len(items) == 2, f"expected both cards, got {len(items)}"
+    assert len({it["item_id"] for it in items}) == 2, "an item id appeared twice"
+
+    for got, expected in zip(items, EXPECTED, strict=True):
+        assert got["item_id"] == expected["item_id"]
+        assert got["title"] == expected["title"]
+
+
+def test_yuan_glued_price_is_read_from_the_card() -> None:
+    """999¥ is glyph-attached, so priceTextsIn keeps it as the price candidate."""
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+    first = payload["items"][0]
+    assert first["price_texts"]["attached"] == ["999¥"]
+    price, _old = server.prices_from_tile(first)
+    assert price == 999.0
+
+
+def test_a_hidden_price_is_none_never_zero() -> None:
+    """«面议» carries no digits and must not read as a price or as 0."""
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+    second = payload["items"][1]
+    assert second["price_texts"]["attached"] == []
+    assert second["price_texts"]["other"] == []
+    price, _old = server.prices_from_tile(second)
+    assert price is None
+
+
+def test_items_carry_the_wire_shape() -> None:
+    """Extractor JS -> Python mapping -> TaobaoSearchItemOut wire shape."""
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+    items = [server._search_item_from_tile(t) for t in payload["items"]]
+    for got, expected in zip(items, EXPECTED, strict=True):
+        assert got.item_id == expected["item_id"]
+        assert got.title == expected["title"]
+        assert got.price_cny == expected["price_cny"]
+        assert got.shop_name == expected["shop_name"]
+        assert got.sales == expected["sales"]
+        assert got.url and got.url.startswith("https://item.taobao.com/item.htm?id=")
+
+
+def test_the_extractor_uses_shared_helpers_not_legacy_heuristics() -> None:
+    """Guard against a regression back to closest()/innerText/parseFloat/Math.min."""
+    code = "\n".join(line.split("//")[0] for line in server._SEARCH_EXTRACT_JS.splitlines())
+    assert ".closest(" not in code, "tile resolution went back to closest()"
+    assert "innerText" not in code, "extractor went back to innerText"
+    assert "parseFloat" not in code, "price parsing went back to parseFloat"
+    assert "Math.min" not in code, "price picking went back to Math.min"
+    assert "tileRootFor" in code, "shared tileRootFor vanished from the extractor"
+    assert "priceTextsIn" in code, "shared priceTextsIn vanished from the extractor"


### PR DESCRIPTION
Результат независимого hardening-аудита: правки кода и тесты, лишнего в коммитах нет.

- mcp-core: экстракторы декодируют вывод как явный UTF-8; глифы валют генерируются из одного списка, юани принимаются
- DNS: карточка фиксирует fallback наличия на textContent, с фикстурой
- Taobao: оба экстрактора переведены на общие DOM-хелперы
- Lamoda/Citilink/Taobao/DNS: DOM-фикстуры и тесты экстракторов (карточки и поиск)
- docs: число тестов и версии приведены к измеренным

980 passed (было 948), 0 лишних файлов в диффе.