### PR TITLE
release: v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-09-09
+
+### Добавлено
+
+- Средний DSH-профиль `ru-marketplace-decision` (консоль-скрипт `decision-mcp`):
+  сравнение цен плюс один card inspector `decision_inspect(source, product_id_or_url)`.
+  Позволяет проверить победителя сравнения, продавца и карточку без полного
+  37-инструментного mount; ряд включён в `dsh/cordis.patch.yml` выключенным по
+  умолчанию и включается через `RU_MARKETPLACE_MCP_DECISION=1` (взаимоисключающе
+  с полным mount).
+- `compare_prices`: предложения теперь несут `identity` (бренд, модель, MPN,
+  GTIN, атрибуты варианта) и `evidence` (provenance нативного оффера), чтобы
+  точное соответствие товара проверялось, а не предполагалось.
+- Reliability-скрипты: детерминированный routing-контракт DSH
+  (`scripts/routing_eval.py`), операционные гейты (`scripts/test_ops_gates.py`),
+  baseline/snapshot-режимы `scripts/mcp_wire.py` против регрессии wire-токенов
+  и латентности.
+- CDP: ограничение размера websocket-фреймов и allowlist финального хоста
+  (`_check_final_host`) после навигации.
+
+### Изменено
+
+- `e2e_stdio_check.py` проверяет 15 stdio-серверов, включая `decision-mcp`;
+  dsh-bundle guard в CI ожидает 3 MCP rows, все выключены по умолчанию.
+- Офлайн-счётчик тестов в документации обновлён до 1243.
+
+### Added
+
+- Middle DSH profile `ru-marketplace-decision` (`decision-mcp`): comparison plus
+  one card inspector `decision_inspect(source, product_id_or_url)`, shipped
+  disabled by default and enabled with `RU_MARKETPLACE_MCP_DECISION=1`.
+- `compare_prices` offers carry `identity` (brand, model, MPN, GTIN, variant
+  attributes) and `evidence` provenance for verifiable exact-product matching.
+- Reliability scripts: DSH routing eval, operational gates, and
+  `mcp_wire.py` wire-token/latency regression baselines.
+- CDP hardening: bounded websocket frames and a final-host allowlist.
+
+### Changed
+
+- `e2e_stdio_check.py` covers 15 stdio servers including `decision-mcp`; the DSH
+  bundle CI guard asserts all 3 MCP rows are disabled by default.
+- Documented offline test count is 1243.
+
 ## [2.0.2] — 2026-09-09
 
 ### Исправлено

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
   # uncomment CHROME_CDP_HOST plus the chrome sidecar to unlock those sources.
   marketplace-mcp:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["marketplace-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -45,7 +45,7 @@ services:
 
   wb:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["wb-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -58,7 +58,7 @@ services:
 
   yandex:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["yandex-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -71,7 +71,7 @@ services:
 
   detmir:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["detmir-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -99,7 +99,7 @@ services:
   #    browser profile, so use a dedicated scraping profile only.
   ozon:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["ozon-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -137,7 +137,7 @@ services:
   # in the Chrome profile the sidecar drives, not on these services.
   avito:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["avito-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -152,7 +152,7 @@ services:
 
   taobao:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["taobao-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -167,7 +167,7 @@ services:
 
   megamarket:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["megamarket-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -182,7 +182,7 @@ services:
 
   lamoda:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["lamoda-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -197,7 +197,7 @@ services:
 
   dns:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["dns-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -212,7 +212,7 @@ services:
 
   citilink:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["citilink-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -227,7 +227,7 @@ services:
 
   aliexpress:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["aliexpress-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -244,7 +244,7 @@ services:
   # starts but its tools return auth_missing. No Chrome needed — plain httpx.
   mpstats:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["mpstats-mcp"]
     environment:
       MCP_TRANSPORT: http
@@ -275,7 +275,7 @@ services:
   # container is enough; Ozon inside it inherits the same two caveats.
   compare:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["compare-mcp"]
     environment:
       MCP_TRANSPORT: http

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Image tags are pinned: the builder is `ghcr.io/astral-sh/uv:0.11.32-python3.12-t
 ### Build
 
 ```bash
-docker build -t ru-marketplace-mcp:2.0.2 .
+docker build -t ru-marketplace-mcp:2.1.0 .
 ```
 
 The install uses `uv sync --all-packages --frozen`: `--all-packages` installs
@@ -117,14 +117,14 @@ host, so the container binds to all of its *own* interfaces and the perimeter
 moves to the **published port**. Publish it to the host's loopback:
 
 ```bash
-docker run --rm -p 127.0.0.1:8000:8000 ru-marketplace-mcp:2.0.2
+docker run --rm -p 127.0.0.1:8000:8000 ru-marketplace-mcp:2.1.0
 # -> http://127.0.0.1:8000/mcp on the host
 ```
 
 Run a different marketplace by overriding the command:
 
 ```bash
-docker run --rm -p 127.0.0.1:8001:8000 ru-marketplace-mcp:2.0.2 yandex-mcp
+docker run --rm -p 127.0.0.1:8001:8000 ru-marketplace-mcp:2.1.0 yandex-mcp
 ```
 
 `-p 127.0.0.1:8000:8000` is the security boundary. `-p 8000:8000` would publish

--- a/docs/releases/RELEASE_NOTES_v2.1.0.md
+++ b/docs/releases/RELEASE_NOTES_v2.1.0.md
@@ -1,0 +1,40 @@
+# v2.1.0
+
+Minor release: evidence-aware comparison layer and a middle DSH profile.
+
+## Added
+
+- Middle DSH mount `ru-marketplace-decision` via the new `decision-mcp` console
+  script: the cheap comparison trio plus one generic card inspector
+  `decision_inspect(source, product_id_or_url)`. A DSH agent can verify the
+  comparison winner, seller and card details without paying for the full
+  37-tool marketplace mount. The row ships disabled by default and is enabled
+  with `RU_MARKETPLACE_MCP_DECISION=1` (mutually exclusive with the full mount).
+- `compare_prices` offers now carry `identity` (brand, model, MPN, GTIN,
+  variant attributes) and optional `evidence` provenance, so exact-product
+  matching is checkable instead of assumed; the raw cheapest offer is kept
+  separate from the comparable candidate as before.
+- Reliability scripts: deterministic DSH routing contract eval
+  (`scripts/routing_eval.py`), operational gates (`scripts/test_ops_gates.py`),
+  and `scripts/mcp_wire.py` baseline/snapshot modes that fail CI on wire-token
+  or latency regressions.
+- CDP hardening: bounded websocket frames and a final-host allowlist
+  (`_check_final_host`) so post-navigation redirects cannot drift off the
+  connector's configured marketplace hosts.
+
+## Changed
+
+- `e2e_stdio_check.py` now covers 15 stdio servers including `decision-mcp`
+  (4 tools); the DSH bundle CI guard asserts all 3 MCP rows are disabled by
+  default.
+- Documented offline test count is 1243 across the repository.
+
+## Verification
+
+- Full offline suite passed on Linux, macOS and Windows (Python 3.12/3.13).
+- `e2e_stdio_check.py`: 15/15 real MCP sessions at this version.
+- ruff, mypy (host/win32/darwin), coverage >= 70% gate, lockfile, version
+  consistency (79 declarations) and test-count gates all passed.
+
+Live marketplace data was not freshly re-verified by this release; anti-bot
+challenges remain honestly typed `blocked/inconclusive`.

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -95,7 +95,7 @@ No MCP process survives profile restart without `RU_MARKETPLACE_MCP_DIR`.
 
 Since v1.8.0 every release tag builds a stdio image and proves it with a real
 MCP session over `docker run --rm -i` before publishing to the MCP Registry:
-initialize, `tools/list` (36 tools) and a `marketplace_sources` call. Use the
+initialize, `tools/list` (37 tools) and a `marketplace_sources` call. Use the
 published GHCR image instead of a local clone:
 
 ```yaml
@@ -110,7 +110,7 @@ published GHCR image instead of a local clone:
       - run
       - --rm
       - -i
-      - ghcr.io/vladimir-human/ru-marketplace-mcp:1.8.0
+      - ghcr.io/vladimir-human/ru-marketplace-mcp:2.1.0
     failOnStartupError: false
 ```
 

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ru-marketplace-mcp-dsh",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "type": "module",
   "files": ["cordis.patch.yml", "skills"],
   "dsh": { "bundle": { "patch": "./cordis.patch.yml" } }

--- a/packages/aliexpress-connector/pyproject.toml
+++ b/packages/aliexpress-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "aliexpress-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "AliExpress MCP connector — search and cards rendered in the operator's Chrome over CDP (x5sec)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/aliexpress-connector/src/aliexpress_connector/__init__.py
+++ b/packages/aliexpress-connector/src/aliexpress_connector/__init__.py
@@ -1,3 +1,3 @@
 """AliExpress MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/aliexpress-connector/src/aliexpress_connector/server.py
+++ b/packages/aliexpress-connector/src/aliexpress_connector/server.py
@@ -74,7 +74,7 @@ from aliexpress_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://aliexpress.ru"

--- a/packages/avito-connector/pyproject.toml
+++ b/packages/avito-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "avito-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Avito MCP connector — search, cards and sellers via the internal js/items API, with a CDP fallback"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "curl_cffi>=0.8",

--- a/packages/avito-connector/src/avito_connector/__init__.py
+++ b/packages/avito-connector/src/avito_connector/__init__.py
@@ -1,3 +1,3 @@
 """Avito MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/avito-connector/src/avito_connector/server.py
+++ b/packages/avito-connector/src/avito_connector/server.py
@@ -75,7 +75,7 @@ from avito_connector.shape_reference import missing_required_families
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.avito.ru"

--- a/packages/citilink-connector/pyproject.toml
+++ b/packages/citilink-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "citilink-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Citilink-Shop MCP connector — catalog search and cards rendered in the operator's Chrome over CDP (Qrator)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/citilink-connector/src/citilink_connector/__init__.py
+++ b/packages/citilink-connector/src/citilink_connector/__init__.py
@@ -1,3 +1,3 @@
 """Citilink-Shop MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/citilink-connector/src/citilink_connector/server.py
+++ b/packages/citilink-connector/src/citilink_connector/server.py
@@ -61,7 +61,7 @@ from citilink_connector.shape_reference import SEARCH_REQUIRED_KEYS, SEARCH_SHAP
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.citilink.ru"

--- a/packages/compare-connector/pyproject.toml
+++ b/packages/compare-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "compare-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Cross-marketplace price comparison MCP server — queries every configured marketplace at once"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "wb-connector",
     "detmir-connector",
     "yandex-connector",

--- a/packages/compare-connector/src/compare_connector/__init__.py
+++ b/packages/compare-connector/src/compare_connector/__init__.py
@@ -1,3 +1,3 @@
 """Cross-marketplace price comparison MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -52,7 +52,7 @@ from compare_connector.models_output import (
     SourceOutcome,
 )
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 # Per-source ceiling. Yandex pages are ~2 MB and WB search occasionally stalls, so

--- a/packages/detmir-connector/pyproject.toml
+++ b/packages/detmir-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "detmir-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Detsky Mir MCP connector — anonymous public JSON API (cards, category listings, search)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/detmir-connector/src/detmir_connector/__init__.py
+++ b/packages/detmir-connector/src/detmir_connector/__init__.py
@@ -1,3 +1,3 @@
 """Detsky Mir MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/detmir-connector/src/detmir_connector/server.py
+++ b/packages/detmir-connector/src/detmir_connector/server.py
@@ -73,7 +73,7 @@ from detmir_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 API_BASE = "https://api.detmir.ru"

--- a/packages/dns-connector/pyproject.toml
+++ b/packages/dns-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dns-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "DNS-Shop MCP connector — catalog search and cards rendered in the operator's Chrome over CDP (Qrator)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/dns-connector/src/dns_connector/__init__.py
+++ b/packages/dns-connector/src/dns_connector/__init__.py
@@ -1,3 +1,3 @@
 """DNS-Shop MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/dns-connector/src/dns_connector/server.py
+++ b/packages/dns-connector/src/dns_connector/server.py
@@ -61,7 +61,7 @@ from dns_connector.shape_reference import SEARCH_REQUIRED_KEYS, SEARCH_SHAPE_REF
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.dns-shop.ru"

--- a/packages/lamoda-connector/pyproject.toml
+++ b/packages/lamoda-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "lamoda-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Lamoda MCP connector — GraphQL SKU enrichment plus CDP-backed search"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/lamoda-connector/src/lamoda_connector/__init__.py
+++ b/packages/lamoda-connector/src/lamoda_connector/__init__.py
@@ -1,3 +1,3 @@
 """Lamoda MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -65,7 +65,7 @@ from lamoda_connector.shape_reference import SEARCH_SHAPE_REFERENCE, missing_req
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.lamoda.ru"

--- a/packages/marketplace-connector/pyproject.toml
+++ b/packages/marketplace-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "marketplace-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Unified marketplace MCP server — mounts every installed connector as one namespaced toolset"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -13,7 +13,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "wb-connector",

--- a/packages/marketplace-connector/src/marketplace_connector/__init__.py
+++ b/packages/marketplace-connector/src/marketplace_connector/__init__.py
@@ -1,3 +1,3 @@
 """Unified marketplace MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/marketplace-connector/src/marketplace_connector/server.py
+++ b/packages/marketplace-connector/src/marketplace_connector/server.py
@@ -42,7 +42,7 @@ class MarketplaceSourcesResponse(BaseModel):
     server_version: str = Field(default="", description="Unified server version.")
 
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 
 mcp = FastMCP(
     "marketplace",

--- a/packages/mcp-core/pyproject.toml
+++ b/packages/mcp-core/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcp-core"
-version = "2.0.2"
+version = "2.1.0"
 description = "Shared runtime for ru-marketplace-mcp connectors — error taxonomy, transports, tolerant-reader helpers"
 requires-python = ">=3.12"
 license = { text = "MIT" }

--- a/packages/mcp-core/src/mcp_core/__init__.py
+++ b/packages/mcp-core/src/mcp_core/__init__.py
@@ -54,4 +54,4 @@ __all__ = [
     "redact_error_text",
 ]
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/megamarket-connector/pyproject.toml
+++ b/packages/megamarket-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "megamarket-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Megamarket MCP connector — mobile JSON API fetched inside the operator's Chrome over CDP (ServicePipe)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/megamarket-connector/src/megamarket_connector/__init__.py
+++ b/packages/megamarket-connector/src/megamarket_connector/__init__.py
@@ -1,3 +1,3 @@
 """Megamarket MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/megamarket-connector/src/megamarket_connector/server.py
+++ b/packages/megamarket-connector/src/megamarket_connector/server.py
@@ -60,7 +60,7 @@ from megamarket_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://megamarket.ru"

--- a/packages/mpstats-connector/pyproject.toml
+++ b/packages/mpstats-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mpstats-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "MPStats MCP connector — sales/stock analytics for Ozon/WB items via plugin.mpstats.io"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/mpstats-connector/src/mpstats_connector/__init__.py
+++ b/packages/mpstats-connector/src/mpstats_connector/__init__.py
@@ -4,4 +4,4 @@ from __future__ import annotations
 
 __all__ = ["__version__"]
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/mpstats-connector/src/mpstats_connector/server.py
+++ b/packages/mpstats-connector/src/mpstats_connector/server.py
@@ -78,7 +78,7 @@ from mpstats_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/ozon-connector/pyproject.toml
+++ b/packages/ozon-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ozon-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Ozon MCP connector — two-tier transport (TLS impersonation + authenticated Chrome CDP)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/ozon-connector/src/ozon_connector/__init__.py
+++ b/packages/ozon-connector/src/ozon_connector/__init__.py
@@ -1,3 +1,3 @@
 """Ozon MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/ozon-connector/src/ozon_connector/server.py
+++ b/packages/ozon-connector/src/ozon_connector/server.py
@@ -66,7 +66,7 @@ from ozon_connector.models_output import (
 )
 from ozon_connector.settings import get_settings
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/taobao-connector/pyproject.toml
+++ b/packages/taobao-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "taobao-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Taobao MCP connector — search and item cards rendered in the operator's own Chrome over CDP"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/taobao-connector/src/taobao_connector/__init__.py
+++ b/packages/taobao-connector/src/taobao_connector/__init__.py
@@ -1,3 +1,3 @@
 """Taobao MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -62,7 +62,7 @@ from taobao_connector.shape_reference import SEARCH_SHAPE_REFERENCE, missing_req
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SEARCH_BASE = "https://s.taobao.com/search"

--- a/packages/wb-connector/pyproject.toml
+++ b/packages/wb-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wb-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Wildberries MCP connector — public catalog, reviews, sellers and search"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/wb-connector/src/wb_connector/__init__.py
+++ b/packages/wb-connector/src/wb_connector/__init__.py
@@ -1,3 +1,3 @@
 """Wildberries MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/wb-connector/src/wb_connector/server.py
+++ b/packages/wb-connector/src/wb_connector/server.py
@@ -78,7 +78,7 @@ from wb_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 mcp = FastMCP(

--- a/packages/yandex-connector/pyproject.toml
+++ b/packages/yandex-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "yandex-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Yandex Market MCP connector — SSR state extraction (search, cards, reviews)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-"mcp-core==2.0.2",
+"mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "httpx>=0.27",
     "pydantic>=2.6",

--- a/packages/yandex-connector/src/yandex_connector/__init__.py
+++ b/packages/yandex-connector/src/yandex_connector/__init__.py
@@ -1,3 +1,3 @@
 """Yandex Market MCP connector."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/yandex-connector/src/yandex_connector/server.py
+++ b/packages/yandex-connector/src/yandex_connector/server.py
@@ -71,7 +71,7 @@ from yandex_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://market.yandex.ru"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ru-marketplace-mcp"
-version = "2.0.2"
+version = "2.1.0"
 description = "MCP servers for Russian marketplaces — Wildberries, Ozon and more"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/server.json
+++ b/server.json
@@ -3,7 +3,7 @@
   "name": "io.github.Vladimir-Human/ru-marketplace-mcp",
   "description": "Read-only MCP servers for Russian marketplaces: prices, stock, ratings, reviews, seller identity",
   "title": "ru-marketplace-mcp",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "websiteUrl": "https://github.com/Vladimir-Human/ru-marketplace-mcp",
   "repository": {
     "url": "https://github.com/Vladimir-Human/ru-marketplace-mcp",
@@ -134,7 +134,7 @@
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/vladimir-human/ru-marketplace-mcp:2.0.2",
+      "identifier": "ghcr.io/vladimir-human/ru-marketplace-mcp:2.1.0",
       "runtimeHint": "docker",
       "transport": {
         "type": "stdio"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 
 [[package]]
 name = "aliexpress-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/aliexpress-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -149,7 +149,7 @@ wheels = [
 
 [[package]]
 name = "avito-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/avito-connector" }
 dependencies = [
     { name = "curl-cffi" },
@@ -316,7 +316,7 @@ wheels = [
 
 [[package]]
 name = "citilink-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/citilink-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -358,7 +358,7 @@ wheels = [
 
 [[package]]
 name = "compare-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/compare-connector" }
 dependencies = [
     { name = "detmir-connector" },
@@ -597,7 +597,7 @@ wheels = [
 
 [[package]]
 name = "detmir-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/detmir-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -627,7 +627,7 @@ wheels = [
 
 [[package]]
 name = "dns-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/dns-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1106,7 +1106,7 @@ wheels = [
 
 [[package]]
 name = "lamoda-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/lamoda-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1203,7 +1203,7 @@ wheels = [
 
 [[package]]
 name = "marketplace-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/marketplace-connector" }
 dependencies = [
     { name = "avito-connector" },
@@ -1269,7 +1269,7 @@ wheels = [
 
 [[package]]
 name = "mcp-core"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/mcp-core" }
 dependencies = [
     { name = "fastmcp" },
@@ -1310,7 +1310,7 @@ wheels = [
 
 [[package]]
 name = "megamarket-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/megamarket-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1340,7 +1340,7 @@ wheels = [
 
 [[package]]
 name = "mpstats-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/mpstats-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -1457,7 +1457,7 @@ wheels = [
 
 [[package]]
 name = "ozon-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/ozon-connector" }
 dependencies = [
     { name = "curl-cffi" },
@@ -2033,7 +2033,7 @@ wheels = [
 
 [[package]]
 name = "ru-marketplace-mcp"
-version = "2.0.2"
+version = "2.1.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aliexpress-connector" },
@@ -2171,7 +2171,7 @@ wheels = [
 
 [[package]]
 name = "taobao-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/taobao-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -2345,7 +2345,7 @@ wheels = [
 
 [[package]]
 name = "wb-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/wb-connector" }
 dependencies = [
     { name = "fastmcp" },
@@ -2495,7 +2495,7 @@ wheels = [
 
 [[package]]
 name = "yandex-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/yandex-connector" }
 dependencies = [
     { name = "fastmcp" },


### PR DESCRIPTION
## What changes

Minor release with the evidence-aware comparison layer from #45 and the middle
DSH decision profile:

- `decision-mcp` console script and disabled-by-default `ru-marketplace-decision`
  DSH row (comparison + `decision_inspect` card inspector).
- `compare_prices` offers carry `identity` (MPN/GTIN/variant evidence) and
  `evidence` provenance.
- Reliability scripts: routing eval, operational gates, `mcp_wire.py` wire/latency
  baseline modes.
- CDP hardening: bounded websocket frames and final-host allowlist.
- 15-server stdio smoke including `decision-mcp`; bundle guard now expects 3
  (all-disabled) MCP rows.
- All workspace packages, pins, Docker/OCI references, DSH bundle metadata and
  lockfile move from `2.0.2` to `2.1.0`. Documented offline test count is 1243.
- `dsh/README.md` Docker example now points at the current release.

## Validation

- offline suite with coverage: 1242 passed, 1 skipped, 5 deselected, 77.98%
  (70% gate)
- `e2e_stdio_check.py`: 15/15 real MCP sessions at `2.1.0`
- ruff, mypy (host/win32/darwin), no-print, version (79 declarations), test-count
  and lockfile gates
