### PR TITLE
fix(release): docker probe counts and manual re-publish trigger

### DIFF
--- a/.github/workflows/mcp-registry-publish.yml
+++ b/.github/workflows/mcp-registry-publish.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/scripts/e2e_stdio_check_docker.py
+++ b/scripts/e2e_stdio_check_docker.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import time
 
-EXPECTED_TOOLS = 34
+EXPECTED_TOOLS = 36
 TIMEOUT_S = 120.0
 
 
@@ -102,8 +102,8 @@ def probe(image: str) -> int:
         if result.get("isError"):
             raise RuntimeError(f"marketplace_sources returned an error: {result}")
         mounted = (result.get("structuredContent") or {}).get("mounted_count") or 0
-        if mounted != 12:
-            raise RuntimeError(f"expected 12 mounted sources, got {mounted}")
+        if mounted != 13:
+            raise RuntimeError(f"expected 13 mounted sources, got {mounted}")
         print(f"PASS: docker stdio MCP session, {len(tools)} tools, {mounted} sources mounted")
         return 0
     finally:


### PR DESCRIPTION
The v1.6.0 tag run built the OCI image successfully but its stdio probe expected the pre-AliExpress inventory (34 tools / 12 sources) and failed before publishing. This aligns the probe with the 36/13 inventory and adds workflow_dispatch so a re-publish is explicit rather than tag surgery.