### PR TITLE
Publish the server to the official MCP Registry as a stdio OCI package

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -1,0 +1,71 @@
+name: Publish MCP Registry package
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
+jobs:
+  publish:
+    name: OCI image + registry publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Version from tag
+        id: version
+        shell: bash
+        run: echo "value=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/vladimir-human/ru-marketplace-mcp
+          tags: |
+            type=match,pattern=v(.*),group=1
+
+      - name: Build and push the stdio image
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile.stdio
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+      # This is the acceptance gate for the exact artifact the registry will
+      # advertise: the previous Docker-workflow version was never run through a
+      # client, so that [U] stayed [U]. The probe performs initialize /
+      # tools/list / tools/call over a real `docker run --rm -i`.
+      - name: Real MCP session over docker stdio
+        env:
+          MCP_DOCKER_IMAGE: ghcr.io/vladimir-human/ru-marketplace-mcp:${{ steps.version.outputs.value }}
+        run: python3 scripts/e2e_stdio_check_docker.py
+
+      - name: Install mcp-publisher
+        run: |
+          curl -fL "https://github.com/modelcontextprotocol/registry/releases/download/v1.8.1/mcp-publisher_linux_amd64.tar.gz" | tar xz mcp-publisher
+          ./mcp-publisher --help
+
+      - name: Authenticate to MCP Registry
+        run: ./mcp-publisher login github-oidc
+
+      - name: Publish server.json
+        run: ./mcp-publisher publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,44 @@
 Русский текст первый, английский — ниже в каждом разделе. Аудитория проекта
 русскоязычная, и переводить для неё собственные заметки о релизе странно.
 
+## [1.5.1] — 2026-08-16
+
+Патч доставки для официального MCP-реестра: OCI-образ stdio, настоящий
+`docker run -i` probe в CI и публикация `server.json` через `mcp-publisher` на
+каждый тег. Функциональных изменений поверхности нет.
+
+### Добавлено
+
+- `Dockerfile.stdio` с `MCP_TRANSPORT=stdio`, `CMD ["marketplace-mcp"]` и
+  OCI-меткой владения для MCP Registry.
+- `scripts/e2e_stdio_check_docker.py` — initialize / tools/list / tools/call
+  через настоящий `docker run --rm -i`.
+- `.github/workflows/mcp-registry-publish.yml` — на тег `v*`: сборка и push в
+  GHCR, docker-stdio probe, `mcp-publisher login github-oidc` + `publish`.
+- `packages` в `server.json`: `ghcr.io/vladimir-human/ru-marketplace-mcp:1.5.1`,
+  `runtimeHint: docker`, transport stdio.
+
+### Изменено
+
+- Версия всех 72 объявлений поднята на 1.5.1.
+
+English summary:
+
+### Added
+
+- `Dockerfile.stdio` with `MCP_TRANSPORT=stdio`, a default
+  `marketplace-mcp` entrypoint and the MCP Registry ownership label.
+- `scripts/e2e_stdio_check_docker.py`: a real initialize / tools/list /
+  tools/call session over `docker run --rm -i`.
+- A tag-driven workflow that pushes the OCI image to GHCR, runs the docker
+  stdio probe, then authenticates through GitHub OIDC and publishes
+  `server.json` with `mcp-publisher`.
+- An `oci` package entry in `server.json` pointing at the 1.5.1 GHCR image.
+
+### Changed
+
+- All 72 version declarations bumped to 1.5.1.
+
 ## [1.5.0] — 2026-08-16
 
 Основной релиз: установка в DeepSeek Harness и снижение постоянной цены

--- a/Dockerfile.stdio
+++ b/Dockerfile.stdio
@@ -1,0 +1,123 @@
+# syntax=docker/dockerfile:1
+#
+# STDIO variant for MCP clients (dsh, Claude Desktop, ...). Clients run the image with `docker run --rm -i` and speak JSON-RPC over stdin/stdout. The root Dockerfile remains HTTP-first for docker-compose deployments.
+
+# Multi-stage build for the ru-marketplace-mcp connectors.
+#
+# Stage 1 installs the workspace with uv into a self-contained virtualenv.
+# Stage 2 is a plain Python runtime that copies only that virtualenv plus the
+# source — uv itself never ships in the runtime image, keeping it lean and
+# reducing the attack surface. This is the layout uv's own Docker guide
+# recommends.
+#
+# Tags are pinned deliberately. The builder pins uv 0.11.32 (the version this
+# repo's uv.lock was produced with) on Python 3.12; the runtime pins the same
+# Python minor. Floating tags would let a base rebuild change the toolchain out
+# from under a reproducible install.
+
+# ---- Stage 1: build the environment -----------------------------------------
+FROM ghcr.io/astral-sh/uv:0.11.32-python3.12-trixie-slim AS builder
+
+# - bytecode compile for faster cold starts (production images start often).
+# - copy mode, not hardlink: the cache mount and the image are different
+#   filesystems, so hardlinks would warn and fall back anyway.
+# - install into the project's own .venv at /app/.venv.
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/app/.venv \
+    UV_PYTHON_DOWNLOADS=0
+
+WORKDIR /app
+
+# First install ONLY dependencies, keyed on the manifests and lockfile. This
+# layer is cached and reused across source edits, so day-to-day rebuilds skip
+# re-downloading the dependency set. --frozen means "use uv.lock exactly, never
+# re-resolve"; --no-install-project defers the workspace packages themselves to
+# the next step; --no-dev drops the test/lint toolchain from the runtime image.
+#
+# Every one of the 13 workspace members must be listed here. `uv sync
+# --all-packages` reads each member's pyproject.toml even under
+# --no-install-project (it still resolves their workspace deps), so a missing
+# manifest fails the resolve with "Distribution not found at:
+# file:///app/packages/<member>". A `COPY packages/*/pyproject.toml ...` glob
+# does NOT work: a multi-file COPY flattens every match into one destination
+# path, collapsing the packages/<member>/ nesting the file:// sources require.
+# So the members are enumerated explicitly, one COPY each.
+COPY pyproject.toml uv.lock ./
+COPY packages/mcp-core/pyproject.toml packages/mcp-core/pyproject.toml
+COPY packages/wb-connector/pyproject.toml packages/wb-connector/pyproject.toml
+COPY packages/ozon-connector/pyproject.toml packages/ozon-connector/pyproject.toml
+COPY packages/yandex-connector/pyproject.toml packages/yandex-connector/pyproject.toml
+COPY packages/detmir-connector/pyproject.toml packages/detmir-connector/pyproject.toml
+COPY packages/compare-connector/pyproject.toml packages/compare-connector/pyproject.toml
+COPY packages/avito-connector/pyproject.toml packages/avito-connector/pyproject.toml
+COPY packages/taobao-connector/pyproject.toml packages/taobao-connector/pyproject.toml
+COPY packages/megamarket-connector/pyproject.toml packages/megamarket-connector/pyproject.toml
+COPY packages/lamoda-connector/pyproject.toml packages/lamoda-connector/pyproject.toml
+COPY packages/dns-connector/pyproject.toml packages/dns-connector/pyproject.toml
+COPY packages/citilink-connector/pyproject.toml packages/citilink-connector/pyproject.toml
+COPY packages/mpstats-connector/pyproject.toml packages/mpstats-connector/pyproject.toml
+COPY packages/marketplace-connector/pyproject.toml packages/marketplace-connector/pyproject.toml
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --all-packages --frozen --no-dev --no-install-project
+
+# Now copy the source and install the workspace packages themselves. Only this
+# thin layer rebuilds when application code changes.
+COPY packages/ packages/
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --all-packages --frozen --no-dev
+
+# ---- Stage 2: runtime -------------------------------------------------------
+FROM python:3.12-slim-trixie AS runtime
+
+# Ownership marker the official MCP Registry verifies for OCI packages.
+LABEL io.modelcontextprotocol.server.name="io.github.Vladimir-Human/ru-marketplace-mcp"
+
+# Run as an unprivileged user: a scraper reachable over HTTP should not be root
+# inside its container. Create the user first so the copied tree is owned by it.
+RUN groupadd --system app && useradd --system --gid app --create-home --home-dir /home/app app
+
+WORKDIR /app
+
+# Copy the built virtualenv and the source it points at. The .venv is
+# relocatable here because UV_PROJECT_ENVIRONMENT put it at the same /app/.venv
+# path in the builder. Ownership is handed to the non-root user.
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --from=builder --chown=app:app /app/packages /app/packages
+
+# The skills travel with the servers. Each connector has one, and it is how an
+# agent learns the tool exists, when to reach for it, and which of its answers
+# need a second look. A container with the servers but not the skills runs
+# thirteen MCP endpoints nothing knows how to use.
+COPY --chown=app:app skills/ /app/skills/
+
+# Put the venv on PATH so the console scripts (wb-mcp, ozon-mcp, ...) resolve
+# directly, and keep Python from writing .pyc files or buffering stdout/stderr.
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    MCP_TRANSPORT=stdio
+
+USER app
+
+EXPOSE 8000
+
+# No HEALTHCHECK on purpose. These servers expose only the FastMCP JSON-RPC
+# endpoint at $MCP_HTTP_PATH (/mcp); there is no plain-GET liveness route in the
+# codebase (mcp_core/http.py is httpx timeout/error helpers, and runtime.py hands
+# the socket straight to FastMCP without registering a custom route). The /mcp
+# endpoint speaks streamable-HTTP: a bare GET does not return a simple 200, so a
+# naive `curl -f http://127.0.0.1:8000/mcp` would flap. A truthful healthcheck
+# needs a real liveness route — add `@mcp.custom_route("/healthz", methods=["GET"])`
+# in mcp-core returning 200, then a HEALTHCHECK hitting it — but that is a code
+# change in packages/, out of scope here. Until then, no check beats a lying one.
+
+# Default to the Wildberries server; override the command to run any of the
+# other twelve entry points — ozon-mcp, yandex-mcp, detmir-mcp, compare-mcp,
+# avito-mcp, taobao-mcp, megamarket-mcp, lamoda-mcp, dns-mcp, citilink-mcp,
+# mpstats-mcp, or the unified marketplace-mcp (all sources in one server).
+# docker-compose.yml shows running several at once, each on its own published
+# port.
+# The advertised package runs the unified 34-tool server over stdio. Override
+# the command to launch a single-source connector with the same image.
+CMD ["marketplace-mcp"]

--- a/RELEASE_NOTES_v1.5.1.md
+++ b/RELEASE_NOTES_v1.5.1.md
@@ -1,0 +1,47 @@
+# RELEASE NOTES — v1.5.1 (2026-08-16)
+
+Патч для официального MCP-реестра: v1.5.1 публикует OCI-образ, который клиент
+может запустить как stdio-сервер через `docker run --rm -i`, и добавляет
+автоматическую публикацию в реестр на каждый тег. Основной функциональный
+релиз — v1.5.0; здесь меняется только канал доставки.
+
+## Гейт выпуска
+
+| Проверка | Результат |
+|---|---|
+| `ruff check` + `ruff format --check` | зелёный |
+| `mypy` (host / win32 / darwin) | 87 файлов, 0 ошибок |
+| `pytest -m "not live and not cdp"` | 1181 passed, 1 skipped (1182) |
+| `check_versions.py 1.5.1` | 72 места согласованы |
+| `check_test_count.py` / `check_no_print.py` / `uv lock --check` | зелёные |
+| `e2e_stdio_check.py` | 13/13 локальных серверов |
+| Сборка и публикация OCI + реестр | автоматически на теге `v1.5.1` (workflow `mcp-registry-publish`) |
+
+## Что вошло в патч
+
+### Добавлено
+
+- **`Dockerfile.stdio`** — вариант образа для MCP-клиентов: `MCP_TRANSPORT=stdio`,
+  `CMD ["marketplace-mcp"]` (34 инструмента), метка
+  `io.modelcontextprotocol.server.name` для верификации владения в реестре.
+- **`scripts/e2e_stdio_check_docker.py`** — настоящая сессия MCP через
+  `docker run --rm -i`: initialize → tools/list (ровно 34) → вызов
+  `marketplace_sources` (12 смонтированных источников). Это закрывает
+  прежнее «Docker не проверен» из v1.5.0 по крайней мере для stdio-пути.
+- **`.github/workflows/mcp-registry-publish.yml`** — на тег `v*` собирает и
+  публикует образ в GHCR, прогоняет docker-stdio probe, затем
+  `mcp-publisher login github-oidc` и `mcp-publisher publish` для официального
+  MCP-реестра.
+- **`server.json`** — добавлен OCI-пакет
+  `ghcr.io/vladimir-human/ru-marketplace-mcp:1.5.1` с `runtimeHint: docker`;
+  файл проходит JSON Schema `2025-12-11` без ошибок.
+
+### Изменено
+
+- Версия всех 72 объявлений поднята на 1.5.1, включая пакеты workspace,
+  `uv.lock`, dsh-бандл и Docker-теги.
+
+## Проверка публикации
+
+Факт успешной публикации в официальный MCP-реестр фиксируется ран-логом
+workflow `mcp-registry-publish` для тега `v1.5.1`, а не текстом этого файла.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # uncomment CHROME_CDP_HOST plus the chrome sidecar to unlock those sources.
   marketplace-mcp:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["marketplace-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -45,7 +45,7 @@ services:
 
   wb:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["wb-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -58,7 +58,7 @@ services:
 
   yandex:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["yandex-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -71,7 +71,7 @@ services:
 
   detmir:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["detmir-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -99,7 +99,7 @@ services:
   #    browser profile, so use a dedicated scraping profile only.
   ozon:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["ozon-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -134,7 +134,7 @@ services:
   # in the Chrome profile the sidecar drives, not on these services.
   avito:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["avito-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -149,7 +149,7 @@ services:
 
   taobao:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["taobao-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -164,7 +164,7 @@ services:
 
   megamarket:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["megamarket-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -179,7 +179,7 @@ services:
 
   lamoda:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["lamoda-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -194,7 +194,7 @@ services:
 
   dns:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["dns-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -209,7 +209,7 @@ services:
 
   citilink:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["citilink-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -226,7 +226,7 @@ services:
   # starts but its tools return auth_missing. No Chrome needed — plain httpx.
   mpstats:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["mpstats-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -257,7 +257,7 @@ services:
   # container is enough; Ozon inside it inherits the same two caveats.
   compare:
     build: .
-    image: ru-marketplace-mcp:1.5.0
+    image: ru-marketplace-mcp:1.5.1
     command: ["compare-mcp"]
     environment:
       MCP_TRANSPORT: http

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Image tags are pinned: the builder is `ghcr.io/astral-sh/uv:0.11.32-python3.12-t
 ### Build
 
 ```bash
-docker build -t ru-marketplace-mcp:1.5.0 .
+docker build -t ru-marketplace-mcp:1.5.1 .
 ```
 
 The install uses `uv sync --all-packages --frozen`: `--all-packages` installs
@@ -117,14 +117,14 @@ host, so the container binds to all of its *own* interfaces and the perimeter
 moves to the **published port**. Publish it to the host's loopback:
 
 ```bash
-docker run --rm -p 127.0.0.1:8000:8000 ru-marketplace-mcp:1.5.0
+docker run --rm -p 127.0.0.1:8000:8000 ru-marketplace-mcp:1.5.1
 # -> http://127.0.0.1:8000/mcp on the host
 ```
 
 Run a different marketplace by overriding the command:
 
 ```bash
-docker run --rm -p 127.0.0.1:8001:8000 ru-marketplace-mcp:1.5.0 yandex-mcp
+docker run --rm -p 127.0.0.1:8001:8000 ru-marketplace-mcp:1.5.1 yandex-mcp
 ```
 
 `-p 127.0.0.1:8000:8000` is the security boundary. `-p 8000:8000` would publish

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -109,7 +109,7 @@ clone, use this row shape:
       - run
       - --rm
       - -i
-      - ru-marketplace-mcp:1.5.0
+      - ru-marketplace-mcp:1.5.1
       - marketplace-mcp
     failOnStartupError: false
 ```

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ru-marketplace-mcp-dsh",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "type": "module",
   "files": ["cordis.patch.yml", "skills"],
   "dsh": { "bundle": { "patch": "./cordis.patch.yml" } }

--- a/packages/avito-connector/pyproject.toml
+++ b/packages/avito-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avito-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Avito MCP connector — search, cards and sellers via the internal js/items API, with a CDP fallback"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "curl_cffi>=0.8",

--- a/packages/avito-connector/src/avito_connector/__init__.py
+++ b/packages/avito-connector/src/avito_connector/__init__.py
@@ -1,3 +1,3 @@
 """Avito MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/avito-connector/src/avito_connector/server.py
+++ b/packages/avito-connector/src/avito_connector/server.py
@@ -75,7 +75,7 @@ from avito_connector.shape_reference import missing_required_families
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.avito.ru"

--- a/packages/citilink-connector/pyproject.toml
+++ b/packages/citilink-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citilink-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Citilink-Shop MCP connector — catalog search and cards rendered in the operator's Chrome over CDP (Qrator)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/citilink-connector/src/citilink_connector/__init__.py
+++ b/packages/citilink-connector/src/citilink_connector/__init__.py
@@ -1,3 +1,3 @@
 """Citilink-Shop MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/citilink-connector/src/citilink_connector/server.py
+++ b/packages/citilink-connector/src/citilink_connector/server.py
@@ -61,7 +61,7 @@ from citilink_connector.shape_reference import SEARCH_REQUIRED_KEYS, SEARCH_SHAP
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.citilink.ru"

--- a/packages/compare-connector/pyproject.toml
+++ b/packages/compare-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "compare-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Cross-marketplace price comparison MCP server — queries every configured marketplace at once"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "wb-connector",
     "detmir-connector",
     "yandex-connector",

--- a/packages/compare-connector/src/compare_connector/__init__.py
+++ b/packages/compare-connector/src/compare_connector/__init__.py
@@ -1,3 +1,3 @@
 """Cross-marketplace price comparison MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -52,7 +52,7 @@ from compare_connector.models_output import (
     SourceOutcome,
 )
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 # Per-source ceiling. Yandex pages are ~2 MB and WB search occasionally stalls, so

--- a/packages/detmir-connector/pyproject.toml
+++ b/packages/detmir-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detmir-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Detsky Mir MCP connector — anonymous public JSON API (cards, category listings, search)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/detmir-connector/src/detmir_connector/__init__.py
+++ b/packages/detmir-connector/src/detmir_connector/__init__.py
@@ -1,3 +1,3 @@
 """Detsky Mir MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/detmir-connector/src/detmir_connector/server.py
+++ b/packages/detmir-connector/src/detmir_connector/server.py
@@ -73,7 +73,7 @@ from detmir_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 API_BASE = "https://api.detmir.ru"

--- a/packages/dns-connector/pyproject.toml
+++ b/packages/dns-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dns-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "DNS-Shop MCP connector — catalog search and cards rendered in the operator's Chrome over CDP (Qrator)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/dns-connector/src/dns_connector/__init__.py
+++ b/packages/dns-connector/src/dns_connector/__init__.py
@@ -1,3 +1,3 @@
 """DNS-Shop MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/dns-connector/src/dns_connector/server.py
+++ b/packages/dns-connector/src/dns_connector/server.py
@@ -61,7 +61,7 @@ from dns_connector.shape_reference import SEARCH_REQUIRED_KEYS, SEARCH_SHAPE_REF
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.dns-shop.ru"

--- a/packages/lamoda-connector/pyproject.toml
+++ b/packages/lamoda-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lamoda-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Lamoda MCP connector — GraphQL SKU enrichment plus CDP-backed search"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/lamoda-connector/src/lamoda_connector/__init__.py
+++ b/packages/lamoda-connector/src/lamoda_connector/__init__.py
@@ -1,3 +1,3 @@
 """Lamoda MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -65,7 +65,7 @@ from lamoda_connector.shape_reference import SEARCH_SHAPE_REFERENCE, missing_req
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.lamoda.ru"

--- a/packages/marketplace-connector/pyproject.toml
+++ b/packages/marketplace-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marketplace-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Unified marketplace MCP server — mounts every installed connector as one namespaced toolset"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -13,7 +13,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "pydantic>=2.6",
     "wb-connector",

--- a/packages/marketplace-connector/src/marketplace_connector/__init__.py
+++ b/packages/marketplace-connector/src/marketplace_connector/__init__.py
@@ -1,3 +1,3 @@
 """Unified marketplace MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/marketplace-connector/src/marketplace_connector/server.py
+++ b/packages/marketplace-connector/src/marketplace_connector/server.py
@@ -36,7 +36,7 @@ class MarketplaceSourcesResponse(BaseModel):
     server_version: str = Field(default="", description="Unified server version.")
 
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 
 mcp = FastMCP(
     "marketplace",

--- a/packages/mcp-core/pyproject.toml
+++ b/packages/mcp-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-core"
-version = "1.5.0"
+version = "1.5.1"
 description = "Shared runtime for ru-marketplace-mcp connectors — error taxonomy, transports, tolerant-reader helpers"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/packages/mcp-core/src/mcp_core/__init__.py
+++ b/packages/mcp-core/src/mcp_core/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "redact_error_text",
 ]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/megamarket-connector/pyproject.toml
+++ b/packages/megamarket-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "megamarket-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Megamarket MCP connector — mobile JSON API fetched inside the operator's Chrome over CDP (ServicePipe)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/megamarket-connector/src/megamarket_connector/__init__.py
+++ b/packages/megamarket-connector/src/megamarket_connector/__init__.py
@@ -1,3 +1,3 @@
 """Megamarket MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/megamarket-connector/src/megamarket_connector/server.py
+++ b/packages/megamarket-connector/src/megamarket_connector/server.py
@@ -60,7 +60,7 @@ from megamarket_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://megamarket.ru"

--- a/packages/mpstats-connector/pyproject.toml
+++ b/packages/mpstats-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpstats-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "MPStats MCP connector — sales/stock analytics for Ozon/WB items via plugin.mpstats.io"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/mpstats-connector/src/mpstats_connector/__init__.py
+++ b/packages/mpstats-connector/src/mpstats_connector/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/mpstats-connector/src/mpstats_connector/server.py
+++ b/packages/mpstats-connector/src/mpstats_connector/server.py
@@ -78,7 +78,7 @@ from mpstats_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/ozon-connector/pyproject.toml
+++ b/packages/ozon-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ozon-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Ozon MCP connector — two-tier transport (TLS impersonation + authenticated Chrome CDP)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/ozon-connector/src/ozon_connector/__init__.py
+++ b/packages/ozon-connector/src/ozon_connector/__init__.py
@@ -1,3 +1,3 @@
 """Ozon MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/ozon-connector/src/ozon_connector/server.py
+++ b/packages/ozon-connector/src/ozon_connector/server.py
@@ -66,7 +66,7 @@ from ozon_connector.models_output import (
 )
 from ozon_connector.settings import get_settings
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/taobao-connector/pyproject.toml
+++ b/packages/taobao-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taobao-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Taobao MCP connector — search and item cards rendered in the operator's own Chrome over CDP"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/taobao-connector/src/taobao_connector/__init__.py
+++ b/packages/taobao-connector/src/taobao_connector/__init__.py
@@ -1,3 +1,3 @@
 """Taobao MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -62,7 +62,7 @@ from taobao_connector.shape_reference import SEARCH_SHAPE_REFERENCE, missing_req
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SEARCH_BASE = "https://s.taobao.com/search"

--- a/packages/wb-connector/pyproject.toml
+++ b/packages/wb-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wb-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Wildberries MCP connector — public catalog, reviews, sellers and search"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/wb-connector/src/wb_connector/__init__.py
+++ b/packages/wb-connector/src/wb_connector/__init__.py
@@ -1,3 +1,3 @@
 """Wildberries MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/wb-connector/src/wb_connector/server.py
+++ b/packages/wb-connector/src/wb_connector/server.py
@@ -78,7 +78,7 @@ from wb_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/yandex-connector/pyproject.toml
+++ b/packages/yandex-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yandex-connector"
-version = "1.5.0"
+version = "1.5.1"
 description = "Yandex Market MCP connector — SSR state extraction (search, cards, reviews)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==1.5.0",
+    "mcp-core==1.5.1",
     "fastmcp>=3.4.6",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/yandex-connector/src/yandex_connector/__init__.py
+++ b/packages/yandex-connector/src/yandex_connector/__init__.py
@@ -1,3 +1,3 @@
 """Yandex Market MCP connector."""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"

--- a/packages/yandex-connector/src/yandex_connector/server.py
+++ b/packages/yandex-connector/src/yandex_connector/server.py
@@ -71,7 +71,7 @@ from yandex_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "1.5.0"
+SERVER_VERSION = "1.5.1"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://market.yandex.ru"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ru-marketplace-mcp"
-version = "1.5.0"
+version = "1.5.1"
 description = "MCP servers for Russian marketplaces — Wildberries, Ozon and more"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/scripts/e2e_stdio_check_docker.py
+++ b/scripts/e2e_stdio_check_docker.py
@@ -1,0 +1,131 @@
+"""End-to-end stdio MCP check through the published OCI package.
+
+The local e2e check spawns console scripts on PATH. This one proves the exact
+artifact the MCP Registry will advertise: `docker run --rm -i <image>` with the
+stdio variant of the Dockerfile, defaulting to the unified marketplace server.
+Uses only the standard library so it runs on a GitHub-hosted Ubuntu runner
+without installing the Python MCP SDK.
+
+Run: MCP_DOCKER_IMAGE=ghcr.io/owner/image:tag uv run python scripts/e2e_stdio_check_docker.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+
+EXPECTED_TOOLS = 34
+TIMEOUT_S = 120.0
+
+
+def send(proc: subprocess.Popen, message: object) -> None:
+    assert proc.stdin is not None
+    proc.stdin.write((json.dumps(message) + "\n").encode())
+    proc.stdin.flush()
+
+
+def read_line(proc: subprocess.Popen, deadline: float) -> dict | None:
+    while time.time() < deadline:
+        assert proc.stdout is not None
+        raw = proc.stdout.readline()
+        if not raw:
+            return None
+        try:
+            message = json.loads(raw.decode())
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            continue
+        return message
+    return None
+
+
+def probe(image: str) -> int:
+    started = time.time()
+    deadline = started + TIMEOUT_S
+    proc = subprocess.Popen(
+        ["docker", "run", "--rm", "-i", image],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "initialize",
+                "params": {
+                    "protocolVersion": "2025-06-18",
+                    "capabilities": {},
+                    "clientInfo": {"name": "docker-stdio-probe", "version": "0"},
+                },
+            },
+        )
+        init = read_line(proc, deadline)
+        if init is None or init.get("id") != 1:
+            raise RuntimeError("initialize: no response")
+        send(proc, {"jsonrpc": "2.0", "method": "notifications/initialized"})
+        send(proc, {"jsonrpc": "2.0", "id": 2, "method": "tools/list", "params": {}})
+        listed = None
+        while True:
+            message = read_line(proc, deadline)
+            if message is None:
+                raise RuntimeError("tools/list: no response")
+            if message.get("id") == 2:
+                listed = message
+                break
+        tools = (listed.get("result") or {}).get("tools", [])
+        if len(tools) != EXPECTED_TOOLS:
+            raise RuntimeError(f"expected {EXPECTED_TOOLS} tools, got {len(tools)}")
+
+        send(
+            proc,
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "tools/call",
+                "params": {"name": "marketplace_sources", "arguments": {}},
+            },
+        )
+        called = None
+        while True:
+            message = read_line(proc, deadline)
+            if message is None:
+                raise RuntimeError("tools/call marketplace_sources: no response")
+            if message.get("id") == 3:
+                called = message
+                break
+        result = called.get("result") or {}
+        if result.get("isError"):
+            raise RuntimeError(f"marketplace_sources returned an error: {result}")
+        mounted = (result.get("structuredContent") or {}).get("mounted_count") or 0
+        if mounted != 12:
+            raise RuntimeError(f"expected 12 mounted sources, got {mounted}")
+        print(f"PASS: docker stdio MCP session, {len(tools)} tools, {mounted} sources mounted")
+        return 0
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+def main() -> int:
+    image = os.environ.get("MCP_DOCKER_IMAGE")
+    if not image:
+        print("MCP_DOCKER_IMAGE is not set", file=sys.stderr)
+        return 2
+    print(f"probe {image}")
+    try:
+        return probe(image)
+    except Exception as exc:
+        print(f"FAIL: {type(exc).__name__}: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Vladimir-Human/ru-marketplace-mcp",
   "description": "Read-only MCP servers for Russian marketplaces: prices, stock, ratings, reviews, seller identity",
   "title": "ru-marketplace-mcp",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "websiteUrl": "https://github.com/Vladimir-Human/ru-marketplace-mcp",
   "repository": {
     "url": "https://github.com/Vladimir-Human/ru-marketplace-mcp",
@@ -121,5 +121,15 @@
         }
       ]
     }
-  }
+  },
+  "packages": [
+    {
+      "registryType": "oci",
+      "identifier": "ghcr.io/vladimir-human/ru-marketplace-mcp:1.5.1",
+      "runtimeHint": "docker",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
 }

--- a/uv.lock
+++ b/uv.lock
@@ -127,7 +127,7 @@ wheels = [
 
 [[package]]
 name = "avito-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/avito-connector" }
 dependencies = [
     { name = "curl-cffi" },
@@ -294,7 +294,7 @@ wheels = [
 
 [[package]]
 name = "citilink-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/citilink-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -336,7 +336,7 @@ wheels = [
 
 [[package]]
 name = "compare-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/compare-connector" }
 dependencies = [
     { name = "detmir-connector" },
@@ -575,7 +575,7 @@ wheels = [
 
 [[package]]
 name = "detmir-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/detmir-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -605,7 +605,7 @@ wheels = [
 
 [[package]]
 name = "dns-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/dns-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1065,7 +1065,7 @@ wheels = [
 
 [[package]]
 name = "lamoda-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/lamoda-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1162,7 +1162,7 @@ wheels = [
 
 [[package]]
 name = "marketplace-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/marketplace-connector" }
 dependencies = [
     { name = "avito-connector" },
@@ -1228,7 +1228,7 @@ wheels = [
 
 [[package]]
 name = "mcp-core"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/mcp-core" }
 dependencies = [
     { name = "fastmcp" },
@@ -1269,7 +1269,7 @@ wheels = [
 
 [[package]]
 name = "megamarket-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/megamarket-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "mpstats-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/mpstats-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1407,7 +1407,7 @@ wheels = [
 
 [[package]]
 name = "ozon-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/ozon-connector" }
 dependencies = [
     { name = "curl-cffi" },
@@ -1983,7 +1983,7 @@ wheels = [
 
 [[package]]
 name = "ru-marketplace-mcp"
-version = "1.5.0"
+version = "1.5.1"
 source = { virtual = "." }
 dependencies = [
     { name = "avito-connector" },
@@ -2119,7 +2119,7 @@ wheels = [
 
 [[package]]
 name = "taobao-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/taobao-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -2293,7 +2293,7 @@ wheels = [
 
 [[package]]
 name = "wb-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/wb-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -2403,7 +2403,7 @@ wheels = [
 
 [[package]]
 name = "yandex-connector"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "packages/yandex-connector" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## Why this exists

The official MCP Registry no longer accepts repository-only `server.json` files: a server must be backed by a real package artifact (npm, PyPI, NuGet, Cargo, OCI, or MCPB) or a public remote. PyPI is blocked for this project by the squatted `mcp-core` name, so the honest channel is **OCI**: a stdio Docker image published to GHCR.

## What this adds

- `Dockerfile.stdio` — the same multi-stage build as the root Dockerfile, but `MCP_TRANSPORT=stdio`, default `CMD ["marketplace-mcp"]` (34 tools), and the `io.modelcontextprotocol.server.name` ownership label the registry checks.
- `scripts/e2e_stdio_check_docker.py` — speaks the real MCP protocol through `docker run --rm -i`: initialize, tools/list (asserts 34), tools/call `marketplace_sources` (asserts 12 mounted sources). This turns the old “Docker not verified” note into a CI-checked property.
- `.github/workflows/mcp-registry-publish.yml` — on every `v*` tag: build and push the OCI image to GHCR, run the docker-stdio acceptance probe, then `mcp-publisher login github-oidc` and `mcp-publisher publish`.
- `server.json` now advertises the OCI package for `ghcr.io/vladimir-human/ru-marketplace-mcp:<tag>` with `runtimeHint: docker`; validated against the registry's `2025-12-11` JSON Schema with zero errors.

## Local gates

- `pytest -m "not live and not cdp"`: 1181 passed, 1 skipped.
- ruff, mypy (host/win32/darwin), `uv lock --check`, `check_versions.py 1.5.1`, `check_no_print`, `check_test_count`: clean.
- `e2e_stdio_check.py`: 13/13 local servers.

## After merge

Merge, tag `v1.5.1`. The new workflow publishes the image and the registry entry; a successful run, not this PR text, is the release ticket for that channel.
