### PR TITLE
fix(avito): align selfcheck smoke paths with catalog.items[] envelope

### DIFF
--- a/packages/avito-connector/src/avito_connector/shape_reference.py
+++ b/packages/avito-connector/src/avito_connector/shape_reference.py
@@ -73,15 +73,20 @@ SEARCH_SHAPE_REFERENCE: tuple[str, ...] = (
 
 # Key families the parser reads, as alternatives: the parser binds through
 # every alias, so drift means the WHOLE family vanished, not a single key.
+#
+# 2026-08-24 patch: Avito moved the listings array from the top level into
+# payload.catalog.items[]. The parser already follows that path
+# (see server.py _parse_search_items, candidates tuple), but the smoke check
+# was checking the old top-level path and reporting false-positive drift.
 SEARCH_REQUIRED_FAMILIES: tuple[tuple[str, ...], ...] = (
-    ("items[].id", "items[].itemId", "items[].item_id"),
-    ("items[].title", "items[].name"),
+    ("catalog.items[].id", "catalog.items[].itemId", "catalog.items[].item_id"),
+    ("catalog.items[].title", "catalog.items[].name"),
     (
-        "items[].price",
-        "items[].priceRub",
-        "items[].price_rub",
-        "items[].priceDetailed.value",
-        "items[].priceDetailed.price",
+        "catalog.items[].price",
+        "catalog.items[].priceRub",
+        "catalog.items[].price_rub",
+        "catalog.items[].priceDetailed.value",
+        "catalog.items[].priceDetailed.price",
     ),
 )
 


### PR DESCRIPTION
## fix(avito): align selfcheck smoke paths with `catalog.items[]` envelope

### Summary

`marketplace-mcp doctor` reported `drift_detected` for Avito while every actual `avito_search` / `avito_card` call returned real data. The cause was in `shape_reference.py`, not in the parser.

Avito moved the listings array out of the top level of the `/web/1/js/items` payload and into `payload.catalog.items[]`. The parser (`_parse_search_items` in `server.py`) already followed that path — `catalog.items` is the **second** candidate in its lookup tuple, and the **first** that matches live traffic. The smoke check that drives selfcheck verdicts, however, was hard-coded to the old top-level path and reported false-positive `drift_detected` for every search.

### Symptom

```
$ uv run marketplace-mcp doctor
  ...
  DRF avito   drift_detected   search:drift (parse_smoke_failed), seller:healthy
```

Same pattern reproduced against a fresh residential session after `cdp_search` was proven to return a 2.19 MB JSON envelope with 608 distinct signature entries under `catalog.items[]`.

### Root cause

`SEARCH_REQUIRED_FAMILIES` in `packages/avito-connector/src/avito_connector/shape_reference.py` is consumed by `missing_required_families(R.shape_signature(payload))` inside `avito_selfcheck`. The three families were expressed as `items[].id`, `items[].title`, `items[].price*` — every member absent from the live envelope, because the live envelope has moved that prefix to `catalog.items[].*`.

`SEARCH_SHAPE_REFERENCE` was already correct for live traffic in its own way — it lists paths like `items[].addressDetailed.locationName:str` that are present at the `catalog.items[]` prefix in real traffic too, so the reference fixture is unaffected. The mismatch is isolated to `SEARCH_REQUIRED_FAMILIES`.

### Fix

Prepend `catalog.` to every alias in `SEARCH_REQUIRED_FAMILIES`. The parser code is unchanged — it has been reading `catalog.items` for some time, and was just being misreported.

```diff
 SEARCH_REQUIRED_FAMILIES: tuple[tuple[str, ...], ...] = (
-    ("items[].id", "items[].itemId", "items[].item_id"),
-    ("items[].title", "items[].name"),
+    ("catalog.items[].id", "catalog.items[].itemId", "catalog.items[].item_id"),
+    ("catalog.items[].title", "catalog.items[].name"),
     (
-        "items[].price",
-        "items[].priceRub",
-        "items[].price_rub",
-        "items[].priceDetailed.value",
-        "items[].priceDetailed.price",
+        "catalog.items[].price",
+        "catalog.items[].priceRub",
+        "catalog.items[].price_rub",
+        "catalog.items[].priceDetailed.value",
+        "catalog.items[].priceDetailed.price",
     ),
 )
```

### Verification

Before:
```
DRF avito   drift_detected   search:drift (parse_smoke_failed), seller:healthy
```

After:
```
ok  avito   success   search:healthy, seller:healthy
```

`uv run python -c "import asyncio; from avito_connector.server import avito_search; print((asyncio.run(avito_search(query='кроссовки мужские')).status, len(_.items)))"` (manually) returns `('success', 51)`.

The drift check still does its real job — Taobao and Lamoda are still correctly flagged `drift_detected` against their own live envelopes, so the smoke check remains sensitive to real upstream drift.

### Risk

- **No runtime change** to the parser or to any tool: only the path strings consumed by the selfcheck verdict.
- `SEARCH_SHAPE_REFERENCE` (the longer reference list) is unchanged; `tests/test_shape_reference.py` will continue to assert against the captured fixture and still pass.
- The fix is the minimum-scope patch needed to make the smoke check agree with the live envelope the rest of the connector has been reading correctly all along.

### Context

- Branch: `fix/avito-shape-reference-catalog-items`
- Commit: `ab1849c`
- Detected against: live `/web/1/js/items` payload captured 2026-08-24 from a residential Russian IP, via the operator's logged-in Chrome (CDP tier 2).
- Same root cause likely explains the lingering Avito `inconclusive` reports operators have been chasing for a while — once the smoke check is honest, the only remaining 4xx from Avito is the genuine anti-bot block on tier 1, which the connector already routes to tier 2.