### PR TITLE
fix: make macOS CDP stealth path probe portable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@
 
 ## [Unreleased]
 
+### Исправлено
+
+- macOS: CDP-Chrome больше не забирает фокус и не перекидывает рабочий стол
+  (Space) на каждый вызов. Причина была в `Target.createTarget` без
+  `background: true` — так Chrome становится активным приложением, а macOS
+  следует за его окном; закрытие вкладки и навигация вдобавок «расхайдивали»
+  приложение. Режим `CHROME_STEALTH` (по умолчанию включён) теперь работает и на
+  macOS: вкладки открываются в фоне в обоих путях (Playwright через
+  browser-level CDP-сессию и raw CDP), а окно скрапинг-профиля прячется (⌘H)
+  после навигации и после закрытия вкладки. `start_chrome_cdp.sh` прячет окно
+  сразу после подъёма CDP. Прячется только процесс с нашим `--user-data-dir`;
+  основной Chrome не трогается. `CHROME_STEALTH=0` возвращает прежнее поведение.
+
+### Fixed
+
+- macOS: the CDP Chrome no longer steals focus or drags the desktop to its
+  Space on every call. `Target.createTarget` without `background: true` makes
+  Chrome the active app and macOS follows its window; closing the tab and
+  navigating un-hid the app on top of that. `CHROME_STEALTH` (on by default) now
+  covers macOS: tabs open in the background on both paths (Playwright via a
+  browser-level CDP session, and raw CDP), and the scraping-profile window is
+  hidden (⌘H) after navigation and after the tab closes. `start_chrome_cdp.sh`
+  hides the window as soon as CDP is up. Only the process running our
+  `--user-data-dir` is touched; the operator's daily Chrome is left alone.
+  `CHROME_STEALTH=0` restores the old behaviour.
+
 ## [2.0.1] — 2026-09-09
 
 ### Исправлено

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1222 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1235 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -502,7 +502,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1222 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1235 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -565,7 +565,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1222 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1235 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -645,7 +645,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1222 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1235 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -962,7 +962,7 @@ commits.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1222 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1235 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1022,7 +1022,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1222 offline
+are confidently wrong, so the project is arranged around verification: 1235 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1222 offline tests, no network required. Three flavours:
+1235 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/CDP_SETUP.md
+++ b/docs/CDP_SETUP.md
@@ -103,7 +103,7 @@ payload shape and the connector needs updating.
 | `CHROME_CDP_PORT` | `9222` | Debugging port |
 | `CHROME_SCRAPING_PROFILE` | platform default above | Profile directory |
 | `CHROME_BINARY` | auto-detected | Explicit path to Chrome/Chromium/Edge |
-| `CHROME_STEALTH` | `1` | Windows: park the window off-screen so it never steals focus |
+| `CHROME_STEALTH` | `1` | Windows: park the window off-screen; macOS: open tabs in the background and keep the app hidden (⌘H) so it never steals focus or switches your Space |
 | `CHROME_HEADLESS` | `0` | Headless mode — detectable, use only on a display-less host |
 
 Auto-detection covers Chrome, Chromium and Edge in the standard locations for all

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -27,8 +27,9 @@ No credentials are ever stored, read, or transmitted by this code: the operator
 logs in by hand, in a browser they control.
 
 Cross-platform: Chrome binaries and profile locations are resolved per platform
-(Windows / macOS / Linux). Window-hiding stealth is Windows-only; elsewhere the
-browser launches normally, or headless when ``CHROME_HEADLESS=1``.
+(Windows / macOS / Linux). Window-hiding stealth exists on Windows (window parked
+off-screen) and macOS (tabs opened in the background, app kept hidden); on Linux
+the browser launches normally, or headless when ``CHROME_HEADLESS=1``.
 """
 
 from __future__ import annotations
@@ -36,6 +37,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import re
 import shutil
 import socket
 import subprocess
@@ -130,9 +132,11 @@ def _default_profile_dir() -> Path:
 
 SCRAPING_PROFILE = os.environ.get("CHROME_SCRAPING_PROFILE", str(_default_profile_dir()))
 
-# Windows-only: park the scraping window off-screen so it never steals focus.
-# A real (non-headless) window keeps Chrome's renderer fingerprint intact, which
-# is the whole point of using CDP instead of a headless scraper.
+# Keep the scraping window out of the operator's way without going headless:
+# Windows parks it off-screen, macOS opens tabs in the background and hides the
+# app (⌘H) so it never takes focus or drags the desktop to its Space. A real
+# (non-headless) window keeps Chrome's renderer fingerprint intact, which is the
+# whole point of using CDP instead of a headless scraper.
 STEALTH = os.environ.get("CHROME_STEALTH", "1") != "0"
 
 # Opt-in headless mode for Linux hosts with no display. Anti-bot systems detect
@@ -284,14 +288,40 @@ async def _ensure_cdp_running(timeout_s: float = 12.0) -> tuple[bool, str]:
 
 
 def _scraping_profile_pids() -> set[int]:
-    """PIDs of Chrome processes bound to *our* scraping profile (Windows only).
+    """PIDs of Chrome processes bound to *our* scraping profile (Windows, macOS).
 
     Any failure returns an empty set, which makes the caller hide nothing —
     leaving a scraping window visible beats hiding the operator's real browser.
     """
+    profile_marker = str(Path(SCRAPING_PROFILE))
+    if sys.platform == "darwin":
+        # Only the main browser process owns the app in System Events; the
+        # renderer/GPU helpers carry the same --user-data-dir but no windows.
+        try:
+            proc = subprocess.run(
+                ["ps", "-axo", "pid=,command="],
+                capture_output=True,
+                text=True,
+                timeout=5,
+                check=False,
+            )
+            if proc.returncode != 0:
+                return set()
+            # Anchor the profile path on a following space or end of line so
+            # a sibling profile such as "Chrome-Scraping-2" is not matched.
+            marker = re.compile(rf"--user-data-dir={re.escape(profile_marker)}(?:\s|$)")
+            pids: set[int] = set()
+            for line in proc.stdout.splitlines():
+                if not marker.search(line) or "Helper" in line:
+                    continue
+                pid_str = line.strip().split(None, 1)[0]
+                if pid_str.isdigit():
+                    pids.add(int(pid_str))
+            return pids
+        except Exception:
+            return set()
     if sys.platform != "win32":
         return set()
-    profile_marker = str(Path(SCRAPING_PROFILE))
     try:
         ps_cmd = (
             "Get-CimInstance Win32_Process -Filter \"Name='chrome.exe'\" "
@@ -314,11 +344,33 @@ def _scraping_profile_pids() -> set[int]:
 
 
 def _hide_chrome_windows() -> None:
-    """Hide scraping-profile Chrome windows (Windows only, best-effort).
+    """Hide scraping-profile Chrome windows (Windows and macOS, best-effort).
 
     Only windows whose PID is confirmed to belong to the scraping profile are
     touched; ambiguity means do nothing.
+
+    On macOS a new tab (even one created with ``background: true``) and a
+    navigation both un-hide the app, so this runs after each of them. It hides
+    the app the way ⌘H does — the window keeps its Space and never takes focus,
+    which is what stops the desktop from switching mid-call.
     """
+    if sys.platform == "darwin":
+        for pid in _scraping_profile_pids():
+            try:
+                subprocess.run(
+                    [
+                        "osascript",
+                        "-e",
+                        'tell application "System Events" to set visible of '
+                        f"(first process whose unix id is {pid}) to false",
+                    ],
+                    capture_output=True,
+                    timeout=5,
+                    check=False,
+                )
+            except Exception:
+                continue
+        return
     if sys.platform != "win32":
         return
     try:
@@ -632,9 +684,13 @@ async def _raw_cdp_page(url: str, wait_ms: int) -> AsyncIterator[_RawCdpPage]:
         raise RuntimeError(f"CDP endpoint on {CDP_HOST}:{CDP_PORT} returned no websocket URL")
 
     async with _websockets.connect(browser_ws, max_size=None, open_timeout=_RAW_CONNECT_TIMEOUT_S) as bws:
-        created = await _RawCdpPage(bws, "")._send(
-            "Target.createTarget", {"url": "about:blank"}, timeout=_RAW_CONNECT_TIMEOUT_S
-        )
+        # ``background`` keeps the new tab from activating the window: without
+        # it Chrome comes to the front on every call (and macOS follows it to
+        # its Space). Chrome-only parameter, and this path is Chrome-only.
+        create_params: dict[str, Any] = {"url": "about:blank"}
+        if STEALTH:
+            create_params["background"] = True
+        created = await _RawCdpPage(bws, "")._send("Target.createTarget", create_params, timeout=_RAW_CONNECT_TIMEOUT_S)
         target_id = created.get("targetId")
         if not isinstance(target_id, str) or not target_id:
             raise RuntimeError("CDP Target.createTarget returned no targetId")
@@ -666,7 +722,7 @@ async def _raw_cdp_page(url: str, wait_ms: int) -> AsyncIterator[_RawCdpPage]:
                 raise NavBlocked(status, page.url)
             if wait_ms > 0:
                 await asyncio.sleep(wait_ms / 1000)
-            if STEALTH and sys.platform == "win32":
+            if STEALTH and sys.platform in ("win32", "darwin"):
                 await asyncio.to_thread(_hide_chrome_windows)
             yield page
         finally:
@@ -674,12 +730,43 @@ async def _raw_cdp_page(url: str, wait_ms: int) -> AsyncIterator[_RawCdpPage]:
                 await asyncio.wait_for(page.close(), timeout=_TAB_OP_TIMEOUT_S)
             except Exception:
                 pass
+            # Closing the tab un-hides the app again; tuck it away between calls.
+            if STEALTH and sys.platform in ("win32", "darwin"):
+                await asyncio.to_thread(_hide_chrome_windows)
+
+
+async def _new_tab(ctx: BrowserContext) -> Page:
+    """Open a tab in ``ctx`` — in the background when stealth is on.
+
+    ``BrowserContext.new_page`` creates its target in the foreground, which
+    activates the Chrome window on every call (and drags macOS along to the
+    Space that window lives on). With stealth on, create the target over a
+    browser-level CDP session with ``background: true`` and pick up the Page
+    Playwright attaches for it. If the CDP session itself cannot be opened,
+    fall back to the plain call: a visible tab beats no tab.
+    """
+    browser = ctx.browser
+    if not STEALTH or browser is None:
+        return await ctx.new_page()
+    try:
+        cdp = await browser.new_browser_cdp_session()
+    except Exception:
+        return await ctx.new_page()
+    try:
+        async with ctx.expect_page(timeout=_TAB_OP_TIMEOUT_S * 1000) as new_page:
+            await cdp.send("Target.createTarget", {"url": "about:blank", "background": True})
+        return await new_page.value
+    finally:
+        try:
+            await cdp.detach()
+        except Exception:
+            pass
 
 
 @asynccontextmanager
 async def _playwright_page(url: str, wait_ms: int = 5000) -> AsyncIterator[Page]:
     async with get_context() as ctx:
-        page = await asyncio.wait_for(ctx.new_page(), timeout=_TAB_OP_TIMEOUT_S)
+        page = await asyncio.wait_for(_new_tab(ctx), timeout=_TAB_OP_TIMEOUT_S)
         try:
             resp = await page.goto(url, wait_until="domcontentloaded", timeout=20_000)
             status = resp.status if resp is not None else None
@@ -692,7 +779,7 @@ async def _playwright_page(url: str, wait_ms: int = 5000) -> AsyncIterator[Page]
                 raise NavBlocked(status, final)
             if wait_ms > 0:
                 await page.wait_for_timeout(wait_ms)
-            if STEALTH and sys.platform == "win32":
+            if STEALTH and sys.platform in ("win32", "darwin"):
                 await asyncio.to_thread(_hide_chrome_windows)
             yield page
         finally:
@@ -700,6 +787,9 @@ async def _playwright_page(url: str, wait_ms: int = 5000) -> AsyncIterator[Page]
                 await asyncio.wait_for(page.close(), timeout=_TAB_OP_TIMEOUT_S)
             except Exception:
                 pass
+            # Closing the tab un-hides the app again; tuck it away between calls.
+            if STEALTH and sys.platform in ("win32", "darwin"):
+                await asyncio.to_thread(_hide_chrome_windows)
 
 
 @asynccontextmanager

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -293,7 +293,10 @@ def _scraping_profile_pids() -> set[int]:
     Any failure returns an empty set, which makes the caller hide nothing —
     leaving a scraping window visible beats hiding the operator's real browser.
     """
-    profile_marker = str(Path(SCRAPING_PROFILE))
+    # Keep the configured spelling on macOS. ``Path`` uses the host OS rules,
+    # so converting a POSIX profile path while running the offline Windows
+    # test suite would turn ``/Users/...`` into backslashes and miss the PID.
+    profile_marker = SCRAPING_PROFILE if sys.platform == "darwin" else str(Path(SCRAPING_PROFILE))
     if sys.platform == "darwin":
         # Only the main browser process owns the app in System Events; the
         # renderer/GPU helpers carry the same --user-data-dir but no windows.

--- a/packages/mcp-core/tests/test_chrome_cdp_stealth.py
+++ b/packages/mcp-core/tests/test_chrome_cdp_stealth.py
@@ -1,0 +1,240 @@
+"""Stealth on macOS: find the scraping Chrome, hide it, open tabs in the background.
+
+Everything here runs offline. Platform branches are driven by patching
+``sys.platform`` and ``subprocess.run``; the Playwright side is a duck-typed
+fake, because the contract is only "which CDP command was sent and what came
+back", never a real browser.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import asynccontextmanager
+
+import pytest
+from mcp_core.transport import chrome_cdp
+
+PROFILE = "/Users/op/Library/Application Support/Chrome-Scraping"
+
+# What `ps -axo pid=,command=` prints on a Mac with the operator's daily Chrome,
+# the scraping Chrome, one of its helpers, and a sibling profile with a longer
+# name that a naive substring match would swallow.
+_PS_OUTPUT = f"""\
+  100 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --restore-last-session
+  200 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9222 --user-data-dir={PROFILE} --no-first-run about:blank
+  201 /Applications/Google Chrome.app/Contents/Frameworks/Google Chrome Framework.framework/Helpers/Google Chrome Helper (Renderer).app/Contents/MacOS/Google Chrome Helper (Renderer) --type=renderer --user-data-dir={PROFILE} --remote-debugging-port=9222
+  300 /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --remote-debugging-port=9333 --user-data-dir={PROFILE}-2 --no-first-run
+"""
+
+
+def _completed(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess[str]:
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr="")
+
+
+# --------------------------------------------------------- profile PIDs ----
+
+
+def test_macos_profile_pids_pick_the_main_process_of_our_profile_only(monkeypatch):
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "SCRAPING_PROFILE", PROFILE)
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", lambda *a, **k: _completed(_PS_OUTPUT))
+
+    assert chrome_cdp._scraping_profile_pids() == {200}
+
+
+def test_macos_profile_pids_empty_when_ps_fails(monkeypatch):
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "SCRAPING_PROFILE", PROFILE)
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", lambda *a, **k: _completed("", returncode=1))
+
+    assert chrome_cdp._scraping_profile_pids() == set()
+
+
+def test_macos_profile_pids_empty_when_ps_raises(monkeypatch):
+    def boom(*_a, **_k):
+        raise subprocess.TimeoutExpired(cmd="ps", timeout=5)
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "SCRAPING_PROFILE", PROFILE)
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", boom)
+
+    assert chrome_cdp._scraping_profile_pids() == set()
+
+
+def test_linux_profile_pids_never_shell_out(monkeypatch):
+    def forbidden(*_a, **_k):
+        raise AssertionError("subprocess.run must not be called on linux")
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "linux")
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", forbidden)
+
+    assert chrome_cdp._scraping_profile_pids() == set()
+
+
+# --------------------------------------------------------- hiding the app ----
+
+
+def test_macos_hide_sends_one_osascript_per_profile_pid(monkeypatch):
+    calls: list[list[str]] = []
+
+    def record(cmd, *_a, **_k):
+        calls.append(cmd)
+        return _completed()
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "_scraping_profile_pids", lambda: {200})
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", record)
+
+    chrome_cdp._hide_chrome_windows()
+
+    assert len(calls) == 1
+    assert calls[0][0] == "osascript"
+    script = calls[0][-1]
+    assert "unix id is 200" in script
+    assert "set visible of" in script and "to false" in script
+
+
+def test_macos_hide_does_nothing_without_a_confirmed_pid(monkeypatch):
+    def forbidden(*_a, **_k):
+        raise AssertionError("no PID means no osascript")
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "_scraping_profile_pids", set)
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", forbidden)
+
+    chrome_cdp._hide_chrome_windows()
+
+
+def test_macos_hide_survives_a_failing_osascript(monkeypatch):
+    def boom(*_a, **_k):
+        raise OSError("osascript missing")
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    monkeypatch.setattr(chrome_cdp, "_scraping_profile_pids", lambda: {200, 201})
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", boom)
+
+    chrome_cdp._hide_chrome_windows()
+
+
+def test_linux_hide_is_a_noop(monkeypatch):
+    def forbidden(*_a, **_k):
+        raise AssertionError("nothing to hide on linux")
+
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "linux")
+    monkeypatch.setattr(chrome_cdp, "_scraping_profile_pids", forbidden)
+    monkeypatch.setattr(chrome_cdp.subprocess, "run", forbidden)
+
+    chrome_cdp._hide_chrome_windows()
+
+
+# ------------------------------------------------ background tab creation ----
+
+
+class _FakeCdp:
+    def __init__(self) -> None:
+        self.sent: list[tuple[str, dict[str, object] | None]] = []
+        self.detached = False
+
+    async def send(self, method: str, params: dict[str, object] | None = None) -> dict[str, object]:
+        self.sent.append((method, params))
+        return {"targetId": "T1"}
+
+    async def detach(self) -> None:
+        self.detached = True
+
+
+class _FakeBrowser:
+    def __init__(self, cdp: _FakeCdp | None) -> None:
+        self._cdp = cdp
+
+    async def new_browser_cdp_session(self) -> _FakeCdp:
+        if self._cdp is None:
+            raise RuntimeError("no browser-level CDP session here")
+        return self._cdp
+
+
+class _FakeEventInfo:
+    def __init__(self, page: str) -> None:
+        self._page = page
+
+    @property
+    def value(self):
+        async def _resolve() -> str:
+            return self._page
+
+        return _resolve()
+
+
+class _FakeContext:
+    def __init__(self, browser: _FakeBrowser | None) -> None:
+        self.browser = browser
+        self.plain_pages = 0
+        self.expect_timeouts: list[float | None] = []
+
+    async def new_page(self) -> str:
+        self.plain_pages += 1
+        return "foreground-page"
+
+    @asynccontextmanager
+    async def expect_page(self, timeout: float | None = None):
+        self.expect_timeouts.append(timeout)
+        yield _FakeEventInfo("background-page")
+
+
+async def test_new_tab_creates_the_target_in_the_background_when_stealth_is_on(monkeypatch):
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    cdp = _FakeCdp()
+    ctx = _FakeContext(_FakeBrowser(cdp))
+
+    page = await chrome_cdp._new_tab(ctx)  # type: ignore[arg-type]
+
+    assert page == "background-page"
+    assert cdp.sent == [("Target.createTarget", {"url": "about:blank", "background": True})]
+    assert cdp.detached is True
+    assert ctx.plain_pages == 0
+    assert ctx.expect_timeouts == [chrome_cdp._TAB_OP_TIMEOUT_S * 1000]
+
+
+async def test_new_tab_uses_plain_new_page_when_stealth_is_off(monkeypatch):
+    monkeypatch.setattr(chrome_cdp, "STEALTH", False)
+    cdp = _FakeCdp()
+    ctx = _FakeContext(_FakeBrowser(cdp))
+
+    page = await chrome_cdp._new_tab(ctx)  # type: ignore[arg-type]
+
+    assert page == "foreground-page"
+    assert cdp.sent == []
+    assert ctx.plain_pages == 1
+
+
+async def test_new_tab_falls_back_to_new_page_without_a_browser(monkeypatch):
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    ctx = _FakeContext(None)
+
+    assert await chrome_cdp._new_tab(ctx) == "foreground-page"  # type: ignore[arg-type]
+    assert ctx.plain_pages == 1
+
+
+async def test_new_tab_falls_back_to_new_page_when_the_cdp_session_fails(monkeypatch):
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    ctx = _FakeContext(_FakeBrowser(None))
+
+    assert await chrome_cdp._new_tab(ctx) == "foreground-page"  # type: ignore[arg-type]
+    assert ctx.plain_pages == 1
+
+
+async def test_new_tab_detaches_the_session_even_when_no_page_arrives(monkeypatch):
+    class _NoPageContext(_FakeContext):
+        @asynccontextmanager
+        async def expect_page(self, timeout: float | None = None):
+            raise TimeoutError("no page event")
+            yield  # pragma: no cover
+
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    cdp = _FakeCdp()
+    ctx = _NoPageContext(_FakeBrowser(cdp))
+
+    with pytest.raises(TimeoutError):
+        await chrome_cdp._new_tab(ctx)  # type: ignore[arg-type]
+
+    assert cdp.detached is True

--- a/scripts/start_chrome_cdp.sh
+++ b/scripts/start_chrome_cdp.sh
@@ -112,6 +112,7 @@ echo "Launching… log into the marketplaces you need IN THIS WINDOW ONLY."
 echo "Keep banking and email out of this profile."
 
 nohup "$CHROME" "${ARGS[@]}" >/dev/null 2>&1 &
+CHROME_PID=$!
 disown || true
 
 for _ in $(seq 1 30); do
@@ -119,6 +120,14 @@ for _ in $(seq 1 30); do
     if curl -sf -m 1 "http://127.0.0.1:$PORT/json/version" >/dev/null 2>&1; then
         echo
         echo "CDP is up. Verify with: curl -s http://127.0.0.1:$PORT/json/version"
+        # macOS: tuck the freshly opened window away (⌘H) so it does not sit on
+        # top of whatever you were doing. Connectors keep it hidden afterwards
+        # (CHROME_STEALTH=1, the default). Skip when the user opted out.
+        if [[ "$(uname -s)" == "Darwin" && "${CHROME_STEALTH:-1}" != "0" ]]; then
+            sleep 1
+            osascript -e "tell application \"System Events\" to set visible of (first process whose unix id is $CHROME_PID) to false" >/dev/null 2>&1 || true
+            echo "Window hidden (⌘H). Unhide it from the Dock when you need to log in; CHROME_STEALTH=0 disables this."
+        fi
         exit 0
     fi
 done


### PR DESCRIPTION
Follow-up for #42. The original PR adds macOS CDP stealth and its tests. This follow-up fixes a cross-platform test/runtime issue: on Windows test hosts, Path() rewrote the configured POSIX macOS profile path, causing _scraping_profile_pids() to return an empty set. The configured macOS spelling is now preserved.\n\nValidation: 13 stealth tests passed; full offline suite on the PR worktree: 1234 passed, 1 skipped, 5 deselected.