### PR TITLE
feat: add a Cian connector (real estate, tier 2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -208,6 +208,7 @@ jobs:
               "dns": 2,
               "citilink": 2,
               "aliexpress": 2,
+              "cian": 2,
               "mpstats": 2,
           }
 
@@ -224,6 +225,7 @@ jobs:
               from dns_connector.server import mcp as dns_mcp
               from citilink_connector.server import mcp as citilink_mcp
               from aliexpress_connector.server import mcp as aliexpress_mcp
+              from cian_connector.server import mcp as cian_mcp
               from mpstats_connector.server import mcp as mpstats_mcp
 
               servers = {
@@ -239,6 +241,7 @@ jobs:
                   "dns": dns_mcp,
                   "citilink": citilink_mcp,
                   "aliexpress": aliexpress_mcp,
+                  "cian": cian_mcp,
                   "mpstats": mpstats_mcp,
               }
               # Guard the guard: mpstats was listed in EXPECTED but never added to
@@ -278,6 +281,7 @@ jobs:
           uv run which dns-mcp
           uv run which citilink-mcp
           uv run which aliexpress-mcp
+          uv run which cian-mcp
           uv run which mpstats-mcp
           uv run which marketplace-mcp
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -420,7 +420,7 @@ jobs:
           test -f "$installed/cordis.patch.yml"
           skills=$(find "$installed/skills" -name SKILL.md | wc -l)
           echo "vendored skills: $skills"
-          test "$skills" -eq 14
+          test "$skills" -eq 15
 
       - name: All MCP rows are still disabled by default
         # The safety promise of this bundle: skills are free, MCP tools are opt-in.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -324,8 +324,8 @@ jobs:
         # a red assertion abort the job — but we DO capture the exact pytest exit
         # code and hand it to the summary step, which is what makes the outcome
         # honest instead of a blanket green. Only wb, detmir and yandex carry
-        # @pytest.mark.live tests (3 of the 13 sources), so this canary covers 3
-        # of 11 — the summary spells that out so a pass is not mistaken for
+        # @pytest.mark.live tests (3 of the 14 sources), so this canary covers 3
+        # of 12 — the summary spells that out so a pass is not mistaken for
         # "everything works". Exit codes: 0 = all passed, 1 = failures (from a
         # datacenter runner with no Russian IP this usually means blocked, but it
         # is indistinguishable here from real drift), 5 = nothing collected, other
@@ -349,7 +349,7 @@ jobs:
           {
             echo "## Live endpoint canaries"
             echo ""
-            echo "Coverage: **3 of 13 sources** carry \`@pytest.mark.live\` tests — wb, detmir, yandex. The other 10 have none, so a green canary says nothing about them. AliExpress is CDP-only against x5sec: its drift signal comes from \`aliexpress_selfcheck\` on the operator's machine, not from this nightly job."
+            echo "Coverage: **3 of 14 sources** carry \`@pytest.mark.live\` tests — wb, detmir, yandex. The other 11 have none, so a green canary says nothing about them. AliExpress is CDP-only against x5sec: its drift signal comes from \`aliexpress_selfcheck\` on the operator's machine, not from this nightly job."
             echo ""
             echo "GitHub's runners have no Russian-friendly IP, so a blocked source and genuine drift both surface as test failures here; disambiguating needs a rerun from a Russian-friendly IP."
             echo ""

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@
 
 ## [Unreleased]
 
+### Добавлено
+
+- Коннектор Циан (`cian-connector`, скрипт `cian-mcp`, тулы `cian_search` и
+  `cian_card`) — недвижимость, а не товары: квартиры, комнаты, дома и коммерция
+  на продажу и в долгосрочную аренду. Только второй ярус (CDP): WAF Циана режет
+  голый HTTP по IP (403 `cian_waf_block`, без капчи), а из сессии Chrome
+  отвечает собственный JSON-API сайта (`search-offers-desktop`) и состояние
+  карточки в `window._cianConfig`. Поиск по фильтрам (сделка, тип, регион,
+  комнаты, цена, площадь), не по тексту; регионы 1/2/4593/4588 проверены живьём.
+  Карточка отдаёт цену и её историю, планировку, дом, адрес, метро, описание и
+  публикатора. Цена без указания — `None`, не 0. В `compare_prices` источник не
+  участвует. Страница агента структурированных данных не отдаёт, поэтому тула
+  `cian_agent` нет — агент приходит внутри карточки (`docs/ANTI_BOT.md` § Cian).
+
+### Added
+
+- Cian connector (`cian-connector`, `cian-mcp` console script, tools
+  `cian_search` and `cian_card`) — real estate, not goods: flats, rooms, houses
+  and commercial property for sale or long-term rent. Tier 2 only: Cian's WAF
+  blocks plain HTTP by IP (403 `cian_waf_block`, no captcha), while inside the
+  Chrome session the site's own JSON API (`search-offers-desktop`) and the card
+  state in `window._cianConfig` answer. Search is by filters (deal, type,
+  region, rooms, price, area), not text; regions 1/2/4593/4588 verified live.
+  The card carries the price and its history, layout, building, address, metro,
+  description and publisher. A missing price is `None`, never 0. The source
+  takes no part in `compare_prices`. The agent page exposes no structured data,
+  so there is no `cian_agent` tool — the agent ships inside the card
+  (`docs/ANTI_BOT.md` § Cian).
+
 ## [2.1.0] — 2026-09-09
 
 ### Добавлено

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@
 
 ### Добавлено
 
+- `cian_search` умеет посуточную аренду: `deal="daily"` (рядом с `sale` и
+  `rent`). Это отдельный рынок Циана — тот же `_type`, но `for_day: "1"` вместо
+  `"!1"`; замер 2026-09-10 по Москве: 25 411 длительных квартир против 53 441
+  суточной, а без флага выдача их смешивает. Работает для квартир, комнат и
+  домов; коммерции посуточно у Циана нет, и такой запрос отклоняется как
+  `bad_request`, а не отдаёт пустую страницу под видом «сегодня ничего нет».
+- Новое поле `price_unit` в выдаче и карточке: `total` (продажа), `month`
+  (длительная аренда) или `day` (посуточно). У суточных объявлений Циан не
+  заполняет ни `paymentPeriod`, ни `leaseTermType` и не отдаёт `priceRur` —
+  без явной единицы 5 000 ₽ за ночь читались бы как более дешёвое предложение,
+  чем 90 000 ₽ за месяц.
+
 - Коннектор Циан (`cian-connector`, скрипт `cian-mcp`, тулы `cian_search` и
   `cian_card`) — недвижимость, а не товары: квартиры, комнаты, дома и коммерция
   на продажу и в долгосрочную аренду. Только второй ярус (CDP): WAF Циана режет
@@ -25,6 +37,16 @@
 
 ### Added
 
+- `cian_search` covers daily rent: `deal="daily"` alongside `sale` and `rent`.
+  It is a separate Cian market — same `_type`, `for_day: "1"` instead of `"!1"`;
+  measured in Moscow on 2026-09-10: 25 411 long-term flats against 53 441 daily
+  ones, and dropping the flag mixes them. Flats, rooms and houses only; Cian has
+  no daily commercial market, so that pair is refused as `bad_request` rather
+  than returning an empty page that reads as "nothing free today".
+- New `price_unit` field on search rows and cards: `total` (sale), `month`
+  (long-term rent) or `day` (daily). Cian fills in neither `paymentPeriod` nor
+  `leaseTermType` on daily offers and omits `priceRur` there, so without an
+  explicit unit a 5 000 ₽ night would read as cheaper than a 90 000 ₽ month.
 - Cian connector (`cian-connector`, `cian-mcp` console script, tools
   `cian_search` and `cian_card`) — real estate, not goods: flats, rooms, houses
   and commercial property for sale or long-term rent. Tier 2 only: Cian's WAF

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ WORKDIR /app
 # re-resolve"; --no-install-project defers the workspace packages themselves to
 # the next step; --no-dev drops the test/lint toolchain from the runtime image.
 #
-# Every one of the 15 workspace members must be listed here. `uv sync
+# Every one of the 16 workspace members must be listed here. `uv sync
 # --all-packages` reads each member's pyproject.toml even under
 # --no-install-project (it still resolves their workspace deps), so a missing
 # manifest fails the resolve with "Distribution not found at:

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ COPY packages/lamoda-connector/pyproject.toml packages/lamoda-connector/pyprojec
 COPY packages/dns-connector/pyproject.toml packages/dns-connector/pyproject.toml
 COPY packages/citilink-connector/pyproject.toml packages/citilink-connector/pyproject.toml
 COPY packages/aliexpress-connector/pyproject.toml packages/aliexpress-connector/pyproject.toml
+COPY packages/cian-connector/pyproject.toml packages/cian-connector/pyproject.toml
 COPY packages/mpstats-connector/pyproject.toml packages/mpstats-connector/pyproject.toml
 COPY packages/marketplace-connector/pyproject.toml packages/marketplace-connector/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -120,9 +121,9 @@ EXPOSE 8000
 # change in packages/, out of scope here. Until then, no check beats a lying one.
 
 # Default to the Wildberries server; override the command to run any of the
-# other thirteen entry points — ozon-mcp, yandex-mcp, detmir-mcp, compare-mcp,
+# other fourteen entry points — ozon-mcp, yandex-mcp, detmir-mcp, compare-mcp,
 # avito-mcp, taobao-mcp, megamarket-mcp, lamoda-mcp, dns-mcp, citilink-mcp,
-# aliexpress-mcp, mpstats-mcp, or the unified marketplace-mcp (all sources in
-# one server). docker-compose.yml shows running several at once, each on its
+# aliexpress-mcp, cian-mcp, mpstats-mcp, or the unified marketplace-mcp (all
+# sources in one server). docker-compose.yml shows running several at once, each on its
 # own published port.
 CMD ["wb-mcp"]

--- a/Dockerfile.stdio
+++ b/Dockerfile.stdio
@@ -57,6 +57,7 @@ COPY packages/lamoda-connector/pyproject.toml packages/lamoda-connector/pyprojec
 COPY packages/dns-connector/pyproject.toml packages/dns-connector/pyproject.toml
 COPY packages/citilink-connector/pyproject.toml packages/citilink-connector/pyproject.toml
 COPY packages/aliexpress-connector/pyproject.toml packages/aliexpress-connector/pyproject.toml
+COPY packages/cian-connector/pyproject.toml packages/cian-connector/pyproject.toml
 COPY packages/mpstats-connector/pyproject.toml packages/mpstats-connector/pyproject.toml
 COPY packages/marketplace-connector/pyproject.toml packages/marketplace-connector/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -114,10 +115,10 @@ EXPOSE 8000
 # change in packages/, out of scope here. Until then, no check beats a lying one.
 
 # Default to the Wildberries server; override the command to run any of the
-# other thirteen entry points — ozon-mcp, yandex-mcp, detmir-mcp, compare-mcp,
+# other fourteen entry points — ozon-mcp, yandex-mcp, detmir-mcp, compare-mcp,
 # avito-mcp, taobao-mcp, megamarket-mcp, lamoda-mcp, dns-mcp, citilink-mcp,
-# aliexpress-mcp, mpstats-mcp, or the unified marketplace-mcp (all sources in
-# one server). docker-compose.yml shows running several at once, each on its
+# aliexpress-mcp, cian-mcp, mpstats-mcp, or the unified marketplace-mcp (all
+# sources in one server). docker-compose.yml shows running several at once, each on its
 # own published port.
 # The advertised package runs the unified 36-tool server over stdio. Override
 # the command to launch a single-source connector with the same image.

--- a/Dockerfile.stdio
+++ b/Dockerfile.stdio
@@ -35,7 +35,7 @@ WORKDIR /app
 # re-resolve"; --no-install-project defers the workspace packages themselves to
 # the next step; --no-dev drops the test/lint toolchain from the runtime image.
 #
-# Every one of the 15 workspace members must be listed here. `uv sync
+# Every one of the 16 workspace members must be listed here. `uv sync
 # --all-packages` reads each member's pyproject.toml even under
 # --no-install-project (it still resolves their workspace deps), so a missing
 # manifest fails the resolve with "Distribution not found at:
@@ -90,7 +90,7 @@ COPY --from=builder --chown=app:app /app/packages /app/packages
 # The skills travel with the servers. Each connector has one, and it is how an
 # agent learns the tool exists, when to reach for it, and which of its answers
 # need a second look. A container with the servers but not the skills runs
-# thirteen MCP endpoints nothing knows how to use.
+# fourteen MCP endpoints nothing knows how to use.
 COPY --chown=app:app skills/ /app/skills/
 
 # Put the venv on PATH so the console scripts (wb-mcp, ozon-mcp, ...) resolve
@@ -120,6 +120,6 @@ EXPOSE 8000
 # aliexpress-mcp, cian-mcp, mpstats-mcp, or the unified marketplace-mcp (all
 # sources in one server). docker-compose.yml shows running several at once, each on its
 # own published port.
-# The advertised package runs the unified 36-tool server over stdio. Override
+# The advertised package runs the unified 39-tool server over stdio. Override
 # the command to launch a single-source connector with the same image.
 CMD ["marketplace-mcp"]

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ claude mcp add compare-prices -- uv run --directory /путь/к/ru-marketplace-
 <summary><b>Другой stdio-клиент</b></summary>
 
 Запустите `uv run --directory /путь/к/репозиторию <команда>`, где команда — одна из
-`wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `aliexpress-mcp`, `compare-mcp`. Серверы говорят по
+`wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `aliexpress-mcp`, `cian-mcp`, `compare-mcp`. Серверы говорят по
 JSON-RPC через stdin и stdout, диагностику пишут в stderr. Опциональный
 `mpstats-mcp` запускается так же, с `MPSTATS_MP_AUTH` в окружении.
 
@@ -359,6 +359,23 @@ Lamoda.
 `aliexpress_selfcheck` доказывает, что транспорт ответил, — не то, что цена
 верна.
 
+### Циан — `cian_*`
+
+| Инструмент                                                                                  | Что делает                                              |
+| ------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
+| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Поиск недвижимости по фильтрам: 28 объявлений на страницу |
+| `cian_card(offer_id_or_url)`                                                                | Карточка: цена и её история, планировка, дом, адрес, метро, публикатор |
+
+Недвижимость, а не товары: квартиры, комнаты, дома и коммерция на продажу и в
+долгосрочную аренду. Поиск только по фильтрам — текстового поиска у Циана нет.
+Регион задаётся id Циана: 1 Москва, 2 Санкт-Петербург, 4593 Московская область,
+4588 Ленинградская область (все четыре проверены живьём); остальным регионам
+нужен их id. Читается через ваш Chrome (CDP): WAF Циана режет голый HTTP по IP,
+а из сессии браузера отвечает собственный JSON-API сайта, так что HTML не
+парсится. Цена «не указана» приходит как `null`, не `0`. Агентской страницы как
+инструмента нет: она не отдаёт структурированных данных, агент приходит внутри
+карточки. В `compare_prices` источник не участвует.
+
 ### Сравнение цен — `compare_*`
 
 | Инструмент                                         | Что делает                                   |
@@ -438,6 +455,7 @@ compare_prices("кроссовки мужские")
 | `skills/dns-connector`        | `dns-mcp`         |
 | `skills/citilink-connector`   | `citilink-mcp`    |
 | `skills/aliexpress-connector` | `aliexpress-mcp`  |
+| `skills/cian-connector`       | `cian-mcp`        |
 | `skills/compare-prices`       | `compare-mcp`     |
 | `skills/mpstats-connector`    | `mpstats-mcp`     |
 | `skills/marketplace`          | `marketplace-mcp` |
@@ -649,7 +667,7 @@ uv run pytest -q -m "not live and not cdp"    # 1243 offline tests, no network n
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
-script (`wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `aliexpress-mcp`, `compare-mcp`) launched
+script (`wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `aliexpress-mcp`, `cian-mcp`, `compare-mcp`) launched
 through `uv run --directory /path/to/repo <script>`. The optional `mpstats-mcp`
 runs the same way with `MPSTATS_MP_AUTH` in the entry's `env` (paid MPStats
 account; without it the tools return `auth_missing`). `marketplace-mcp install
@@ -784,6 +802,23 @@ coupon is reported as a warning. Review texts are not exposed; rating and order
 counts are. As with every CDP source, a green `aliexpress_selfcheck` proves the
 transport answered — not that a given price is right.
 
+### Cian — `cian_*`
+
+| Tool                                                                                        | What it does                                                    |
+| ------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
+| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Real-estate search by filters: 28 offers per page               |
+| `cian_card(offer_id_or_url)`                                                                | One offer: price and its history, layout, building, address, metro, publisher |
+
+Real estate, not goods: flats, rooms, houses and commercial property for sale or
+long-term rent. Search is by filters only — Cian has no text search. The region
+is a Cian id: 1 Moscow, 2 St. Petersburg, 4593 Moscow oblast, 4588 Leningrad
+oblast (all four verified live); other regions need their own id. Read through
+your Chrome (CDP): Cian's WAF blocks plain HTTP by IP, while inside the browser
+session the site's own JSON API answers, so no HTML is parsed. A price Cian does
+not state arrives as `null`, never `0`. There is no agent tool: the agent page
+exposes no structured data, and the publisher ships inside the card. The source
+takes no part in `compare_prices`.
+
 ### Avito — `avito_*`
 
 | Tool                                              | What it does                                      |
@@ -898,6 +933,7 @@ answers should not be trusted without a second look.
 | `skills/dns-connector`        | `dns-mcp`         |
 | `skills/citilink-connector`   | `citilink-mcp`    |
 | `skills/aliexpress-connector` | `aliexpress-mcp`  |
+| `skills/cian-connector`       | `cian-mcp`        |
 | `skills/compare-prices`       | `compare-mcp`     |
 | `skills/mpstats-connector`    | `mpstats-mcp`     |
 | `skills/marketplace`          | `marketplace-mcp` |

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 **MCP-серверы для российских и китайских маркетплейсов.** Цены, наличие,
 рейтинги, отзывы и реквизиты продавцов с Wildberries, Ozon, Яндекс Маркета,
 Детского мира, Авито, AliExpress, Taobao, Мегамаркета, Lamoda, DNS и Ситилинка.
-Плюс
-сравнение цен по всем источникам одним вызовом.
+Плюс недвижимость с Циана и
+сравнение цен по всем товарным источникам одним вызовом.
 
 Только чтение. Ключи API, токены и регистрация не нужны — площадки с жёстким
 анти-ботом читаются через ваш собственный Chrome. Одно исключение по желанию:
@@ -36,7 +36,8 @@
 | **DNS**           | 2            | ваш Chrome (Qrator)                                                        | Поиск и карточки электроники                                                              |
 | **Ситилинк**      | 2            | ваш Chrome (Qrator)                                                        | Поиск и карточки электроники                                                              |
 | **AliExpress**    | 2            | ваш Chrome (x5sec)                                                       | Поиск и карточки, цены в рублях                            |
-| **Сравнение**     | 2            | опрашивает всё перечисленное                                               | «Где дешевле?» одним вызовом                                                              |
+| **Циан**          | 2            | ваш Chrome (WAF по IP)                                                     | Недвижимость: поиск по фильтрам (продажа, аренда, посуточно) и карточка объявления         |
+| **Сравнение**     | 3            | опрашивает всё перечисленное                                               | «Где дешевле?» одним вызовом                                                              |
 | **MPStats**       | 2            | платный аккаунт MPStats, cookie `mp_auth` (опционально)                    | Продажи/остатки/графики за 30 дней по SKU Ozon/WB, остатки по складам (FBS/FBO)           |
 
 Читается анонимно, без браузера: Wildberries, Яндекс Маркет, Детский мир и
@@ -54,10 +55,10 @@ MPStats стоит особняком: это единственный **пла�
 поэтому он опционален и подключается по желанию, на остальные двенадцать
 серверов он не влияет никак.
 
-Всего 35 инструментов в 13 серверах на общем рантайме `mcp-core`. Плюс объединённый
+Всего 38 инструментов в 14 серверах на общем рантайме `mcp-core`. Плюс объединённый
 `marketplace-mcp`, который монтирует всё разом — одна запись в конфиге клиента
-вместо тринадцати. Он добавляет свой инструмент `marketplace_sources` (какие коннекторы
-поднялись, а какие отвалились и почему), так что в нём 36 инструментов: 35
+вместо четырнадцати. Он добавляет свой инструмент `marketplace_sources` (какие коннекторы
+поднялись, а какие отвалились и почему), так что в нём 39 инструментов: 38
 смонтированных плюс этот.
 
 ## Быстрый старт
@@ -68,7 +69,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1243 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1311 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -363,11 +364,16 @@ Lamoda.
 
 | Инструмент                                                                                  | Что делает                                              |
 | ------------------------------------------------------------------------------------------- | ------------------------------------------------------- |
-| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Поиск недвижимости по фильтрам: 28 объявлений на страницу |
+| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Поиск по фильтрам: продажа, аренда, посуточно — 28 объявлений на страницу |
 | `cian_card(offer_id_or_url)`                                                                | Карточка: цена и её история, планировка, дом, адрес, метро, публикатор |
 
-Недвижимость, а не товары: квартиры, комнаты, дома и коммерция на продажу и в
-долгосрочную аренду. Поиск только по фильтрам — текстового поиска у Циана нет.
+Недвижимость, а не товары: квартиры, комнаты, дома и коммерция на продажу, в
+долгосрочную аренду и посуточно (`deal="daily"`; коммерции посуточно у Циана
+нет, такой запрос отклоняется). Длительная и суточная аренда — два разных рынка,
+в одной выдаче не смешиваются: у суточных цена за ночь, `price_period` и
+`lease_term` пустые, поэтому у каждой строки есть `price_unit` — `total`,
+`month` или `day`. Сравнивать цены между единицами нельзя.
+Поиск только по фильтрам — текстового поиска у Циана нет.
 Регион задаётся id Циана: 1 Москва, 2 Санкт-Петербург, 4593 Московская область,
 4588 Ленинградская область (все четыре проверены живьём); остальным регионам
 нужен их id. Читается через ваш Chrome (CDP): WAF Циана режет голый HTTP по IP,
@@ -520,7 +526,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1243 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1311 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -583,7 +589,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1243 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1311 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -631,7 +637,8 @@ it every other server is unaffected.
 | **DNS**           | 2     | your Chrome (Qrator)                                                          | Electronics search and cards                                                                       |
 | **Citilink**      | 2     | your Chrome (Qrator)                                                          | Electronics search and cards                                                                       |
 | **AliExpress**    | 2     | your Chrome (x5sec)                                                           | Search and cards, ruble prices                            |
-| **Compare**       | 2     | aggregates the above                                                          | "Where is this cheapest?" in one call                                                              |
+| **Cian**          | 2     | your Chrome (WAF by IP)                                                      | Real estate: filter search (sale, long-term rent, daily) and one offer's card                      |
+| **Compare**       | 3     | aggregates the above                                                          | "Where is this cheapest?" in one call                                                              |
 | **MPStats**       | 2     | paid MPStats account, `mp_auth` cookie (optional)                             | 30-day sales/stock graphs per Ozon/WB SKU, warehouse split (FBS/FBO)                               |
 
 Anonymous, no browser: Wildberries, Yandex Market, Detsky Mir and Lamoda cards.
@@ -648,10 +655,10 @@ MPStats stands apart as the only **paid** source: without `MPSTATS_MP_AUTH` the
 server boots but its tools answer `auth_missing`. It is therefore optional —
 plug it in if you have an account; the other thirteen servers never notice.
 
-35 tools across 13 stdio MCP servers, sharing one runtime (`mcp-core`), plus the
+38 tools across 14 stdio MCP servers, sharing one runtime (`mcp-core`), plus the
 unified `marketplace-mcp` that mounts them all under one client entry. It adds its
 own `marketplace_sources` tool — which connectors mounted, and which dropped out and
-why — so it exposes 36 tools: the 35 mounted plus that one. stdio is the default;
+why — so it exposes 39 tools: the 38 mounted plus that one. stdio is the default;
 HTTP transport is opt-in for remote deployment — see
 [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
@@ -663,7 +670,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1243 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1311 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -806,11 +813,16 @@ transport answered — not that a given price is right.
 
 | Tool                                                                                        | What it does                                                    |
 | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------- |
-| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Real-estate search by filters: 28 offers per page               |
+| `cian_search(deal, offer_type, region, rooms, price_min, price_max, area_min, area_max, page)` | Search by filters — sale, long-term rent, daily: 28 offers per page |
 | `cian_card(offer_id_or_url)`                                                                | One offer: price and its history, layout, building, address, metro, publisher |
 
-Real estate, not goods: flats, rooms, houses and commercial property for sale or
-long-term rent. Search is by filters only — Cian has no text search. The region
+Real estate, not goods: flats, rooms, houses and commercial property for sale,
+long-term rent or daily rent (`deal="daily"`; Cian has no daily commercial
+market and that combination is refused). Long-term and daily are separate
+markets that never share a result page: a daily price is per night and Cian
+leaves `price_period` and `lease_term` null there, so every row carries
+`price_unit` — `total`, `month` or `day`. Never compare prices across units.
+Search is by filters only — Cian has no text search. The region
 is a Cian id: 1 Moscow, 2 St. Petersburg, 4593 Moscow oblast, 4588 Leningrad
 oblast (all four verified live); other regions need their own id. Read through
 your Chrome (CDP): Cian's WAF blocks plain HTTP by IP, while inside the browser
@@ -998,7 +1010,7 @@ commits.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1243 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1311 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1058,7 +1070,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1243 offline
+are confidently wrong, so the project is arranged around verification: 1311 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -245,7 +245,7 @@ services:
   # sidecar like the sources above.
   cian:
     build: .
-    image: ru-marketplace-mcp:2.0.2
+    image: ru-marketplace-mcp:2.1.0
     command: ["cian-mcp"]
     environment:
       MCP_TRANSPORT: http

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -240,6 +240,24 @@ services:
       - "127.0.0.1:8014:8000"
     restart: unless-stopped
 
+  # cian-mcp is real estate (flats, houses, commercial property), not goods.
+  # Tier-2 only: Cian's WAF blocks plain HTTP by IP, so it needs the Chrome
+  # sidecar like the sources above.
+  cian:
+    build: .
+    image: ru-marketplace-mcp:2.0.2
+    command: ["cian-mcp"]
+    environment:
+      MCP_TRANSPORT: http
+      MCP_HTTP_HOST: 0.0.0.0
+      MCP_HTTP_PORT: 8000
+      MCP_HTTP_PATH: /mcp
+      # CHROME_CDP_HOST: chrome
+      # CHROME_CDP_PORT: "9222"
+    ports:
+      - "127.0.0.1:8015:8000"
+    restart: unless-stopped
+
   # mpstats-mcp is the optional paid source: without MPSTATS_MP_AUTH the server
   # starts but its tools return auth_missing. No Chrome needed — plain httpx.
   mpstats:

--- a/docs/ANTI_BOT.md
+++ b/docs/ANTI_BOT.md
@@ -610,3 +610,56 @@ per-request proof-of-work is precisely the case the doctrine calls "Neither".
 The connector does not pretend otherwise: on a challenge it degrades into
 `price_missing`/transport errors and tells the operator to pass the check by
 hand.
+
+## Cian (added 2026-09-09)
+
+Real estate, not a marketplace — but the same doctrine applies and the probe
+came out unusually clean. Probed from a datacenter egress (VPN, Timeweb DE) on
+2026-09-09, first with plain HTTP and then through the operator's Chrome.
+
+**Plain HTTP (question 1):** everything is 403 — the search page, the offer
+card, and the internal JSON API `api.cian.ru/search-offers/v2/search-offers-desktop/`,
+with full Chrome headers. The block page is Cian's own WAF
+(`Код страницы: cian_waf_block`, «Обнаружен подозрительный трафик»), no captcha
+markers, no redirect loop. It sets `_yasc` and answers by IP reputation:
+question 2's answer is "firewall", not "challenge".
+
+**Inside the operator's Chrome (tier 2):** the same egress passes. The search
+page renders (636 listings for a one-room Moscow query), and — the useful part —
+the page's own JSON API answers an in-page `fetch` POST with
+`credentials: 'include'`: 200, `data.offersSerialized[]` (28 per page),
+`data.aggregatedCount`, `data.offerCount`. Structured fields, no HTML parsing:
+id, `bargainTerms.priceRur`/`price`, `totalArea`, `roomsCount`, `floorNumber`,
+`building.floorsCount`, `geo.userInput`, `geo.undergrounds[]`, `fullUrl`,
+`user.agencyName`, `isByHomeowner`, `creationDate`. `jsonQuery` keys confirmed
+live: `_type` (`flatsale`, `flatrent`, `suburbansale`, `commercialsale`),
+`engine_version 2`, `region` (1 Moscow, 2 St. Petersburg, 4593 Moscow oblast,
+4588 Leningrad oblast — all four verified by the addresses that came back),
+`room` (`[0]` yields `roomSale` offers), `price` range, `page`, `for_day "!1"`
+(long-term rent).
+
+**Offer card (question 3):** `https://www.cian.ru/sale/flat/<id>/` embeds the
+whole offer in `window._cianConfig['frontend-offer-card']` →
+`defaultState.offerData`: `offer` (83 keys; a new-building offer carries the
+price in `bargainTerms.price` and `priceTotalRur`, with NO `priceRur` — the
+parser reads all three), `agent`, `company`, `priceChanges` (price history),
+`stats` («12907 просмотров, 98 за сегодня» as a string). A rent id requested
+under `/sale/flat/` is redirected by Cian to the right `/rent/flat/` URL on the
+regional subdomain, `offerData` intact.
+
+**Reviews:** none as a data family — real estate has no per-offer reviews.
+
+**Agent page:** `/agents/<id>/` renders, but `_cianConfig['realtor-reviews-frontend']`
+is application config (project name, version, telemetry endpoints), and the
+profile facts («На Циане 1 год», «В работе 1500 объектов», «Регион работы»)
+exist only as DOM text. No structured source → no `cian_agent` tool, per the
+rule at the end of ADDING_A_SOURCE.md. The agent's name, type and id ship inside
+`cian_card` from `offerData.agent`.
+
+**Load (question 5):** eight back-to-back API POSTs inside the session: all
+200, ~1.2 s each, no 429. The connector still paces itself (1.5 s) and holds
+one tab under a lock; a 403 inside the session maps to `transport_down` with
+the instruction to open cian.ru in the scraping Chrome and pass the check.
+
+**Verdict:** tier 2 only, JSON both ways. Tier 1 (`curl_cffi`) was not built:
+the WAF keys on IP and the residential case is unmeasured.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -196,7 +196,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1243 offline tests, no network required. Three flavours:
+1311 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -77,7 +77,7 @@ export RU_MARKETPLACE_MCP_FULL=1     # POSIX shell
 ```
 
 The enabled row then changes from `compare-mcp` (3 tools) to `marketplace-mcp`
-(36 tools). Both rows share `serverName: rumarket`, and their `disabled`
+(39 tools). Both rows share `serverName: rumarket`, and their `disabled`
 conditions are mutually exclusive, so exactly one server instance runs at a
 time.
 

--- a/dsh/skills/cian-connector/SKILL.md
+++ b/dsh/skills/cian-connector/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: cian-connector
+description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale or long-term rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
+---
+
+# Cian Connector
+
+Reads Cian through the site's own JSON API, called from inside the operator's
+Chrome over CDP: the search endpoint answers an in-page POST, and the offer
+card embeds its whole state in `window._cianConfig`. No HTML is parsed. Plain
+HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен подозрительный
+трафик» page, no captcha), so there is no anonymous tier.
+
+## When to use
+- Find offers by filters: deal (sale / rent), property type, region, rooms,
+  price range, total area
+- One offer's price, its price history, layout, building, address, metro,
+  description and publisher
+- Real estate only. For goods use the marketplace connectors; for price
+  comparison across shops use `compare_prices` — Cian takes no part in it
+
+## Tools available
+- `cian_search(deal, offer_type="flat", region=None, rooms=None, price_min=None, price_max=None, area_min=None, area_max=None, page=1)`
+  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale` or
+  `rent` (long-term); `offer_type` is `flat`, `room`, `house` or `commercial`.
+  `price_rub` is None for an offer without a stated price — never 0.
+- `cian_card(offer_id_or_url)` — one offer: price, `price_history`, rooms,
+  areas, floor, building, address, `metro[]`, description, views, `agent`.
+
+**Not an MCP tool:** `cian_selfcheck()` is a tri-state drift canary. It is
+CLI-only — `marketplace-mcp doctor` runs every connector's canary at once.
+
+## Region is an id, not a name
+
+Cian addresses regions by its own numeric ids and the connector has no
+lookup table. Known and verified live:
+
+| id   | region                |
+|------|-----------------------|
+| 1    | Москва                |
+| 2    | Санкт-Петербург       |
+| 4593 | Московская область    |
+| 4588 | Ленинградская область |
+
+Anything else needs the Cian id (visible as `region=` in a cian.ru search
+URL). Do not guess an id: a wrong one returns another region's offers with
+correct-looking prices. Default is `CIAN_REGION` (1, Moscow).
+
+## Filters: what the search does and does not do
+
+- **No text search.** There is no query string; "двушка у метро Сокол" has to
+  become `rooms=[2]` plus a region and a price range. Metro and street filters
+  are not exposed; filter the returned rows by `address` / `metro` yourself.
+- **`rooms`** applies to flats only: any of 1–6, plus Cian's codes 7 (свободная
+  планировка) and 9 (студия) — verified live, and easy to get backwards.
+  Rooms (`offer_type="room"`) are searched as flats with Cian's room code 0 —
+  the caller's `rooms` is ignored there.
+- **Rent is long-term** (`for_day: "!1"`); daily rent is not exposed.
+- **`price_min` / `price_max`** are rubles: total for sale, per month for rent.
+- **`total_count`** is Cian's `aggregatedCount` — the de-duplicated figure the
+  site shows, usually below the raw `offerCount`.
+
+## What a row carries and how to read it
+
+Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
+
+- **Price** comes from `bargainTerms.priceRur`, then `bargainTerms.price`, then
+  `priceTotalRur`. A new-building card has only the latter two — the parser
+  reads all three, so a `null` price means Cian shows none, not a missed key.
+- **`title` is Cian's own only on some offers**; otherwise the short info line
+  ("1-комн.кв. · 12/22 этаж") or a composed "rooms, area, floor" stands in.
+  Do not treat the title as a marketing name.
+- **`metro`** on a search row is the station Cian marks as the tile's own
+  (`isDefault`), not the shortest travel time — a 7-minute bus ride does not
+  outrank a 10-minute walk. The card returns every station in that order, with
+  `mode` `walk` or `transport`.
+- **`category`** tells the market: `newBuildingFlatSale` is a developer's
+  primary offer (`agent.user_type = developer`, `saleType fz214`), `flatSale`
+  is resale, `roomSale`, `houseSale`, `officeSale` and friends for the rest.
+- **Rent rows** add `price_period` (`monthly`), `lease_term` (`longTerm` /
+  `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only when the
+  owner publishes without an agent; None means Cian did not say.
+- **`created_at`** is Cian's local ISO time without a zone; `updated_at` on the
+  card is UTC. Do not compare them as if they were in one zone.
+- **`views`** on the card is parsed from Cian's own text
+  («12907 просмотров, 98 за сегодня»): the first number, total views.
+
+## What the source cannot do (and the connector does not pretend)
+
+- No agent/agency tool: `/agents/<id>/` renders profile facts only as page
+  text, with no structured state, so no tool reads it. The publisher's name,
+  type, id, offer count and account age ship inside the card's `agent` field.
+- No reviews — real estate has no per-offer review pool.
+- No geo-suggest: regions and metro are ids, not names (see above).
+- No phone numbers: the card knows how many phones the offer has, not their
+  values.
+
+## Gotchas
+- **403 inside the browser session** (`transport_down` with "WAF block") means
+  Cian challenged the scraping profile: open cian.ru in that Chrome, pass the
+  check if one is shown, retry. From a datacenter IP a cold session can start
+  blocked; a warmed-up session answered 8 requests in a row with no 429.
+- **Pace is deliberate**: 1.5 s between requests, one tab at a time. Do not
+  hammer pages 1–10 in a loop; ask for what is needed.
+- **`parser_drift`** means the envelope or `_cianConfig` shape changed — the
+  connector will not hand back a half-parsed card as if it were data. Run the
+  canary, then fix the parser.
+- **A removed offer** may render as "объявление не найдено" → `not_found`.
+- **Verification story:** a green selfcheck proves the transport answered and
+  the parser found ids, prices and addresses. It does not prove a particular
+  price is current — Cian's `price_history` on the card is the evidence to
+  quote when it matters.
+
+## DSH activation
+
+In DeepSeek Harness, the default profile exposes only `compare_prices` and
+`compare_sources` through the cheap compare mount. Per-marketplace tools and
+`marketplace_sources` require `RU_MARKETPLACE_MCP_FULL=1` and a profile restart;
+do not call them in the default mode. Cian is never part of the compare mount,
+so it is only reachable in the full profile.

--- a/dsh/skills/cian-connector/SKILL.md
+++ b/dsh/skills/cian-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cian-connector
-description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale or long-term rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
+description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale, long-term rent or daily rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "снять посуточно", "квартира на сутки", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
 ---
 
 # Cian Connector
@@ -12,8 +12,8 @@ HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен по�
 трафик» page, no captcha), so there is no anonymous tier.
 
 ## When to use
-- Find offers by filters: deal (sale / rent), property type, region, rooms,
-  price range, total area
+- Find offers by filters: deal (sale / long-term rent / daily rent), property
+  type, region, rooms, price range, total area
 - One offer's price, its price history, layout, building, address, metro,
   description and publisher
 - Real estate only. For goods use the marketplace connectors; for price
@@ -21,9 +21,10 @@ HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен по�
 
 ## Tools available
 - `cian_search(deal, offer_type="flat", region=None, rooms=None, price_min=None, price_max=None, area_min=None, area_max=None, page=1)`
-  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale` or
-  `rent` (long-term); `offer_type` is `flat`, `room`, `house` or `commercial`.
-  `price_rub` is None for an offer without a stated price — never 0.
+  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale`, `rent`
+  (long-term) or `daily` (посуточно); `offer_type` is `flat`, `room`, `house`
+  or `commercial`. `price_rub` is None for an offer without a stated price —
+  never 0, and `price_unit` says what it buys.
 - `cian_card(offer_id_or_url)` — one offer: price, `price_history`, rooms,
   areas, floor, building, address, `metro[]`, description, views, `agent`.
 
@@ -55,18 +56,41 @@ correct-looking prices. Default is `CIAN_REGION` (1, Moscow).
   планировка) and 9 (студия) — verified live, and easy to get backwards.
   Rooms (`offer_type="room"`) are searched as flats with Cian's room code 0 —
   the caller's `rooms` is ignored there.
-- **Rent is long-term** (`for_day: "!1"`); daily rent is not exposed.
-- **`price_min` / `price_max`** are rubles: total for sale, per month for rent.
+- **`price_min` / `price_max`** are rubles, in whatever unit the deal implies:
+  total for sale, per month for `rent`, **per night** for `daily`.
 - **`total_count`** is Cian's `aggregatedCount` — the de-duplicated figure the
   site shows, usually below the raw `offerCount`.
+
+## Long-term and daily are two markets, never one page
+
+`deal="rent"` and `deal="daily"` are separate on Cian and the connector keeps
+them separate (`for_day` `"!1"` vs `"1"`). Measured live in Moscow on
+2026-09-10: 25 411 long-term flats, 53 441 daily ones, and dropping the flag
+entirely returns a mixture, which is why the connector never does.
+
+- **A daily price is per night.** `price_unit` is `"day"`, and the category
+  comes back as `dailyFlatRent` / `dailyRoomRent` / `dailyHouseRent`. Cian
+  leaves `price_period` and `lease_term` null there, so `price_unit` is the
+  only honest signal — do not rank a 5 000 ₽ night against a 90 000 ₽ month.
+- **Daily covers flat, room and house only.** `offer_type="commercial"` with
+  `deal="daily"` is refused as a bad request: Cian accepts that query upstream
+  and answers zero, which would read as "nothing free today" rather than "this
+  market does not exist".
+- **For a stay of about a month**, both markets are worth a look: long-term
+  with `lease_term == "fewMonths"` (снять на несколько месяцев), and daily
+  where a monthly discount is usually negotiated in the description rather
+  than published as a field.
 
 ## What a row carries and how to read it
 
 Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
 
 - **Price** comes from `bargainTerms.priceRur`, then `bargainTerms.price`, then
-  `priceTotalRur`. A new-building card has only the latter two — the parser
-  reads all three, so a `null` price means Cian shows none, not a missed key.
+  `priceTotalRur`. A new-building card has only the latter two, and a daily
+  offer has no `priceRur` at all — the parser reads all three, so a `null`
+  price means Cian shows none, not a missed key.
+- **`price_unit`** is computed by the connector, not Cian: `total`, `month` or
+  `day`. Quote it whenever you show a price, and never average across units.
 - **`title` is Cian's own only on some offers**; otherwise the short info line
   ("1-комн.кв. · 12/22 этаж") or a composed "rooms, area, floor" stands in.
   Do not treat the title as a marketing name.
@@ -77,9 +101,9 @@ Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
 - **`category`** tells the market: `newBuildingFlatSale` is a developer's
   primary offer (`agent.user_type = developer`, `saleType fz214`), `flatSale`
   is resale, `roomSale`, `houseSale`, `officeSale` and friends for the rest.
-- **Rent rows** add `price_period` (`monthly`), `lease_term` (`longTerm` /
-  `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only when the
-  owner publishes without an agent; None means Cian did not say.
+- **Long-term rent rows** add `price_period` (`monthly`), `lease_term`
+  (`longTerm` / `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only
+  when the owner publishes without an agent; None means Cian did not say.
 - **`created_at`** is Cian's local ISO time without a zone; `updated_at` on the
   card is UTC. Do not compare them as if they were in one zone.
 - **`views`** on the card is parsed from Cian's own text

--- a/dsh/skills/marketplace/SKILL.md
+++ b/dsh/skills/marketplace/SKILL.md
@@ -7,17 +7,17 @@ description: Use this skill when the operator wants the full marketplace mount, 
 
 One server mounting every installed connector as a namespaced toolset:
 `wb_*`, `ozon_*`, `yandex_*`, `detmir_*`, `avito_*`, `taobao_*`, `megamarket_*`,
-`lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `mpstats_*` plus
+`lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `cian_*`, `mpstats_*` plus
 `compare_prices` / `compare_sources` and its own `marketplace_sources`. Tool
 names keep their prefixes, so habits and configs carry over — but the operator
-wires a single `marketplace` entry instead of thirteen. The server exposes 36
-tools: 35 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
+wires a single `marketplace` entry instead of fourteen. The server exposes 39
+tools: 38 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
 source: without `MPSTATS_MP_AUTH` its tools answer `auth_missing` while
 everything else is unaffected.
 
 ## When to use
 - "Where is X cheapest" — compare_prices fans out across all searchable sources
-- Client setup: one config entry, not twelve
+- Client setup: one config entry, not fourteen
 - Health overview: the CLI's `doctor` runs every selfcheck at once
 - A source came back empty and you can't tell installed-but-quiet from never-loaded
   → `marketplace_sources`

--- a/packages/cian-connector/pyproject.toml
+++ b/packages/cian-connector/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "cian-connector"
-version = "2.0.2"
+version = "2.1.0"
 description = "Cian MCP connector — real-estate search and offer cards via the site's own JSON API, fetched inside the operator's Chrome (CDP)"
 requires-python = ">=3.12"
 license = { text = "MIT" }
@@ -10,7 +10,7 @@ dependencies = [
     # unrelated project. Unpinned, a wheel installed straight from a GitHub
     # Release resolves to that stranger's package and the server dies on
     # import. A pin turns a silent wrong install into a loud resolve failure.
-    "mcp-core==2.0.2",
+    "mcp-core==2.1.0",
     "fastmcp>=3.4.6,<4",
     "pydantic>=2.6",
     "pydantic-settings>=2.2",

--- a/packages/cian-connector/pyproject.toml
+++ b/packages/cian-connector/pyproject.toml
@@ -1,0 +1,33 @@
+[project]
+name = "cian-connector"
+version = "2.0.2"
+description = "Cian MCP connector — real-estate search and offer cards via the site's own JSON API, fetched inside the operator's Chrome (CDP)"
+requires-python = ">=3.12"
+license = { text = "MIT" }
+authors = [{ name = "fosteev" }]
+dependencies = [
+    # Pinned, not floating: the name `mcp-core` on PyPI belongs to an
+    # unrelated project. Unpinned, a wheel installed straight from a GitHub
+    # Release resolves to that stranger's package and the server dies on
+    # import. A pin turns a silent wrong install into a loud resolve failure.
+    "mcp-core==2.0.2",
+    "fastmcp>=3.4.6,<4",
+    "pydantic>=2.6",
+    "pydantic-settings>=2.2",
+    # Every Cian read runs inside the operator's Chrome over CDP, and
+    # mcp_core.transport.chrome_cdp imports playwright at module load.
+    "playwright>=1.40",
+]
+
+[project.scripts]
+cian-mcp = "cian_connector.__main__:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/cian_connector"]
+
+[tool.uv.sources]
+mcp-core = { workspace = true }

--- a/packages/cian-connector/src/cian_connector/__init__.py
+++ b/packages/cian-connector/src/cian_connector/__init__.py
@@ -1,3 +1,3 @@
 """Cian (cian.ru) MCP connector — Russian real-estate listings."""
 
-__version__ = "2.0.2"
+__version__ = "2.1.0"

--- a/packages/cian-connector/src/cian_connector/__init__.py
+++ b/packages/cian-connector/src/cian_connector/__init__.py
@@ -1,0 +1,3 @@
+"""Cian (cian.ru) MCP connector — Russian real-estate listings."""
+
+__version__ = "2.0.2"

--- a/packages/cian-connector/src/cian_connector/__main__.py
+++ b/packages/cian-connector/src/cian_connector/__main__.py
@@ -1,0 +1,30 @@
+"""Entry point for the Cian MCP server.
+
+Exposed as the ``cian-mcp`` console script, so MCP client configs can spawn the
+server without knowing where the package lives on disk:
+
+    {"command": "uv", "args": ["run", "--directory", "/path/to/repo", "cian-mcp"]}
+
+stdio is the default transport because that is what MCP clients speak. Set
+``MCP_TRANSPORT=http`` (with optional ``MCP_HTTP_HOST``/``MCP_HTTP_PORT``/
+``MCP_HTTP_PATH``) to run it over HTTP — see docs/DEPLOYMENT.md. Transport
+selection lives in ``mcp_core.runtime`` and writes diagnostics to stderr;
+nothing here may write to stdout, which the JSON-RPC stream owns.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def main() -> int:
+    """Run the server on the transport selected by the environment (stdio default)."""
+    from mcp_core.runtime import run_server
+
+    from cian_connector.server import mcp
+
+    return run_server(mcp, server_name="cian")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/cian-connector/src/cian_connector/models_output.py
+++ b/packages/cian-connector/src/cian_connector/models_output.py
@@ -49,12 +49,23 @@ class CianSearchItemOut(BaseModel):
             "('цена не указана' / 'договорная') — never 0."
         ),
     )
+    price_unit: str | None = Field(
+        default=None,
+        description=(
+            "What price_rub buys: 'total' (a sale), 'month' (long-term rent) or 'day' (daily rent, a nightly "
+            "rate). Never compare prices across units — a 5 000 ₽ night is not cheaper than a 90 000 ₽ month."
+        ),
+    )
     price_period: str | None = Field(
-        default=None, description="Rent only: payment period the price refers to, usually 'monthly'."
+        default=None,
+        description="Long-term rent only: Cian's own payment period, usually 'monthly'. Null on daily offers.",
     )
     lease_term: str | None = Field(
         default=None,
-        description="Rent only: lease term type as Cian codes it ('longTerm', 'fewMonths'); None for sale.",
+        description=(
+            "Long-term rent only: lease term as Cian codes it — 'longTerm' (от года) or 'fewMonths' "
+            "(на несколько месяцев). Null for sale and for daily rent."
+        ),
     )
     deposit_rub: float | None = Field(default=None, description="Rent only: security deposit in rubles, if stated.")
     rooms: int | None = Field(default=None, description="Number of rooms; None for studios/free layouts and non-flats.")
@@ -130,10 +141,26 @@ class CianCardResponse(BaseModel):
     category: str | None = Field(default=None, description="Cian offer category (see cian_search).")
     price_rub: float | None = Field(
         default=None,
-        description="Price in rubles (total for sale, per period for rent). None when not stated — never 0.",
+        description=(
+            "Price in rubles: total for a sale, per month for long-term rent, per night for daily rent. "
+            "Read price_unit before comparing. None when not stated — never 0."
+        ),
     )
-    price_period: str | None = Field(default=None, description="Rent only: payment period, usually 'monthly'.")
-    lease_term: str | None = Field(default=None, description="Rent only: 'longTerm' or 'fewMonths'.")
+    price_unit: str | None = Field(
+        default=None,
+        description="What price_rub buys: 'total' (sale), 'month' (long-term rent) or 'day' (daily rent).",
+    )
+    price_period: str | None = Field(
+        default=None,
+        description="Long-term rent only: Cian's own payment period, usually 'monthly'. Null on daily offers.",
+    )
+    lease_term: str | None = Field(
+        default=None,
+        description=(
+            "Long-term rent only: 'longTerm' (от года) or 'fewMonths' (на несколько месяцев). "
+            "Null for sale and for daily rent."
+        ),
+    )
     deposit_rub: float | None = Field(default=None, description="Rent only: security deposit in rubles, if stated.")
     rooms: int | None = Field(default=None, description="Number of rooms; None for studios and non-flats.")
     flat_type: str | None = Field(default=None, description="Cian flat type: 'rooms', 'studio' or 'openPlan'.")

--- a/packages/cian-connector/src/cian_connector/models_output.py
+++ b/packages/cian-connector/src/cian_connector/models_output.py
@@ -1,0 +1,184 @@
+"""Typed responses for the Cian connector.
+
+Field descriptions are written for a reader who cannot see Cian's API: they say
+what a value means and when it is absent, because that is what an agent uses to
+decide whether the tool answers the question. Prices are rubles and ``None``
+when Cian shows no price — never 0 (see ``mcp_core.resilience.coerce_price``).
+"""
+
+from __future__ import annotations
+
+from mcp_core.models import MetaOutBase, SelfCheckEntryBase, SelfCheckResponseBase
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MetaOut(MetaOutBase):
+    """Validation metadata attached to every response."""
+
+
+class CianMetroOut(BaseModel):
+    name: str | None = Field(default=None, description="Metro station name.")
+    minutes: int | None = Field(default=None, description="Travel time to the station in minutes, as Cian reports it.")
+    mode: str | None = Field(
+        default=None,
+        description="How the travel time is measured: 'walk' (on foot) or 'transport' (by public transport / car).",
+    )
+
+
+class CianSearchItemOut(BaseModel):
+    offer_id: int | None = Field(default=None, description="Cian offer id (the digits in the offer URL).")
+    title: str | None = Field(
+        default=None,
+        description=(
+            "Offer headline. Cian sets it only on some offers; otherwise the connector composes one from "
+            "rooms, area and floor, e.g. '1-комн. квартира, 38.1 м², 12/22 эт.'."
+        ),
+    )
+    deal_type: str | None = Field(default=None, description="'sale' or 'rent'.")
+    category: str | None = Field(
+        default=None,
+        description=(
+            "Cian offer category, e.g. flatSale, newBuildingFlatSale, flatRent, roomSale, houseSale, "
+            "officeSale. newBuilding* means a developer's primary-market offer."
+        ),
+    )
+    price_rub: float | None = Field(
+        default=None,
+        description=(
+            "Price in rubles: total for sale, per payment period for rent. None when Cian shows no price "
+            "('цена не указана' / 'договорная') — never 0."
+        ),
+    )
+    price_period: str | None = Field(
+        default=None, description="Rent only: payment period the price refers to, usually 'monthly'."
+    )
+    lease_term: str | None = Field(
+        default=None,
+        description="Rent only: lease term type as Cian codes it ('longTerm', 'fewMonths'); None for sale.",
+    )
+    deposit_rub: float | None = Field(default=None, description="Rent only: security deposit in rubles, if stated.")
+    rooms: int | None = Field(default=None, description="Number of rooms; None for studios/free layouts and non-flats.")
+    flat_type: str | None = Field(default=None, description="Cian flat type: 'rooms', 'studio' or 'openPlan'.")
+    is_apartments: bool | None = Field(
+        default=None, description="True when the unit is legally 'апартаменты', not a flat."
+    )
+    total_area_m2: float | None = Field(default=None, description="Total area in square metres.")
+    living_area_m2: float | None = Field(default=None, description="Living area in square metres, if stated.")
+    kitchen_area_m2: float | None = Field(default=None, description="Kitchen area in square metres, if stated.")
+    floor: int | None = Field(default=None, description="Floor the unit is on.")
+    floors_total: int | None = Field(default=None, description="Number of floors in the building.")
+    build_year: int | None = Field(default=None, description="Year the building was built, if Cian states it.")
+    address: str | None = Field(default=None, description="Address as Cian displays it (region, city, street, house).")
+    metro: CianMetroOut | None = Field(default=None, description="Nearest metro station by travel time, if any.")
+    newbuilding_name: str | None = Field(default=None, description="Residential complex (ЖК) name for new buildings.")
+    url: str | None = Field(default=None, description="Canonical cian.ru offer URL (tracking parameters stripped).")
+    agency_name: str | None = Field(default=None, description="Agency or developer name that published the offer.")
+    seller_type: str | None = Field(
+        default=None,
+        description="Publisher type as Cian codes it: 'developer', 'realtor_based', 'agency', 'homeowner' etc.",
+    )
+    is_by_homeowner: bool | None = Field(default=None, description="True when the owner publishes without an agent.")
+    created_at: str | None = Field(
+        default=None, description="Offer creation time as reported by Cian (local ISO-8601)."
+    )
+    photos: int = Field(default=0, description="Number of photos attached to the offer.")
+
+
+class CianSearchResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: str = Field(default="success", description="Response status: success or error.")
+    deal: str = Field(default="", description="Deal type the search ran with: sale or rent.")
+    offer_type: str = Field(
+        default="", description="Property type the search ran with: flat, room, house or commercial."
+    )
+    region: str = Field(default="", description="Cian region id the search ran against.")
+    page: int = Field(default=1, description="Result page number (1-based).")
+    tier_used: str | None = Field(default=None, description="Fetch tier used: cdp or cache.")
+    count: int = Field(default=0, description="Number of offers returned on this page.")
+    total_count: int | None = Field(
+        default=None, description="Total matching offers Cian reports for the query (after de-duplication)."
+    )
+    items: list[CianSearchItemOut] = Field(default_factory=list, description="Search result offers.")
+    meta: MetaOut = Field(default_factory=MetaOut, alias="_meta", description="Validation metadata.")
+
+
+class CianAgentOut(BaseModel):
+    name: str | None = Field(default=None, description="Agent, agency or developer display name.")
+    agent_id: int | None = Field(default=None, description="Cian user id of the publisher.")
+    account_type: str | None = Field(default=None, description="Cian account type, e.g. 'agency', 'specialist'.")
+    user_type: str | None = Field(
+        default=None, description="Publisher type as Cian codes it: 'developer', 'realtor_based', 'homeowner' etc."
+    )
+    is_developer: bool | None = Field(default=None, description="True when the publisher is a developer (застройщик).")
+    offers_count: int | None = Field(default=None, description="Number of active offers this publisher has on Cian.")
+    on_cian_since: str | None = Field(default=None, description="When the publisher account was created (ISO-8601).")
+
+
+class CianPriceChangeOut(BaseModel):
+    changed_at: str | None = Field(default=None, description="When the price was set (ISO-8601 UTC).")
+    price_rub: float | None = Field(default=None, description="Price in rubles after that change.")
+
+
+class CianCardResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    status: str = Field(default="success", description="Response status: success or error.")
+    offer_id: int | None = Field(default=None, description="Cian offer id.")
+    title: str | None = Field(default=None, description="Offer headline (Cian's own, or composed — see cian_search).")
+    deal_type: str | None = Field(default=None, description="'sale' or 'rent'.")
+    category: str | None = Field(default=None, description="Cian offer category (see cian_search).")
+    price_rub: float | None = Field(
+        default=None,
+        description="Price in rubles (total for sale, per period for rent). None when not stated — never 0.",
+    )
+    price_period: str | None = Field(default=None, description="Rent only: payment period, usually 'monthly'.")
+    lease_term: str | None = Field(default=None, description="Rent only: 'longTerm' or 'fewMonths'.")
+    deposit_rub: float | None = Field(default=None, description="Rent only: security deposit in rubles, if stated.")
+    rooms: int | None = Field(default=None, description="Number of rooms; None for studios and non-flats.")
+    flat_type: str | None = Field(default=None, description="Cian flat type: 'rooms', 'studio' or 'openPlan'.")
+    is_apartments: bool | None = Field(default=None, description="True when the unit is 'апартаменты'.")
+    total_area_m2: float | None = Field(default=None, description="Total area in square metres.")
+    living_area_m2: float | None = Field(default=None, description="Living area in square metres, if stated.")
+    kitchen_area_m2: float | None = Field(default=None, description="Kitchen area in square metres, if stated.")
+    floor: int | None = Field(default=None, description="Floor the unit is on.")
+    floors_total: int | None = Field(default=None, description="Floors in the building.")
+    build_year: int | None = Field(default=None, description="Construction year, if stated.")
+    building_material: str | None = Field(
+        default=None, description="Building material as Cian codes it (monolith, panel, brick…)."
+    )
+    ceiling_height_m: float | None = Field(default=None, description="Ceiling height in metres, if stated.")
+    address: str | None = Field(default=None, description="Address as Cian displays it.")
+    metro: list[CianMetroOut] = Field(default_factory=list, description="Nearby metro stations with travel time.")
+    newbuilding_name: str | None = Field(default=None, description="Residential complex (ЖК) name, if any.")
+    description: str | None = Field(default=None, description="Full offer description text.")
+    agency_name: str | None = Field(default=None, description="Agency or developer name that published the offer.")
+    seller_type: str | None = Field(
+        default=None,
+        description="Publisher type as Cian codes it: 'developer', 'realtor_based', 'agency', 'homeowner' etc.",
+    )
+    is_by_homeowner: bool | None = Field(default=None, description="True when the owner publishes without an agent.")
+    photos: int = Field(default=0, description="Number of photos attached.")
+    created_at: str | None = Field(default=None, description="Offer creation time (local ISO-8601).")
+    updated_at: str | None = Field(default=None, description="Last edit time (ISO-8601 UTC).")
+    views: int | None = Field(default=None, description="Total views Cian reports for the offer.")
+    price_history: list[CianPriceChangeOut] = Field(
+        default_factory=list, description="Price changes, newest first, as Cian records them."
+    )
+    agent: CianAgentOut | None = Field(default=None, description="Publisher: agent, agency or developer.")
+    url: str = Field(default="", description="Canonical cian.ru offer URL.")
+    tier_used: str = Field(default="", description="Fetch tier used: cdp or cache.")
+    meta: MetaOut = Field(default_factory=MetaOut, alias="_meta", description="Validation metadata.")
+
+
+class CianSelfcheckCheckOut(SelfCheckEntryBase):
+    """Cian sub-check entry: adds the baseline-comparison fields."""
+
+    ok: bool | None = Field(default=None, description="Boolean health summary if applicable.")
+    baseline: str = Field(default="", description="Baseline identifier used for comparison.")
+    reason: str | None = Field(default=None, description="Reason code for non-healthy verdicts.")
+
+
+class CianSelfcheckResponse(SelfCheckResponseBase):
+    healthy: bool | None = Field(default=None, description="Whether all checks are healthy.")
+    checks: dict[str, CianSelfcheckCheckOut] = Field(default_factory=dict, description="Per-subcheck results.")

--- a/packages/cian-connector/src/cian_connector/server.py
+++ b/packages/cian-connector/src/cian_connector/server.py
@@ -18,6 +18,12 @@ and every field decision happens in Python where a fixture can test it.
 Search is by filters (deal, property type, region, rooms, price, area), not by
 text — Cian has no free-text search worth exposing. Region ids are Cian's own;
 the four the connector knows are in ``KNOWN_REGIONS``.
+
+Rent comes in two markets that Cian keeps apart and that must not be averaged
+together: long-term (``for_day: "!1"``, priced per month) and daily
+(``for_day: "1"``, priced per night, its own dailyFlatRent categories). The
+``deal`` argument selects one; ``price_unit`` on every row says which reading a
+price carries, because Cian leaves ``paymentPeriod`` null on daily offers.
 """
 
 from __future__ import annotations
@@ -62,7 +68,7 @@ from cian_connector.settings import get_settings
 
 _settings = get_settings()
 
-SERVER_VERSION = "2.0.2"
+SERVER_VERSION = "2.1.0"
 SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
 
 SITE_BASE = "https://www.cian.ru"
@@ -80,19 +86,28 @@ KNOWN_REGIONS: dict[str, str] = {
     "4588": "Ленинградская область",
 }
 
-DealType = Literal["sale", "rent"]
+DealType = Literal["sale", "rent", "daily"]
 OfferType = Literal["flat", "room", "house", "commercial"]
 
 # jsonQuery._type per (deal, property type). Rooms are flats with room=[0]
 # (verified: that query returns category roomSale). Houses and commercial
 # property have their own families (houseSale, officeSale … verified).
+#
+# Daily rent is the same ``*rent`` family with ``for_day: "1"`` instead of
+# "!1" — Cian answers with its own dailyFlatRent / dailyRoomRent /
+# dailyHouseRent categories. Commercial has no daily market at all (the query
+# is accepted and returns zero), so the pair is absent and rejected by name
+# rather than shipped as a tool call that always finds nothing.
 _QUERY_TYPE: dict[tuple[str, str], str] = {
     ("sale", "flat"): "flatsale",
     ("rent", "flat"): "flatrent",
+    ("daily", "flat"): "flatrent",
     ("sale", "room"): "flatsale",
     ("rent", "room"): "flatrent",
+    ("daily", "room"): "flatrent",
     ("sale", "house"): "suburbansale",
     ("rent", "house"): "suburbanrent",
+    ("daily", "house"): "suburbanrent",
     ("sale", "commercial"): "commercialsale",
     ("rent", "commercial"): "commercialrent",
 }
@@ -113,12 +128,13 @@ mcp = FastMCP(
     version=SERVER_VERSION,
     instructions=(
         "Cian real-estate listings (Russia): search flats, rooms, houses and "
-        "commercial property for sale or rent, and read one offer's card. "
-        "Read-only, no credentials; every read runs inside the operator's Chrome "
-        "over CDP because Cian's WAF blocks plain HTTP. Start with cian_search "
-        "(filters, not free text — region ids: 1 Москва, 2 Санкт-Петербург, "
-        "4593 Московская область, 4588 Ленинградская область); cian_card takes an "
-        "offer id or URL. Prices are rubles; a missing price is None, never 0."
+        "commercial property for sale, long-term rent or daily rent, and read "
+        "one offer's card. Read-only, no credentials; every read runs inside the "
+        "operator's Chrome over CDP because Cian's WAF blocks plain HTTP. Start "
+        "with cian_search (filters, not free text — region ids: 1 Москва, "
+        "2 Санкт-Петербург, 4593 Московская область, 4588 Ленинградская область); "
+        "cian_card takes an offer id or URL. Prices are rubles and price_unit "
+        "says what one buys (total / month / day); a missing price is None, never 0."
     ),
 )
 mcp.add_middleware(RetryMiddleware())
@@ -441,6 +457,25 @@ def _compose_title(
     return ", ".join(bits) or None
 
 
+def _price_unit(category: str | None, deal_type: str | None, period: str | None) -> str | None:
+    """What one ``price_rub`` actually buys: the whole property, a month, a night.
+
+    Cian encodes this only in the category (``dailyFlatRent`` and friends) and
+    leaves ``paymentPeriod`` null on daily offers, so a caller comparing a
+    nightly 5 000 ₽ against a monthly 90 000 ₽ has nothing to go on unless the
+    connector says it outright.
+    """
+    if category and "daily" in category.lower():
+        return "day"
+    if deal_type == "sale":
+        return "total"
+    if deal_type == "rent":
+        # Long-term rent is quoted monthly; anything else Cian names, we pass
+        # through rather than flatten to a month we did not verify.
+        return "month" if period in (None, "monthly") else period
+    return None
+
+
 def _offer_row(offer: dict[str, Any]) -> dict[str, Any]:
     """The fields shared by a search hit and a card, read from one offer object."""
     terms = _d(offer.get("bargainTerms"))
@@ -461,6 +496,7 @@ def _offer_row(offer: dict[str, Any]) -> dict[str, Any]:
         "deal_type": _s(offer.get("dealType")),
         "category": _s(offer.get("category")),
         "price_rub": _price_of(offer),
+        "price_unit": _price_unit(_s(offer.get("category")), _s(offer.get("dealType")), _s(terms.get("paymentPeriod"))),
         "price_period": _s(terms.get("paymentPeriod")),
         "lease_term": _s(terms.get("leaseTermType")),
         "deposit_rub": R.coerce_price(terms.get("deposit")),
@@ -625,9 +661,11 @@ def _build_json_query(
         query["room"] = {"type": "terms", "value": [0]}
     elif offer_type == "flat" and rooms:
         query["room"] = {"type": "terms", "value": sorted(set(rooms))}
-    if deal == "rent":
-        # "!1" = not daily: long-term rent, the site's default for "Снять".
-        query["for_day"] = {"type": "term", "value": "!1"}
+    if deal in ("rent", "daily"):
+        # "!1" = not daily (the site's default for "Снять"); "1" = daily only.
+        # Omitting the key mixes both markets in one page, which is never what
+        # a caller means.
+        query["for_day"] = {"type": "term", "value": "1" if deal == "daily" else "!1"}
     if price_min is not None or price_max is not None:
         query["price"] = {"type": "range", "value": _range(price_min, price_max)}
     if area_min is not None or area_max is not None:
@@ -659,10 +697,24 @@ def _validate_region(region: str | None) -> str:
     ),
 )
 async def cian_search(
-    deal: Annotated[DealType, Field(description="'sale' (купить) or 'rent' (снять, long-term).")],
+    deal: Annotated[
+        DealType,
+        Field(
+            description=(
+                "'sale' (купить), 'rent' (снять на длительный срок) or 'daily' (снять посуточно). "
+                "'rent' and 'daily' are separate markets on Cian and never mix in one result page; "
+                "a 'daily' price is per night, a 'rent' price per month — read price_unit on each item."
+            )
+        ),
+    ],
     offer_type: Annotated[
         OfferType,
-        Field(description="Property type: 'flat' (квартира), 'room' (комната), 'house' (дом/участок), 'commercial'."),
+        Field(
+            description=(
+                "Property type: 'flat' (квартира), 'room' (комната), 'house' (дом/участок), 'commercial'. "
+                "'commercial' has no daily market on Cian and is rejected with deal='daily'."
+            )
+        ),
     ] = "flat",
     region: Annotated[
         str | None,
@@ -682,8 +734,14 @@ async def cian_search(
             )
         ),
     ] = None,
-    price_min: Annotated[int | None, Field(ge=1, description="Minimum price in rubles (per month for rent).")] = None,
-    price_max: Annotated[int | None, Field(ge=1, description="Maximum price in rubles (per month for rent).")] = None,
+    price_min: Annotated[
+        int | None,
+        Field(ge=1, description="Minimum price in rubles: total for sale, per month for rent, per night for daily."),
+    ] = None,
+    price_max: Annotated[
+        int | None,
+        Field(ge=1, description="Maximum price in rubles: total for sale, per month for rent, per night for daily."),
+    ] = None,
     area_min: Annotated[float | None, Field(gt=0, description="Minimum total area in m².")] = None,
     area_max: Annotated[float | None, Field(gt=0, description="Maximum total area in m².")] = None,
     page: Annotated[int, Field(ge=1, le=100, description="Result page (1-based), 28 offers per page.")] = 1,
@@ -691,22 +749,36 @@ async def cian_search(
 ) -> CianSearchResponse:
     """Search Cian offers by filters (there is no free-text search).
 
+    Long-term rent (``deal='rent'``) and daily rent (``deal='daily'``) are two
+    separate markets: one page never mixes them, and their prices are not
+    comparable — a daily offer is priced per night. ``price_unit`` on every
+    item says which it is.
+
     ## Return Format
 
     CianSearchResponse: {status, deal, offer_type, region, page, tier_used,
     count, total_count, items[], _meta}. Each item carries offer_id, title,
-    price_rub (None when Cian shows no price — never 0), rooms, areas, floor,
-    address, nearest metro, url, agency and publication data.
+    price_rub (None when Cian shows no price — never 0), price_unit
+    ('total' / 'month' / 'day'), rooms, areas, floor, address, nearest metro,
+    url, agency and publication data.
 
     ## Error Format
 
     ToolError: BadRequestError on malformed arguments (region not digits, room
-    code outside 1-6/7/9, min above max); TransportDownError when Cian's WAF
-    blocks the browser session or CDP is down (with the fix inline);
-    ParserDriftError when a 200 body is not the expected envelope.
+    code outside 1-6/7/9, min above max, deal='daily' with
+    offer_type='commercial'); TransportDownError when Cian's WAF blocks the
+    browser session or CDP is down (with the fix inline); ParserDriftError when
+    a 200 body is not the expected envelope.
     """
     log_event("cian_search.start", deal=deal, offer_type=offer_type, page=page)
     try:
+        if (deal, offer_type) not in _QUERY_TYPE:
+            raise_tool_error(
+                BadRequestError(
+                    f"Cian has no {deal} market for {offer_type}: the query is accepted upstream and returns "
+                    "nothing. Daily rent covers flat, room and house only."
+                )
+            )
         region_id = _validate_region(region)
         if rooms is not None:
             bad = sorted({r for r in rooms if r not in _ROOM_CHOICES})
@@ -793,7 +865,7 @@ async def cian_card(
     ## Return Format
 
     CianCardResponse: {status, offer_id, title, deal_type, category, price_rub,
-    price_period, lease_term, deposit_rub, rooms, areas, floor, floors_total,
+    price_unit, price_period, lease_term, deposit_rub, rooms, areas, floor, floors_total,
     build_year, building_material, ceiling_height_m, address, metro[],
     description, photos, created_at, updated_at, views, price_history[], agent,
     url, tier_used, _meta}. price_rub is None when not stated — never 0.

--- a/packages/cian-connector/src/cian_connector/server.py
+++ b/packages/cian-connector/src/cian_connector/server.py
@@ -1,0 +1,1020 @@
+"""Cian MCP connector: real-estate search and offer cards.
+
+Cian (cian.ru) is a classifieds site for flats, houses and commercial property,
+not a marketplace — but the same doctrine applies (docs/ADDING_A_SOURCE.md,
+docs/ANTI_BOT.md § Cian). Probed 2026-09-09:
+
+* Plain HTTP is a dead end: Cian's WAF answers every path, the JSON API
+  included, with a 403 ``cian_waf_block`` page keyed on IP reputation. There is
+  no captcha to solve and no fingerprint to clear.
+* Inside the operator's Chrome (tier 2) the site's own JSON API answers an
+  in-page ``fetch`` POST: structured offers, no HTML parsing. The offer card
+  embeds the whole offer in ``window._cianConfig['frontend-offer-card']``.
+
+So this connector is tier 2 only, and the in-page JavaScript is transport, not
+parsing: it POSTs a ``jsonQuery`` or serialises a subtree of ``_cianConfig``,
+and every field decision happens in Python where a fixture can test it.
+
+Search is by filters (deal, property type, region, rooms, price, area), not by
+text — Cian has no free-text search worth exposing. Region ids are Cian's own;
+the four the connector knows are in ``KNOWN_REGIONS``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime
+import json
+import re
+from typing import Annotated, Any, Literal
+
+from fastmcp import Context, FastMCP
+from fastmcp.exceptions import ToolError
+from fastmcp.server.middleware.error_handling import RetryMiddleware
+from mcp.types import ToolAnnotations
+from mcp_core import resilience as R
+from mcp_core.cache import TTLCache
+from mcp_core.errors import (
+    BadRequestError,
+    NotFoundError,
+    ParserDriftError,
+    TransportDownError,
+    raise_tool_error,
+)
+from mcp_core.logging import log_event
+from mcp_core.output_schema import apply_compact_output_schemas
+from mcp_core.pacing import Pacer
+from mcp_core.redact import redact_error_text as _redact
+from mcp_core.transport.chrome_cdp import NavBlocked, open_page
+from pydantic import Field
+
+from cian_connector.models_output import (
+    CianAgentOut,
+    CianCardResponse,
+    CianMetroOut,
+    CianPriceChangeOut,
+    CianSearchItemOut,
+    CianSearchResponse,
+    CianSelfcheckResponse,
+    MetaOut,
+)
+from cian_connector.settings import get_settings
+
+_settings = get_settings()
+
+SERVER_VERSION = "2.0.2"
+SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00:00", "Z")
+
+SITE_BASE = "https://www.cian.ru"
+SEARCH_API = "https://api.cian.ru/search-offers/v2/search-offers-desktop/"
+CARD_CONFIG_KEY = "frontend-offer-card"
+TIMEOUT = _settings.timeout
+MAX_BODY_BYTES = _settings.max_body_bytes
+_min_gap = _settings.min_gap
+
+# Region ids verified live on 2026-09-09 by the addresses that came back.
+KNOWN_REGIONS: dict[str, str] = {
+    "1": "Москва",
+    "2": "Санкт-Петербург",
+    "4593": "Московская область",
+    "4588": "Ленинградская область",
+}
+
+DealType = Literal["sale", "rent"]
+OfferType = Literal["flat", "room", "house", "commercial"]
+
+# jsonQuery._type per (deal, property type). Rooms are flats with room=[0]
+# (verified: that query returns category roomSale). Houses and commercial
+# property have their own families (houseSale, officeSale … verified).
+_QUERY_TYPE: dict[tuple[str, str], str] = {
+    ("sale", "flat"): "flatsale",
+    ("rent", "flat"): "flatrent",
+    ("sale", "room"): "flatsale",
+    ("rent", "room"): "flatrent",
+    ("sale", "house"): "suburbansale",
+    ("rent", "house"): "suburbanrent",
+    ("sale", "commercial"): "commercialsale",
+    ("rent", "commercial"): "commercialrent",
+}
+# 1..6 rooms; Cian's own codes for a free layout (7) and a studio (9) —
+# verified live 2026-09-09: room=[9] returns flatType studio, room=[7] openPlan.
+_ROOM_CHOICES = frozenset({1, 2, 3, 4, 5, 6, 7, 9})
+_REGION_RE = re.compile(r"^\d{1,7}$")
+_OFFER_ID_RE = re.compile(r"cian\.ru/(?:sale|rent)/[a-z-]+/(\d{6,})(?:[/?#]|$)")
+_WAF_MARKER = "cian_waf_block"
+# The card transport's own envelope: only a state that actually carried the
+# offer is worth caching.
+_CARD_OK_RE = re.compile(r'"kind":\s*"ok"')
+_FIRST_NUMBER_RE = re.compile(r"\d[\d\s  ]*")
+_FLAT_TYPE_RU = {"studio": "студия", "openPlan": "свободная планировка"}
+
+mcp = FastMCP(
+    name="cian-connector",
+    version=SERVER_VERSION,
+    instructions=(
+        "Cian real-estate listings (Russia): search flats, rooms, houses and "
+        "commercial property for sale or rent, and read one offer's card. "
+        "Read-only, no credentials; every read runs inside the operator's Chrome "
+        "over CDP because Cian's WAF blocks plain HTTP. Start with cian_search "
+        "(filters, not free text — region ids: 1 Москва, 2 Санкт-Петербург, "
+        "4593 Московская область, 4588 Ленинградская область); cian_card takes an "
+        "offer id or URL. Prices are rubles; a missing price is None, never 0."
+    ),
+)
+mcp.add_middleware(RetryMiddleware())
+
+_cache: TTLCache[tuple[int, str]] = TTLCache(ttl_s=_settings.cache_ttl, max_entries=256)
+_pacer = Pacer(_min_gap)
+_cdp_lock = asyncio.Lock()
+
+
+async def _polite_wait() -> None:
+    """Space this source's requests out, and back off if it refused us."""
+    await _pacer.wait(min_gap=_min_gap)
+
+
+# ------------------------------------------------------------ transport ----
+
+# Transport only: POST the query the way the site itself does and hand the
+# body back. The body cap mirrors the other CDP connectors — an inflated body
+# would otherwise OOM the connector through the CDP serialisation pipeline.
+_JS_POST = """async (args) => {
+    const res = await fetch(args.url, {
+        method: 'POST',
+        credentials: 'include',
+        headers: {'Content-Type': 'application/json', 'Accept': 'application/json, text/plain, */*'},
+        body: JSON.stringify(args.body)
+    });
+    const reader = res.body.getReader();
+    let total = 0;
+    const chunks = [];
+    while (true) {
+        const {done, value} = await reader.read();
+        if (done) break;
+        total += value.length;
+        if (total > args.cap) {
+            return JSON.stringify({status: 0, text: 'BODY_CAP_EXCEEDED'});
+        }
+        chunks.push(value);
+    }
+    const buf = new Uint8Array(total);
+    let off = 0;
+    for (const c of chunks) { buf.set(c, off); off += c.length; }
+    return JSON.stringify({status: res.status, text: new TextDecoder().decode(buf)});
+}"""
+
+# Transport only: serialise the offer subtree of the card micro-frontend's
+# state. Which keys mean what is decided in Python (_parse_card).
+_JS_CARD_CONFIG = """(args) => {
+    const title = document.title || '';
+    const url = location.href;
+    if (/не найден|удален|удалён|снят/i.test(title)) {
+        return JSON.stringify({kind: 'not_found', title, url});
+    }
+    const cfg = window._cianConfig;
+    if (!cfg) return JSON.stringify({kind: 'no_config', title, url});
+    const entry = cfg[args.key];
+    let state = null;
+    if (Array.isArray(entry)) {
+        const hit = entry.find((x) => x && x.key === 'defaultState');
+        state = hit ? hit.value : null;
+    }
+    const od = state && state.offerData ? state.offerData : null;
+    if (!od || !od.offer) {
+        return JSON.stringify({kind: 'no_offer', title, url, keys: Object.keys(cfg)});
+    }
+    const keep = {};
+    for (const k of ['offer', 'agent', 'company', 'priceChanges', 'stats']) {
+        if (k in od) keep[k] = od[k];
+    }
+    const text = JSON.stringify({kind: 'ok', title, url, offerData: keep});
+    if (text.length > args.cap) return JSON.stringify({kind: 'too_big', title, url});
+    return text;
+}"""
+
+
+async def _cdp_post_json(json_query: dict[str, Any], ctx: Context | None) -> tuple[int, str]:
+    """POST ``jsonQuery`` to the search API from inside a cian.ru tab.
+
+    Serialised via _cdp_lock so a burst of tool calls cannot spray tabs. The
+    tab lands on the site root so the request carries the session's cookies
+    and origin, exactly like the site's own search.
+    """
+
+    async def _attempt() -> tuple[int, str]:
+        async with _cdp_lock, open_page(f"{SITE_BASE}/", wait_ms=2500) as page:
+            raw = await asyncio.wait_for(
+                page.evaluate(
+                    _JS_POST,
+                    {"url": SEARCH_API, "body": {"jsonQuery": json_query}, "cap": MAX_BODY_BYTES},
+                ),
+                timeout=30.0,
+            )
+        result = json.loads(raw) if isinstance(raw, str) else raw
+        return int(result["status"]), str(result["text"])
+
+    try:
+        return await asyncio.wait_for(_attempt(), timeout=max(0.01, float(TIMEOUT)))
+    except TimeoutError:
+        return 0, f"CDP timeout after {TIMEOUT}s"
+
+
+async def _cdp_page_config(url: str, ctx: Context | None) -> tuple[int, str]:
+    """Open an offer page and serialise its ``_cianConfig`` card state."""
+
+    async def _attempt() -> tuple[int, str]:
+        async with _cdp_lock, open_page(url, wait_ms=2500) as page:
+            raw = await asyncio.wait_for(
+                page.evaluate(_JS_CARD_CONFIG, {"key": CARD_CONFIG_KEY, "cap": MAX_BODY_BYTES}),
+                timeout=30.0,
+            )
+        return 200, raw if isinstance(raw, str) else json.dumps(raw)
+
+    try:
+        return await asyncio.wait_for(_attempt(), timeout=max(0.01, float(TIMEOUT)))
+    except TimeoutError:
+        return 0, f"CDP timeout after {TIMEOUT}s"
+
+
+def _looks_like_json(body: str) -> bool:
+    head = body.lstrip()[:1]
+    return head in ("{", "[")
+
+
+async def _fetch_search(json_query: dict[str, Any], ctx: Context | None) -> tuple[int, str, str]:
+    """Run one search query over CDP. Returns (status, body, tier).
+
+    Only JSON-shaped 200s are cached — a cached block page would keep
+    reporting a block after the operator passed the check in the browser.
+    """
+    key = "search:" + json.dumps(json_query, sort_keys=True, ensure_ascii=False)
+    cached = _cache.get(key)
+    if cached is not None:
+        status, body = cached
+        return status, body, "cache"
+
+    await _polite_wait()
+    try:
+        status, body = await _cdp_post_json(json_query, ctx)
+    except NavBlocked as exc:
+        _pacer.record_refusal()
+        return exc.status or 0, str(exc), "cdp_blocked"
+    except Exception as exc:
+        return 0, _redact(str(exc)), "cdp_failed"
+    if status == 200 and _looks_like_json(body):
+        _pacer.record_success()
+        _cache.set(key, (status, body))
+    return status, body, "cdp"
+
+
+async def _fetch_card(offer_id: int, ctx: Context | None) -> tuple[int, str, str]:
+    """Read one offer's card state over CDP. Returns (status, body, tier).
+
+    The page is requested under ``/sale/flat/``: Cian redirects a rent or
+    non-flat id to its real deal/type URL (verified live), so one URL shape
+    serves every category and the connector never has to guess the type.
+    """
+    key = f"card:{offer_id}"
+    cached = _cache.get(key)
+    if cached is not None:
+        status, body = cached
+        return status, body, "cache"
+
+    await _polite_wait()
+    try:
+        status, body = await _cdp_page_config(f"{SITE_BASE}/sale/flat/{offer_id}/", ctx)
+    except NavBlocked as exc:
+        _pacer.record_refusal()
+        return exc.status or 0, str(exc), "cdp_blocked"
+    except Exception as exc:
+        return 0, _redact(str(exc)), "cdp_failed"
+    if status == 200 and _looks_like_json(body) and _CARD_OK_RE.search(body[:80]):
+        _pacer.record_success()
+        _cache.set(key, (status, body))
+    return status, body, "cdp"
+
+
+def _blocked_error(tier: str, detail: str = "") -> TransportDownError:
+    message = (
+        f"Cian answered with its WAF block page via {tier}. "
+        "Open cian.ru in the Chrome CDP profile, pass the check if one is shown, then retry; "
+        "from a datacenter IP the block is expected until the browser session is warmed up."
+    )
+    hint = _pacer.rotation_hint()
+    if hint:
+        message += f" {hint}"
+    if detail:
+        message += f" Detail: {detail[:160]}"
+    return TransportDownError(message, status_code=403)
+
+
+def _raise_for_fetch_failure(status: int, body: str, tier: str, what: str) -> None:
+    """Map a failed fetch to the shared error taxonomy."""
+    if status in (401, 403, 429) or _WAF_MARKER in body[:2000]:
+        _pacer.record_refusal()
+        raise_tool_error(_blocked_error(tier, body))
+    if status == 404:
+        raise_tool_error(NotFoundError(f"Cian {what} not found (404)."))
+    raise_tool_error(TransportDownError(f"Cian {what} fetch failed: HTTP {status} via {tier}. {body[:120]}"))
+
+
+# -------------------------------------------------------------- parsing ----
+
+
+def _s(value: Any) -> str | None:
+    """A non-empty string, else None — never a stringified None or number."""
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return None
+
+
+def _b(value: Any) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _d(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_float(value: Any) -> float | None:
+    """Areas and heights come as strings ('38.1'); a non-positive value is None."""
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value) if value > 0 else None
+    if isinstance(value, str):
+        try:
+            number = float(value.replace(",", ".").replace(" ", "").replace(" ", ""))
+        except ValueError:
+            return None
+        return number if number > 0 else None
+    return None
+
+
+def _price_of(offer: dict[str, Any]) -> float | None:
+    """The price is ``bargainTerms.priceRur``; a new-building card carries only
+    ``bargainTerms.price`` and ``priceTotalRur`` (verified 2026-09-09), so all
+    three are read, in that order. None when none of them holds a real price."""
+    terms = _d(offer.get("bargainTerms"))
+    price = R.coerce_price(R.first_present(terms, "priceRur", "price"))
+    if price is None:
+        price = R.coerce_price(R.first_present(offer, "priceTotalRur", "priceTotal"))
+    return price
+
+
+def _clean_url(value: Any) -> str | None:
+    url = _s(value)
+    if url is None:
+        return None
+    return url.split("?", 1)[0].split("#", 1)[0]
+
+
+def _address(geo: dict[str, Any]) -> str | None:
+    user_input = _s(geo.get("userInput"))
+    if user_input:
+        return user_input
+    parts: list[str] = []
+    for node in geo.get("address") or []:
+        name = _s(_d(node).get("fullName")) or _s(_d(node).get("name"))
+        if name:
+            parts.append(name)
+    return ", ".join(parts) or None
+
+
+def _metro_rows(geo: dict[str, Any]) -> list[dict[str, Any]]:
+    """Stations as Cian ranks them: the one it marks ``isDefault`` (the station
+    shown on the tile) first, then by travel time. Minutes alone would put a
+    7-minute bus ride ahead of a 10-minute walk, which is not what the site
+    shows and not what a reader means by "nearest"."""
+    rows: list[tuple[bool, dict[str, Any]]] = []
+    for node in geo.get("undergrounds") or []:
+        station = _d(node)
+        if not station:
+            continue
+        rows.append(
+            (
+                station.get("isDefault") is True,
+                {
+                    "name": _s(station.get("name")),
+                    "minutes": R.coerce_int(station.get("time")),
+                    "mode": _s(station.get("transportType")),
+                },
+            )
+        )
+    rows.sort(key=lambda item: (not item[0], item[1]["minutes"] is None, item[1]["minutes"] or 0))
+    return [row for _, row in rows]
+
+
+def _rooms(offer: dict[str, Any], flat_type: str | None) -> int | None:
+    if flat_type in _FLAT_TYPE_RU:
+        return None
+    rooms = R.coerce_int(offer.get("roomsCount"))
+    return rooms if rooms else None
+
+
+def _compose_title(
+    offer: dict[str, Any],
+    rooms: int | None,
+    flat_type: str | None,
+    area: float | None,
+    floor: int | None,
+    floors: int | None,
+) -> str | None:
+    own = _s(offer.get("title"))
+    if own:
+        return own
+    short = _s(offer.get("formattedShortInfo"))
+    if short:
+        return re.sub(r"\s+", " ", short)
+    bits: list[str] = []
+    if rooms:
+        bits.append(f"{rooms}-комн. квартира")
+    elif flat_type in _FLAT_TYPE_RU:
+        bits.append(_FLAT_TYPE_RU[flat_type])
+    if area:
+        bits.append(f"{area:g} м²")
+    if floor and floors:
+        bits.append(f"{floor}/{floors} эт.")
+    elif floor:
+        bits.append(f"{floor} эт.")
+    return ", ".join(bits) or None
+
+
+def _offer_row(offer: dict[str, Any]) -> dict[str, Any]:
+    """The fields shared by a search hit and a card, read from one offer object."""
+    terms = _d(offer.get("bargainTerms"))
+    building = _d(offer.get("building"))
+    geo = _d(offer.get("geo"))
+    user = _d(offer.get("user"))
+    newbuilding = _d(offer.get("newbuilding"))
+    photos = offer.get("photos")
+    flat_type = _s(offer.get("flatType"))
+    rooms = _rooms(offer, flat_type)
+    total_area = _as_float(offer.get("totalArea"))
+    floor = R.coerce_int(offer.get("floorNumber"))
+    floors = R.coerce_int(building.get("floorsCount"))
+    metro = _metro_rows(geo)
+    return {
+        "offer_id": R.coerce_int(offer.get("id")),
+        "title": _compose_title(offer, rooms, flat_type, total_area, floor, floors),
+        "deal_type": _s(offer.get("dealType")),
+        "category": _s(offer.get("category")),
+        "price_rub": _price_of(offer),
+        "price_period": _s(terms.get("paymentPeriod")),
+        "lease_term": _s(terms.get("leaseTermType")),
+        "deposit_rub": R.coerce_price(terms.get("deposit")),
+        "rooms": rooms,
+        "flat_type": flat_type,
+        "is_apartments": _b(offer.get("isApartments")),
+        "total_area_m2": total_area,
+        "living_area_m2": _as_float(offer.get("livingArea")),
+        "kitchen_area_m2": _as_float(offer.get("kitchenArea")),
+        "floor": floor,
+        "floors_total": floors,
+        "build_year": R.coerce_int(building.get("buildYear")),
+        "address": _address(geo),
+        "metro": metro,
+        "newbuilding_name": _s(newbuilding.get("name")),
+        "url": _clean_url(offer.get("fullUrl")),
+        "agency_name": _s(R.first_present(user, "agencyName", "companyName")),
+        "seller_type": _s(user.get("userType")),
+        "is_by_homeowner": _b(offer.get("isByHomeowner")),
+        "created_at": _s(offer.get("creationDate")),
+        "photos": len(photos) if isinstance(photos, list) else 0,
+    }
+
+
+def _parse_offers(payload: Any) -> tuple[list[dict[str, Any]], int | None]:
+    """Offers and the total from a search payload. ValueError on the wrong shape."""
+    if not isinstance(payload, dict):
+        raise ValueError("search payload is not a JSON object")
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise ValueError("search payload has no data object")
+    offers = data.get("offersSerialized")
+    if not isinstance(offers, list):
+        raise ValueError("search payload has no offersSerialized list")
+    rows = [_offer_row(offer) for offer in offers if isinstance(offer, dict)]
+    total = R.coerce_int(R.first_present(data, "aggregatedCount", "offerCount"))
+    if total is None and R.first_present(data, "aggregatedCount", "offerCount") == 0:
+        total = 0
+    return rows, total
+
+
+def _views(stats: Any) -> int | None:
+    """``stats.totalViewsFormattedString`` is '12907 просмотров, 98 за сегодня'."""
+    text = _s(_d(stats).get("totalViewsFormattedString"))
+    if not text:
+        return None
+    match = _FIRST_NUMBER_RE.search(text)
+    return R.coerce_int(match.group(0)) if match else None
+
+
+def _price_history(changes: Any) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for change in changes if isinstance(changes, list) else []:
+        node = _d(change)
+        rows.append(
+            {
+                "changed_at": _s(node.get("changeTime")),
+                "price_rub": R.coerce_price(_d(node.get("priceData")).get("price")),
+            }
+        )
+    return rows
+
+
+def _agent(offer_data: dict[str, Any], offer: dict[str, Any]) -> dict[str, Any] | None:
+    agent = _d(offer_data.get("agent"))
+    if not agent:
+        user = _d(offer.get("user"))
+        if not user:
+            return None
+        return {
+            "name": _s(R.first_present(user, "agencyName", "companyName")),
+            "agent_id": R.coerce_int(R.first_present(user, "cianUserId", "userId")),
+            "account_type": _s(user.get("accountType")),
+            "user_type": _s(user.get("userType")),
+            "is_developer": _b(user.get("isBuilder")),
+            "offers_count": None,
+            "on_cian_since": None,
+        }
+    return {
+        "name": _s(R.first_present(agent, "name", "companyName")),
+        "agent_id": R.coerce_int(R.first_present(agent, "cianUserId", "id")),
+        "account_type": _s(agent.get("accountType")),
+        "user_type": _s(agent.get("userType")),
+        "is_developer": _b(agent.get("isDeveloper")),
+        "offers_count": R.coerce_int(agent.get("offersCount")),
+        "on_cian_since": _s(agent.get("creationDate")),
+    }
+
+
+def _parse_card(offer_data: Any) -> dict[str, Any]:
+    """A card from the ``offerData`` subtree. ValueError on the wrong shape."""
+    if not isinstance(offer_data, dict):
+        raise ValueError("card state is not an object")
+    offer = offer_data.get("offer")
+    if not isinstance(offer, dict) or not offer:
+        raise ValueError("card state has no offer object")
+    row = _offer_row(offer)
+    if row["offer_id"] is None:
+        raise ValueError("card offer has no id")
+    building = _d(offer.get("building"))
+    agent = _agent(offer_data, offer)
+    row.update(
+        {
+            "building_material": _s(R.first_present(building, "materialType", "houseMaterialType")),
+            "ceiling_height_m": _as_float(building.get("ceilingHeight")),
+            "description": _s(offer.get("description")),
+            "updated_at": _s(offer.get("editDate")),
+            "views": _views(offer_data.get("stats")),
+            "price_history": _price_history(offer_data.get("priceChanges")),
+            "agent": agent,
+        }
+    )
+    # A card's offer object carries no ``user`` (the one at offerData level is
+    # the viewer, not the publisher); the publisher lives in ``agent``.
+    if agent:
+        row["agency_name"] = row["agency_name"] or agent["name"]
+        row["seller_type"] = row["seller_type"] or agent["user_type"]
+    return row
+
+
+def _extract_offer_id(raw: str) -> int | None:
+    """Bare digits or a cian.ru offer URL; anything else is None.
+
+    Offer ids run 9 digits today; the 6-digit floor rejects a short fragment
+    ('123') instead of fetching an id that never existed.
+    """
+    raw = raw.strip()
+    if raw.isdigit():
+        return int(raw) if len(raw) >= 6 else None
+    match = _OFFER_ID_RE.search(raw)
+    return int(match.group(1)) if match else None
+
+
+def _range(low: float | int | None, high: float | int | None) -> dict[str, float | int]:
+    bounds: dict[str, float | int] = {}
+    if low is not None:
+        bounds["gte"] = low
+    if high is not None:
+        bounds["lte"] = high
+    return bounds
+
+
+def _build_json_query(
+    *,
+    deal: str,
+    offer_type: str,
+    region: str,
+    rooms: list[int] | None,
+    price_min: int | None,
+    price_max: int | None,
+    area_min: float | None,
+    area_max: float | None,
+    page: int,
+) -> dict[str, Any]:
+    query: dict[str, Any] = {
+        "_type": _QUERY_TYPE[(deal, offer_type)],
+        "engine_version": {"type": "term", "value": 2},
+        "region": {"type": "terms", "value": [int(region)]},
+        "page": {"type": "term", "value": page},
+    }
+    if offer_type == "room":
+        query["room"] = {"type": "terms", "value": [0]}
+    elif offer_type == "flat" and rooms:
+        query["room"] = {"type": "terms", "value": sorted(set(rooms))}
+    if deal == "rent":
+        # "!1" = not daily: long-term rent, the site's default for "Снять".
+        query["for_day"] = {"type": "term", "value": "!1"}
+    if price_min is not None or price_max is not None:
+        query["price"] = {"type": "range", "value": _range(price_min, price_max)}
+    if area_min is not None or area_max is not None:
+        query["total_area"] = {"type": "range", "value": _range(area_min, area_max)}
+    return query
+
+
+def _validate_region(region: str | None) -> str:
+    if region is not None and not region.strip():
+        raise_tool_error(BadRequestError("region must not be empty"))
+    value = (region or _settings.region).strip()
+    if not _REGION_RE.match(value):
+        known = ", ".join(f"{k} = {v}" for k, v in KNOWN_REGIONS.items())
+        raise_tool_error(BadRequestError(f"region must be a Cian region id in digits ({known}), got {value!r}"))
+    return value
+
+
+# ---------------------------------------------------------------- tools ----
+
+
+@mcp.tool(
+    name="cian_search",
+    annotations=ToolAnnotations(
+        title="Cian Real-Estate Search",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def cian_search(
+    deal: Annotated[DealType, Field(description="'sale' (купить) or 'rent' (снять, long-term).")],
+    offer_type: Annotated[
+        OfferType,
+        Field(description="Property type: 'flat' (квартира), 'room' (комната), 'house' (дом/участок), 'commercial'."),
+    ] = "flat",
+    region: Annotated[
+        str | None,
+        Field(
+            description=(
+                "Cian region id, digits only: 1 = Москва, 2 = Санкт-Петербург, 4593 = Московская область, "
+                "4588 = Ленинградская область. Other regions need their Cian id. Default CIAN_REGION (1)."
+            )
+        ),
+    ] = None,
+    rooms: Annotated[
+        list[int] | None,
+        Field(
+            description=(
+                "Flats only: room counts to include, any of 1..6; 7 = свободная планировка, 9 = студия. "
+                "Omit for any number of rooms. Ignored for room/house/commercial."
+            )
+        ),
+    ] = None,
+    price_min: Annotated[int | None, Field(ge=1, description="Minimum price in rubles (per month for rent).")] = None,
+    price_max: Annotated[int | None, Field(ge=1, description="Maximum price in rubles (per month for rent).")] = None,
+    area_min: Annotated[float | None, Field(gt=0, description="Minimum total area in m².")] = None,
+    area_max: Annotated[float | None, Field(gt=0, description="Maximum total area in m².")] = None,
+    page: Annotated[int, Field(ge=1, le=100, description="Result page (1-based), 28 offers per page.")] = 1,
+    ctx: Context | None = None,
+) -> CianSearchResponse:
+    """Search Cian offers by filters (there is no free-text search).
+
+    ## Return Format
+
+    CianSearchResponse: {status, deal, offer_type, region, page, tier_used,
+    count, total_count, items[], _meta}. Each item carries offer_id, title,
+    price_rub (None when Cian shows no price — never 0), rooms, areas, floor,
+    address, nearest metro, url, agency and publication data.
+
+    ## Error Format
+
+    ToolError: BadRequestError on malformed arguments (region not digits, room
+    code outside 1-6/7/9, min above max); TransportDownError when Cian's WAF
+    blocks the browser session or CDP is down (with the fix inline);
+    ParserDriftError when a 200 body is not the expected envelope.
+    """
+    log_event("cian_search.start", deal=deal, offer_type=offer_type, page=page)
+    try:
+        region_id = _validate_region(region)
+        if rooms is not None:
+            bad = sorted({r for r in rooms if r not in _ROOM_CHOICES})
+            if bad:
+                raise_tool_error(
+                    BadRequestError(f"rooms must be any of 1-6, 7 (свободная планировка) or 9 (студия); got {bad}")
+                )
+        if price_min is not None and price_max is not None and price_min > price_max:
+            raise_tool_error(BadRequestError("price_min must not exceed price_max"))
+        if area_min is not None and area_max is not None and area_min > area_max:
+            raise_tool_error(BadRequestError("area_min must not exceed area_max"))
+
+        query = _build_json_query(
+            deal=deal,
+            offer_type=offer_type,
+            region=region_id,
+            rooms=rooms,
+            price_min=price_min,
+            price_max=price_max,
+            area_min=area_min,
+            area_max=area_max,
+            page=page,
+        )
+        status, body, tier = await _fetch_search(query, ctx)
+        if status != 200:
+            _raise_for_fetch_failure(status, body, tier, "search")
+        if _WAF_MARKER in body[:2000]:
+            _raise_for_fetch_failure(403, body, tier, "search")
+        try:
+            payload = json.loads(body)
+        except json.JSONDecodeError:
+            raise_tool_error(ParserDriftError(f"non-JSON search body via {tier}; preview: {body[:200]}"))
+        try:
+            rows, total = _parse_offers(payload)
+        except ValueError as exc:
+            raise_tool_error(ParserDriftError(f"search envelope changed: {exc}"))
+
+        warnings: list[str] = []
+        if not rows and total:
+            warnings.append("empty_items_with_nonzero_total")
+        items = [
+            CianSearchItemOut(**{**row, "metro": CianMetroOut(**row["metro"][0]) if row["metro"] else None})
+            for row in rows
+        ]
+        result = CianSearchResponse(
+            deal=deal,
+            offer_type=offer_type,
+            region=region_id,
+            page=page,
+            tier_used=tier,
+            count=len(items),
+            total_count=total,
+            items=items,
+        )
+        attached = R.attach_meta(result.model_dump(by_alias=True, exclude={"meta"}), warnings, source="cian_search")
+        result.meta = MetaOut(**attached["_meta"])
+        return result
+    except ToolError:
+        raise
+    except Exception as exc:
+        log_event("cian_search.error", error=_redact(str(exc)), exc_type=type(exc).__name__)
+        raise_tool_error(TransportDownError(_redact(f"cian_search failed: {exc}")))
+
+
+@mcp.tool(
+    name="cian_card",
+    annotations=ToolAnnotations(
+        title="Cian Offer Card",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=True,
+        openWorldHint=True,
+    ),
+)
+async def cian_card(
+    offer_id_or_url: Annotated[
+        str, Field(min_length=1, max_length=300, description="Cian offer id (digits) or a full cian.ru offer URL.")
+    ],
+    ctx: Context | None = None,
+) -> CianCardResponse:
+    """Read one Cian offer: price and its history, layout, building, address,
+    metro, description, publisher.
+
+    ## Return Format
+
+    CianCardResponse: {status, offer_id, title, deal_type, category, price_rub,
+    price_period, lease_term, deposit_rub, rooms, areas, floor, floors_total,
+    build_year, building_material, ceiling_height_m, address, metro[],
+    description, photos, created_at, updated_at, views, price_history[], agent,
+    url, tier_used, _meta}. price_rub is None when not stated — never 0.
+
+    ## Error Format
+
+    ToolError: BadRequestError when no offer id can be extracted; NotFoundError
+    when Cian says the offer is gone; TransportDownError on a WAF block or CDP
+    failure; ParserDriftError when the page no longer embeds the offer state.
+    """
+    log_event("cian_card.start", input=offer_id_or_url[:80])
+    try:
+        offer_id = _extract_offer_id(offer_id_or_url)
+        if offer_id is None:
+            raise_tool_error(
+                BadRequestError(
+                    f"could not extract an offer id from {offer_id_or_url!r}; "
+                    "pass bare digits or a full cian.ru offer URL"
+                )
+            )
+        status, body, tier = await _fetch_card(offer_id, ctx)
+        if status != 200:
+            _raise_for_fetch_failure(status, body, tier, "card")
+        try:
+            envelope = json.loads(body)
+        except json.JSONDecodeError:
+            raise_tool_error(ParserDriftError(f"non-JSON card state via {tier}; preview: {body[:200]}"))
+        if not isinstance(envelope, dict):
+            raise_tool_error(ParserDriftError("card state is not a JSON object"))
+        kind = envelope.get("kind")
+        title = _s(envelope.get("title")) or ""
+        if kind == "not_found":
+            raise_tool_error(NotFoundError(f"Cian reports offer {offer_id} as removed: {title[:80]}"))
+        if kind == "too_big":
+            raise_tool_error(TransportDownError(f"Cian card state for {offer_id} exceeds the body cap"))
+        if kind != "ok":
+            if "Ошибка" in title or _WAF_MARKER in body[:2000]:
+                _raise_for_fetch_failure(403, body, tier, "card")
+            raise_tool_error(
+                ParserDriftError(
+                    f"offer page no longer embeds the card state ({kind}); "
+                    f"page title: {title[:80]!r}; config keys: {envelope.get('keys')}"
+                )
+            )
+        try:
+            row = _parse_card(envelope.get("offerData"))
+        except ValueError as exc:
+            raise_tool_error(ParserDriftError(f"card state changed: {exc}"))
+
+        warnings: list[str] = []
+        if row["price_rub"] is None:
+            warnings.append("price_missing")
+        agent = row.pop("agent")
+        metro = row.pop("metro")
+        history = row.pop("price_history")
+        # The card's offer object carries no fullUrl; the page URL Chrome
+        # landed on (after Cian's own redirect) is the canonical one.
+        row["url"] = row["url"] or _clean_url(envelope.get("url")) or f"{SITE_BASE}/sale/flat/{offer_id}/"
+        result = CianCardResponse(
+            **row,
+            metro=[CianMetroOut(**station) for station in metro],
+            price_history=[CianPriceChangeOut(**change) for change in history],
+            agent=CianAgentOut(**agent) if agent else None,
+            tier_used=tier,
+        )
+        attached = R.attach_meta(result.model_dump(by_alias=True, exclude={"meta"}), warnings, source="cian_card")
+        result.meta = MetaOut(**attached["_meta"])
+        return result
+    except ToolError:
+        raise
+    except Exception as exc:
+        log_event("cian_card.error", error=_redact(str(exc)), exc_type=type(exc).__name__)
+        raise_tool_error(TransportDownError(_redact(f"cian_card failed: {exc}")))
+
+
+# ------------------------------------------------------------ selfcheck ----
+
+
+async def cian_selfcheck(ctx: Context | None = None) -> CianSelfcheckResponse:
+    """Structural drift canary for Cian (tri-state: success / drift_detected /
+    inconclusive). Not an MCP tool — ``marketplace-mcp doctor`` runs it.
+
+    A WAF block or CDP-down is ``inconclusive`` (transport), NEVER drift: from
+    a cold session that is the expected state. Only a reached-200 body that
+    fails the parse smoke is ``drift``. The search probe supplies the live id
+    for the card probe, so the canary never depends on a hardcoded offer.
+
+    ## Return Format
+
+    CianSelfcheckResponse: {status, healthy, connector, checks, server_version,
+    server_started_at, process_id}.
+
+    ## Error Format
+
+    Raises ToolError (TransportDownError) ONLY on an unexpected internal bug
+    that prevents the canary from producing any verdict.
+    """
+    log_event("cian_selfcheck.start")
+    try:
+        result = await _cian_selfcheck_impl(ctx)
+        log_event("cian_selfcheck.done", status=result.status)
+        return result
+    except ToolError:
+        raise
+    except Exception as exc:
+        log_event("cian_selfcheck.error", error=_redact(str(exc)), exc_type=type(exc).__name__)
+        raise_tool_error(TransportDownError(_redact(f"cian_selfcheck failed: {exc}")))
+
+
+async def _cian_selfcheck_impl(ctx: Context | None) -> CianSelfcheckResponse:
+    checks: dict[str, dict[str, Any]] = {}
+
+    async def _probe(name: str, fetch: Any, baseline: str) -> Any:
+        """Run one fetch; record inconclusive/drift entries; return the parsed
+        JSON on a reached-200, else None."""
+        try:
+            async with asyncio.timeout(60):
+                status, body, tier = await fetch()
+        except TimeoutError:
+            checks[name] = R.selfcheck_entry(
+                "inconclusive", baseline=baseline, reason="timeout", notes=["fetch exceeded 60s"]
+            )
+            return None
+        except Exception as exc:
+            checks[name] = R.selfcheck_entry(
+                "inconclusive",
+                baseline=baseline,
+                reason="transport_down",
+                notes=[f"raised {type(exc).__name__}: {str(exc)[:120]}"],
+            )
+            return None
+        if status != 200 or _WAF_MARKER in body[:2000]:
+            reason = "rate_limited" if status == 429 else ("blocked" if status in (401, 403, 407) else "transport_down")
+            if _WAF_MARKER in body[:2000]:
+                reason = "blocked"
+            checks[name] = R.selfcheck_entry(
+                "inconclusive", baseline=baseline, reason=reason, notes=[f"http {status} via {tier}"], code=status
+            )
+            return None
+        try:
+            return json.loads(body)
+        except json.JSONDecodeError:
+            checks[name] = R.selfcheck_entry(
+                "inconclusive", baseline=baseline, reason="transport_down", notes=["body not JSON (block page?)"]
+            )
+            return None
+
+    def _record(name: str, baseline: str, smoke: Any, payload: Any) -> Any:
+        try:
+            verdict = smoke(payload)
+        except Exception as exc:
+            checks[name] = R.selfcheck_entry(
+                "drift", baseline=baseline, reason="parse_smoke_failed", notes=[str(exc)[:160]]
+            )
+            return None
+        checks[name] = R.selfcheck_entry("healthy", baseline=baseline, notes=[verdict[0]])
+        return verdict[1]
+
+    def _search_smoke(payload: Any) -> tuple[str, int | None]:
+        rows, total = _parse_offers(payload)
+        if not rows:
+            raise ValueError("no offers parsed from a generic query")
+        priced = [row for row in rows if row["price_rub"] is not None]
+        if not priced:
+            raise ValueError("no offer carries a price — bargainTerms family lost")
+        if all(row["offer_id"] is None for row in rows):
+            raise ValueError("offers carry no id")
+        if all(row["address"] is None for row in rows):
+            raise ValueError("offers carry no address — geo family lost")
+        return f"{len(rows)} offers parsed, total {total}", priced[0]["offer_id"]
+
+    def _card_smoke(envelope: Any) -> tuple[str, None]:
+        if not isinstance(envelope, dict):
+            raise ValueError("card state is not an object")
+        kind = envelope.get("kind")
+        if kind != "ok":
+            raise ValueError(f"offer page no longer embeds the card state ({kind}); keys={envelope.get('keys')}")
+        row = _parse_card(envelope.get("offerData"))
+        if row["price_rub"] is None:
+            raise ValueError("card parsed without a price — bargainTerms family lost")
+        return "card state intact", None
+
+    query = _build_json_query(
+        deal="sale",
+        offer_type="flat",
+        region=_validate_region(None),
+        rooms=None,
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+    search_payload = await _probe("search", lambda: _fetch_search(query, ctx), "search-offers-desktop-v2")
+    offer_id: int | None = None
+    if search_payload is not None:
+        offer_id = _record("search", "search-offers-desktop-v2", _search_smoke, search_payload)
+
+    if offer_id is not None:
+        card_payload = await _probe("card", lambda: _fetch_card(offer_id, ctx), "offer-card-config-v1")
+        if card_payload is not None:
+            _record("card", "offer-card-config-v1", _card_smoke, card_payload)
+    elif "card" not in checks:
+        checks["card"] = R.selfcheck_entry(
+            "inconclusive",
+            baseline="offer-card-config-v1",
+            reason="dependency_unavailable",
+            notes=["no live offer id from the search probe"],
+        )
+
+    result_dict = R.selfcheck_result(
+        "cian",
+        checks,
+        required=("search", "card"),
+        server_version=SERVER_VERSION,
+        server_started_at=SERVER_STARTED_AT,
+        process_id=None,
+    )
+    return CianSelfcheckResponse(**result_dict)
+
+
+# Advertised output schemas are the dominant constant cost of an MCP mount:
+# replace the full Pydantic tree with top-level field names.
+apply_compact_output_schemas(mcp)

--- a/packages/cian-connector/src/cian_connector/settings.py
+++ b/packages/cian-connector/src/cian_connector/settings.py
@@ -1,0 +1,57 @@
+"""Cian connector runtime settings (env-driven via CIAN_ prefix).
+
+Env vars (all optional):
+  CIAN_TIMEOUT         - per-call CDP timeout seconds, default 25
+  CIAN_MAX_BODY_BYTES  - hard cap on any body read inside the browser, default 50 MiB
+  CIAN_MIN_GAP         - polite inter-request gap seconds, default 1.5
+  CIAN_CACHE_TTL       - seconds to cache upstream reads, 0 disables, default 120
+  CIAN_REGION          - default Cian region id for search, default "1" (Moscow)
+
+There is no proxy setting: every read runs inside the operator's Chrome over
+CDP (Cian's WAF blocks plain HTTP by IP reputation — see docs/ANTI_BOT.md), so
+the browser's own network path is the only one in play.
+
+Settings are read once at import; tests patch the module-level constants in
+server.py. This module is the single source of truth for env-driven defaults.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_MAX_BODY_BYTES = 50 * 1024 * 1024
+
+
+class CianSettings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_prefix="CIAN_",
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+        case_sensitive=False,
+    )
+
+    timeout: float = Field(default=25.0, gt=0)
+    max_body_bytes: int = Field(default=_DEFAULT_MAX_BODY_BYTES, gt=0)
+    min_gap: float = Field(default=1.5, ge=0)
+    cache_ttl: float = Field(
+        default=120.0,
+        ge=0,
+        description="Seconds to cache upstream reads. 0 disables caching.",
+    )
+    region: str = Field(
+        default="1",
+        min_length=1,
+        description=(
+            "Default Cian region id (1 = Москва, 2 = Санкт-Петербург, 4593 = Московская область, "
+            "4588 = Ленинградская область). Overridden per call by the region argument."
+        ),
+    )
+
+
+@lru_cache(maxsize=1)
+def get_settings() -> CianSettings:
+    return CianSettings()

--- a/packages/cian-connector/tests/conftest.py
+++ b/packages/cian-connector/tests/conftest.py
@@ -1,0 +1,5 @@
+"""Marks this directory as its own pytest rootdir package.
+
+Several connectors have a ``test_server.py``; without a conftest per directory
+pytest cannot tell the identically-named modules apart during collection.
+"""

--- a/packages/cian-connector/tests/fixtures/card_daily_live.json
+++ b/packages/cian-connector/tests/fixtures/card_daily_live.json
@@ -1,0 +1,608 @@
+{
+  "offerData": {
+    "offer": {
+      "category": "dailyFlatRent",
+      "status": "published",
+      "dealType": "rent",
+      "offerType": "flat",
+      "geo": {
+        "address": [
+          {
+            "fullName": "Москва",
+            "id": 1,
+            "locationTypeId": 1,
+            "name": "Москва",
+            "shortName": "Москва",
+            "type": "location",
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno/"
+          },
+          {
+            "fullName": "ЗАО",
+            "id": 11,
+            "locationTypeId": -1,
+            "name": "ЗАО",
+            "shortName": "ЗАО",
+            "type": "okrug",
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-zao-0411/"
+          },
+          {
+            "fullName": "район Филевский парк",
+            "id": 123,
+            "locationTypeId": -1,
+            "name": "Филевский парк",
+            "shortName": "р-н Филевский парк",
+            "type": "raion",
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-filevskiy-park-04123/"
+          },
+          {
+            "fullName": "Береговой проезд",
+            "id": 684,
+            "locationTypeId": -1,
+            "name": "Береговой",
+            "shortName": "Береговой проезд",
+            "type": "street",
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-beregovoy-proezd-02684/"
+          },
+          {
+            "fullName": "5Ак2",
+            "id": 3067547,
+            "locationTypeId": -1,
+            "name": "5Ак2",
+            "shortName": "5Ак2",
+            "type": "house",
+            "url": "https://www.cian.ru/cat.php?deal_type=rent&engine_version=2&house%5B0%5D=3067547&offer_type=flat&room1=1&type=2"
+          }
+        ],
+        "coordinates": {
+          "lat": 55.755459,
+          "lng": 37.509334
+        },
+        "highways": [],
+        "jk": {
+          "id": 5489,
+          "name": "Фили Град",
+          "house": {
+            "id": 2790,
+            "name": "Береговой, 5Ак2"
+          },
+          "gaGeo": {
+            "moId": 0,
+            "oblId": 1,
+            "cityId": 1
+          },
+          "fullUrl": "https://www.cian.ru/zhiloy-kompleks-fili-grad-moskva-5489/",
+          "fullUrlTemplate": "{request_scheme}://zhk-fili-grad-i.{host}/"
+        },
+        "railways": [
+          {
+            "id": 708,
+            "directionIds": [
+              11
+            ],
+            "distance": "1.0",
+            "time": 22,
+            "name": "Фили",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 708,
+            "directionIds": [
+              11
+            ],
+            "distance": "2.0",
+            "time": 5,
+            "name": "Фили",
+            "travelType": "byCar"
+          },
+          {
+            "id": 707,
+            "directionIds": [
+              11
+            ],
+            "distance": "2.0",
+            "time": 29,
+            "name": "Тестовская",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 707,
+            "directionIds": [
+              11
+            ],
+            "distance": "4.0",
+            "time": 8,
+            "name": "Тестовская",
+            "travelType": "byCar"
+          },
+          {
+            "id": 706,
+            "directionIds": [
+              14
+            ],
+            "distance": "4.0",
+            "time": 50,
+            "name": "Москва-Сортировочная",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 706,
+            "directionIds": [
+              14
+            ],
+            "distance": "11.0",
+            "time": 18,
+            "name": "Москва-Сортировочная",
+            "travelType": "byCar"
+          }
+        ],
+        "undergrounds": [
+          {
+            "id": 142,
+            "name": "Фили",
+            "lineColor": "009BD5",
+            "travelType": "walk",
+            "travelTime": 14,
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-metro-fili-142/",
+            "underConstruction": false
+          },
+          {
+            "id": 453,
+            "name": "Шелепиха",
+            "lineColor": "7ACDCE",
+            "travelType": "walk",
+            "travelTime": 19,
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-metro-shelepiha-453/",
+            "underConstruction": false
+          },
+          {
+            "id": 311,
+            "name": "Шелепиха",
+            "lineColor": "FA6F9E",
+            "travelType": "walk",
+            "travelTime": 19,
+            "url": "https://www.cian.ru/snyat-1-komnatnuyu-kvartiru-posutochno-moskva-stanciya-mck-shelepiha-311/",
+            "underConstruction": false,
+            "lineType": "mck"
+          }
+        ]
+      },
+      "id": 191071633,
+      "objectGuid": "b9816532-3160-46c2-8038-a95f5ca887ec",
+      "cianId": 191071633,
+      "userId": 17548313,
+      "publishedUserId": 17548313,
+      "cianUserId": 17548313,
+      "isByHomeowner": false,
+      "description": "Сдается квартира - студия в современном комплексе бизнес класса ЖК Филиград. В квартире можно расположить до 4 человек. Оборудована всем необходимым для комфортного проживания:\n- Холодильник\n- Посудомоечная,стиральная машины,микроволновая \nпечь,эл.чайник .\n-кондиционер ( сплит - система )!!!\n-ТВ,Wi-",
+      "photos": [
+        {
+          "id": 2742596853,
+          "isDefault": true,
+          "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-3.jpg",
+          "isCianLayout": false
+        },
+        {
+          "id": 530398203,
+          "isDefault": false,
+          "fullUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-3.jpg",
+          "isCianLayout": false
+        }
+      ],
+      "phones": [
+        {
+          "countryCode": "+7",
+          "number": "9230758879"
+        }
+      ],
+      "publishTerms": {
+        "terms": [
+          {
+            "services": [
+              "auction"
+            ],
+            "days": 1,
+            "type": "dailyLimited"
+          },
+          {
+            "services": [
+              "paid"
+            ],
+            "days": 30,
+            "type": "periodical",
+            "tariffIdentificator": {
+              "tariffId": 1239212,
+              "tariffGridType": "packageTariff"
+            }
+          }
+        ],
+        "autoprolong": true
+      },
+      "flatType": "rooms",
+      "isApartments": false,
+      "totalArea": "32.4",
+      "windowsViewType": "street",
+      "combinedWcsCount": 1,
+      "hasFridge": true,
+      "hasDishwasher": true,
+      "hasWasher": true,
+      "hasFurniture": true,
+      "hasKitchenFurniture": true,
+      "hasConditioner": true,
+      "hasTv": true,
+      "hasInternet": true,
+      "hasBathtub": false,
+      "hasShower": true,
+      "childrenAllowed": true,
+      "petsAllowed": false,
+      "hasBathhouse": false,
+      "hasPool": false,
+      "flags": {
+        "isArchived": false,
+        "isCommercialOwnershipVerified": false
+      },
+      "specialty": {
+        "types": [],
+        "additionalTypes": []
+      },
+      "isNeedHideExactAddress": false,
+      "areaParts": [],
+      "roomsCount": 1,
+      "floorNumber": 25,
+      "bedsCount": 4,
+      "bargainTerms": {
+        "price": 5000,
+        "priceType": "all",
+        "currency": "rur",
+        "utilitiesTerms": {
+          "includedInPrice": true,
+          "price": 0
+        },
+        "includedOptions": [],
+        "prices": {
+          "rur": 5000,
+          "usd": 59,
+          "eur": 51
+        },
+        "utilitiesTermsPrices": {
+          "rur": 0,
+          "usd": 0,
+          "eur": 0
+        },
+        "tags": []
+      },
+      "building": {
+        "materialType": "monolith",
+        "floorsCount": 25,
+        "buildYear": 2017,
+        "hasGarbageChute": false,
+        "totalArea": "32.4",
+        "liftTypes": [],
+        "cranageTypes": [],
+        "cargoLiftsCount": 2,
+        "houseMaterialType": "monolith"
+      },
+      "editDate": "2026-09-09T21:05:30.277000Z",
+      "humanizedEditDate": "вчера, 21:05",
+      "hasRamp": false,
+      "isInHiddenBase": false,
+      "isObjectHidden": false,
+      "isClosedVisibility": false,
+      "videos": [],
+      "exportLinks": {
+        "pdfUrl": "/export/pdf/rent/flat/191071633/",
+        "docxUrl": "/export/docx/rent/flat/191071633/"
+      },
+      "cargoLiftsCount": 2,
+      "added": "вчера, 21:05",
+      "valueAddedServices": {
+        "isStandard": false,
+        "isTop3": true,
+        "isPremium": false
+      },
+      "promotion": {
+        "isPerformanceVasPilot": false,
+        "promotionDescription": "",
+        "isCpcAuction": false
+      },
+      "categoriesIds": [
+        1000,
+        1100,
+        1110,
+        1113
+      ],
+      "publicationDate": 1532964833,
+      "creationDate": "2018-07-30T18:33:53.143",
+      "recoveryLink": "/razmestit-obyavlenie/191071633/",
+      "isFromBuilder": false,
+      "isFromSeller": false,
+      "isFromLeadFactory": false,
+      "trackingData": {
+        "moId": 0,
+        "oblId": 1,
+        "cityId": 1,
+        "fbRegion": "Москва",
+        "fbCity": "Москва"
+      },
+      "editPhoto": "/realty/add2.aspx?id=191071633",
+      "newEdit": "/razmestit-obyavlenie/?realty_id=191071633",
+      "certificate": "https://www.cian.ru/newobjects/cian/certification/get?announcementId=191071633",
+      "edit": "/realty/add1.aspx?id=191071633",
+      "similarOffersLink": "",
+      "similarOffersCount": 0,
+      "buildersIds": [
+        6008
+      ],
+      "builderId": 6008,
+      "isImported": false,
+      "userConfirmedFix": false,
+      "newbuilding": {
+        "id": 5489,
+        "name": "Фили Град",
+        "house": {
+          "isReliable": false,
+          "isFinished": true,
+          "finishDate": {
+            "quarter": 3,
+            "year": 2017
+          },
+          "id": 2790,
+          "name": "Береговой, 5Ак2"
+        },
+        "isFromDeveloper": false,
+        "isFromBuilder": false,
+        "isFromSeller": false,
+        "isFromLeadFactory": false,
+        "showJkReliableFlag": false,
+        "isFichering": false,
+        "isFicheringPlus": false,
+        "isPremium": false,
+        "newbuildingFeatures": {
+          "imagesCount": 11,
+          "firstImageUrl": "https://images.cdn-cian.ru/images/fili-grad-moskva-jk-2481105058-6.jpg",
+          "videosCount": 0,
+          "deadlineInfo": "Сдан"
+        },
+        "isReliable": false,
+        "isTariffPremium": false
+      },
+      "timezone": 3,
+      "isEnabledCallTracking": true,
+      "callTrackingProvider": "mtt",
+      "isRentByParts": false,
+      "isDuplicate": false,
+      "userTrust": "notInvolved",
+      "userTrustLevel": "notInvolved",
+      "showWarningMessage": false,
+      "moderationInfo": {
+        "showContactWarningMessage": false
+      },
+      "isUnique": false,
+      "isUniqueCheckDate": "2026-09-09",
+      "isCianPartner": false,
+      "isIllegalConstruction": false,
+      "dailyrent": {
+        "actionType": "otaCheckDates",
+        "hotelData": {
+          "isHotel": false
+        },
+        "isOnlineBooking": true,
+        "isVerifiedByCian": true,
+        "offerLabels": [
+          "instantBooking"
+        ],
+        "price": "от 5 000 ₽/сут.",
+        "priceInfo": {
+          "finalPrice": "5 000 ₽",
+          "finalPricePerNight": "от 5 000 ₽/сут."
+        },
+        "realtyId": 191071633,
+        "showBookingCalendar": true,
+        "showBookingCalendarSettings": false,
+        "showFullRating": true,
+        "guestsInfo": {
+          "guestsCount": 1,
+          "maxGuestsCount": 4
+        },
+        "offerButton": {
+          "actionType": "checkCalendar",
+          "text": "Проверить даты"
+        },
+        "rating": {
+          "moderationRulesUrl": "https://support.cian.ru/ru/knowledge_base/art/2192/cat/66/",
+          "scores": [
+            {
+              "fillingPercentage": 100,
+              "id": 1,
+              "name": "Вежливость",
+              "score": "5,0"
+            },
+            {
+              "fillingPercentage": 90,
+              "id": 2,
+              "name": "Цена / Качество",
+              "score": "4,5"
+            },
+            {
+              "fillingPercentage": 100,
+              "id": 3,
+              "name": "Расположение",
+              "score": "5,0"
+            },
+            {
+              "fillingPercentage": 100,
+              "id": 4,
+              "name": "Комфорт и техника",
+              "score": "5,0"
+            },
+            {
+              "fillingPercentage": 100,
+              "id": 5,
+              "name": "Чистота",
+              "score": "5,0"
+            }
+          ],
+          "rating": "5,0",
+          "reviewsCount": "7 отзывов"
+        }
+      },
+      "isVerifiedByCian": true,
+      "amenities": [],
+      "externalOfferUrl": "",
+      "cianLayouts": null,
+      "demolishedInMoscowProgramm": false
+    },
+    "agent": {
+      "id": 17548313,
+      "cianUserId": 17548313,
+      "realtyUserId": 17548313,
+      "accountType": "specialist",
+      "companyName": "Наталья  Ярышкина",
+      "creationDate": "2018-07-25T12:29:32.337000Z",
+      "name": "Наталья  Ярышкина",
+      "isPro": false,
+      "phones": [
+        {
+          "confirmed": true
+        },
+        {
+          "confirmed": true
+        }
+      ],
+      "skills": [],
+      "isDeveloper": false,
+      "firstName": "Наталья ",
+      "lastName": "Ярышкина ",
+      "isRecidivist": false,
+      "isUserOffersHasErrors": false,
+      "offersCount": 1,
+      "offersLink": "https://www.cian.ru/agents/17548313/",
+      "availableServices": {
+        "isUploadsAvailable": false,
+        "isCallTrackingAvailable": false,
+        "isPhoneChangingAvailable": false,
+        "isServicePackagesAvailable": true,
+        "canUseHiddenBase": false
+      },
+      "userType": "realtor_not_commerce",
+      "removeCompetitor": false,
+      "status": "published",
+      "isSubAgent": false,
+      "isMessagingEnabled": false,
+      "isPassportVerified": true,
+      "isSelfEmployed": false,
+      "isPrivateBroker": false,
+      "isCianPartner": false,
+      "canShowOnline": false,
+      "moderationInfo": {
+        "qualityLevelInfo": {
+          "levelSystemName": "max",
+          "levelName": "Суперхозяин",
+          "levelOrder": 4,
+          "hasVerifiedDocuments": true,
+          "highResponsibility": true,
+          "isSuperAgent": false,
+          "isSuperHost": true,
+          "isBlocked": false,
+          "showSuperHost": true,
+          "showSuperAgent": false,
+          "showHighResponsibility": true
+        },
+        "isUserIdentified": true,
+        "isUserIdentifiedByDocuments": true,
+        "showUserIdentifiedByDocuments": false
+      },
+      "isHidden": false,
+      "agentLists": []
+    },
+    "company": {
+      "buildersAuctionRank": 7810170942,
+      "buildingStatus": [
+        {
+          "count": 33,
+          "housesCount": 149,
+          "statusId": 5004
+        },
+        {
+          "count": 18,
+          "housesCount": 88,
+          "statusId": 5002
+        }
+      ],
+      "categoryId": 2002,
+      "description": "MR успешно работает на российском рынке с 2003 года и является одной из крупнейших компаний по объему продаж и строительству жилой и коммерческой недвижимости в России. Входит в число лидеров рынка по уровню цифровизации и инноваций в своих проектах, активно развивает направления трейд-ин и ЗПИФ.\r\n\r\n<p>Портфель компании — это 52 объекта общей площадью 9,5 миллионов кв. м в Москве, Московской области и Сочи.</p>\r\n\r\n<p>Компания сотрудничает с пулом российских и международных партнеров. MR входит в ТОП-3 девелоперов Московского региона по версии РБК и в ТОП-7 крупнейших застройщиков России по версии аналитического агентства Infoline и Национального объединения застройщиков жилья. Одиннадцатикратный «Девелопер года» — по версии Urban Awards, RREF Awards, ProEstate&CRE Awards, CRE Awards, Move Realty Awards и «Рекорды рынка недвижимости».</p>",
+      "fromDeveloperPropsCount": 5033,
+      "hasSpecProject": false,
+      "id": 6008,
+      "isTest": false,
+      "locationIds": [
+        1,
+        6529,
+        4998,
+        34452,
+        349595,
+        349596,
+        190236,
+        349597,
+        349598,
+        199840,
+        5922,
+        5044,
+        202935,
+        197816,
+        277177,
+        338625,
+        1231429,
+        349648,
+        86233,
+        366433,
+        133987,
+        4584,
+        4593,
+        395128
+      ],
+      "logoUrl": "/api/get-company-logo/?id=6008&rnd=149186",
+      "maxBet": 188000,
+      "name": "MR",
+      "newobjectsCount": 48,
+      "offersCount": 5033,
+      "phones": [],
+      "promoCount": 0,
+      "specProjectNewobjectsCount": 0,
+      "status": 12,
+      "website": "http://mr-group.ru/",
+      "yearFoundation": 2003,
+      "reviewStats": {
+        "reviewCount": 2844,
+        "reviewCountText": "2844 отзыва",
+        "totalRate": 4.5
+      },
+      "advantages": null,
+      "email": null,
+      "emailForRequest": null,
+      "headerImageUrl": null,
+      "isReliable": false,
+      "newbuildingIds": null,
+      "stats": null,
+      "url": "#",
+      "workYears": null
+    },
+    "priceChanges": [
+      {
+        "changeTime": "2026-07-11T09:33:57.490653Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 5000
+        }
+      }
+    ],
+    "stats": {
+      "totalViewsFormattedString": "6200 просмотров, 29 за сегодня"
+    }
+  }
+}

--- a/packages/cian-connector/tests/fixtures/card_daily_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/card_daily_live.provenance.json
@@ -1,0 +1,14 @@
+{
+  "captured": "2026-09-10",
+  "page": "https://www.cian.ru/rent/flat/191071633/",
+  "source": "window._cianConfig['frontend-offer-card'] -> defaultState.offerData",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "displayed": {
+    "title": "Аренда однокомнатной квартиры 32.4м² Береговой проезд, 5Ак2, Москва, ЗАО, р-н Филевский парк м. Фили - база ЦИАН, объявление 191071633",
+    "price_per_night": 5000,
+    "priceRur_present": false,
+    "category": "dailyFlatRent"
+  },
+  "note": "A daily card has no bargainTerms.priceRur — only .price, and it is the nightly rate.",
+  "trimmed": "offerData reduced to offer/agent/company/priceChanges/stats; description 300 chars; photos 2"
+}

--- a/packages/cian-connector/tests/fixtures/card_rent_live.json
+++ b/packages/cian-connector/tests/fixtures/card_rent_live.json
@@ -1,0 +1,520 @@
+{
+  "offerData": {
+    "offer": {
+      "category": "flatRent",
+      "status": "published",
+      "dealType": "rent",
+      "offerType": "flat",
+      "geo": {
+        "address": [
+          {
+            "fullName": "Санкт-Петербург",
+            "id": 2,
+            "locationTypeId": 1,
+            "name": "Санкт-Петербург",
+            "shortName": "Санкт-Петербург",
+            "type": "location",
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&offer_type=flat&region=2&room2=1&type=3"
+          },
+          {
+            "fullName": "район Калининский",
+            "id": 147,
+            "locationTypeId": -1,
+            "name": "Калининский",
+            "shortName": "р-н Калининский",
+            "type": "raion",
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&district%5B0%5D=147&engine_version=2&offer_type=flat&room2=1&type=3"
+          },
+          {
+            "fullName": "Прометей",
+            "id": 768,
+            "locationTypeId": -1,
+            "name": "Прометей",
+            "shortName": "Прометей",
+            "type": "okrug",
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&district%5B0%5D=768&engine_version=2&offer_type=flat&room2=1&type=3"
+          },
+          {
+            "fullName": "проспект Просвещения",
+            "id": 4636,
+            "locationTypeId": -1,
+            "name": "Просвещения",
+            "shortName": "просп. Просвещения",
+            "type": "street",
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&offer_type=flat&room2=1&street%5B0%5D=4636&type=3"
+          },
+          {
+            "fullName": "83",
+            "id": 3722,
+            "locationTypeId": -1,
+            "name": "83",
+            "shortName": "83",
+            "type": "house",
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&house%5B0%5D=3722&offer_type=flat&room2=1&type=3"
+          }
+        ],
+        "coordinates": {
+          "lat": 60.036793,
+          "lng": 30.407317
+        },
+        "highways": [],
+        "railways": [
+          {
+            "id": 284,
+            "directionIds": [
+              10
+            ],
+            "distance": "2.0",
+            "time": 4,
+            "name": "Мурино",
+            "travelType": "byCar"
+          },
+          {
+            "id": 284,
+            "directionIds": [
+              10
+            ],
+            "distance": "2.0",
+            "time": 25,
+            "name": "Мурино",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 296,
+            "directionIds": [
+              10
+            ],
+            "distance": "3.0",
+            "time": 39,
+            "name": "Девяткино",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 277,
+            "directionIds": [
+              10
+            ],
+            "distance": "4.0",
+            "time": 6,
+            "name": "Депо Ручьи",
+            "travelType": "byCar"
+          },
+          {
+            "id": 277,
+            "directionIds": [
+              10
+            ],
+            "distance": "4.0",
+            "time": 54,
+            "name": "Депо Ручьи",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 296,
+            "directionIds": [
+              10
+            ],
+            "distance": "7.0",
+            "time": 11,
+            "name": "Девяткино",
+            "travelType": "byCar"
+          }
+        ],
+        "undergrounds": [
+          {
+            "id": 168,
+            "name": "Гражданский проспект",
+            "lineColor": "D70834",
+            "travelType": "walk",
+            "travelTime": 10,
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=168&offer_type=flat&only_foot=2&room2=1&type=3",
+            "underConstruction": false
+          },
+          {
+            "id": 169,
+            "name": "Академическая",
+            "lineColor": "D70834",
+            "travelType": "transport",
+            "travelTime": 7,
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=169&offer_type=flat&only_foot=2&room2=1&type=3",
+            "underConstruction": false
+          },
+          {
+            "id": 167,
+            "name": "Девяткино",
+            "lineColor": "D70834",
+            "travelType": "transport",
+            "travelTime": 7,
+            "url": "https://spb.cian.ru/cat.php?deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=167&offer_type=flat&only_foot=2&room2=1&type=3",
+            "underConstruction": false
+          }
+        ]
+      },
+      "id": 317754437,
+      "objectGuid": "781d647a-a512-4105-909b-3553b57dd660",
+      "cianId": 317754437,
+      "userId": 131124249,
+      "publishedUserId": 131124249,
+      "cianUserId": 131124249,
+      "isByHomeowner": false,
+      "title": "Сдаются впервые после ремонта",
+      "description": "Сдаются двухкомнатные апартаменты площадью 43 м² без комиссии и посредников. В стоимость аренды уже включены коммунальные услуги, уборка раз в две недели, Wi-Fi. \n\nАпартаменты идеально подойдут для семейного проживания или пары, ценящей тишину, уют и порядок. В Вашем распоряжении — отдельная спальня",
+      "photos": [
+        {
+          "id": 2495568875,
+          "isDefault": true,
+          "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-3.jpg",
+          "isCianLayout": false
+        },
+        {
+          "id": 2495555177,
+          "isDefault": false,
+          "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-3.jpg",
+          "isCianLayout": false
+        }
+      ],
+      "phones": [
+        {
+          "countryCode": "+7",
+          "number": "9119664962"
+        }
+      ],
+      "publishTerms": {
+        "terms": [
+          {
+            "services": [
+              "auction"
+            ],
+            "days": 7,
+            "type": "periodical"
+          },
+          {
+            "services": [
+              "top3"
+            ],
+            "days": 30,
+            "type": "periodical",
+            "tariffIdentificator": {
+              "tariffId": 1298636,
+              "tariffGridType": "packageTariff"
+            }
+          }
+        ],
+        "autoprolong": true
+      },
+      "flatType": "rooms",
+      "roomType": "both",
+      "isApartments": true,
+      "totalArea": "43.0",
+      "loggiasCount": 0,
+      "balconiesCount": 0,
+      "separateWcsCount": 0,
+      "combinedWcsCount": 1,
+      "repairType": "design",
+      "hasPhone": false,
+      "hasFridge": true,
+      "hasDishwasher": false,
+      "hasWasher": true,
+      "hasFurniture": true,
+      "hasKitchenFurniture": true,
+      "hasConditioner": true,
+      "hasTv": true,
+      "hasInternet": true,
+      "hasBathtub": false,
+      "hasShower": true,
+      "childrenAllowed": true,
+      "petsAllowed": false,
+      "flags": {
+        "isArchived": false,
+        "isCommercialOwnershipVerified": false
+      },
+      "hasLift": true,
+      "specialty": {
+        "types": [],
+        "additionalTypes": []
+      },
+      "isNeedHideExactAddress": false,
+      "areaParts": [],
+      "roomsCount": 2,
+      "floorNumber": 14,
+      "bargainTerms": {
+        "price": 60000,
+        "priceType": "all",
+        "currency": "rur",
+        "paymentPeriod": "monthly",
+        "leaseTermType": "fewMonths",
+        "prepayMonths": 1,
+        "deposit": 50000,
+        "utilitiesTerms": {
+          "includedInPrice": true,
+          "price": 0,
+          "flowMetersNotIncludedInPrice": false
+        },
+        "includedOptions": [],
+        "clientFee": 0,
+        "agentFee": 0,
+        "prices": {
+          "rur": 60000,
+          "usd": 694,
+          "eur": 598
+        },
+        "depositPrices": {
+          "rur": 50000,
+          "usd": 579,
+          "eur": 498
+        },
+        "utilitiesTermsPrices": {
+          "rur": 0,
+          "usd": 0,
+          "eur": 0
+        },
+        "tags": []
+      },
+      "building": {
+        "floorsCount": 23,
+        "parking": {
+          "type": "ground"
+        },
+        "totalArea": "43.0",
+        "liftTypes": [],
+        "cranageTypes": [],
+        "passengerLiftsCount": 3,
+        "cargoLiftsCount": 0
+      },
+      "editDate": "2026-09-09T14:25:19.803865Z",
+      "humanizedEditDate": "сегодня, 14:25",
+      "isInHiddenBase": false,
+      "isObjectHidden": false,
+      "isClosedVisibility": false,
+      "videos": [],
+      "exportLinks": {
+        "pdfUrl": "/export/pdf/rent/flat/317754437/",
+        "docxUrl": "/export/docx/rent/flat/317754437/"
+      },
+      "passengerLiftsCount": 3,
+      "cargoLiftsCount": 0,
+      "added": "7 сен, 14:03",
+      "valueAddedServices": {
+        "isStandard": false,
+        "isTop3": true,
+        "isPremium": false
+      },
+      "promotion": {
+        "isPerformanceVasPilot": false,
+        "promotionDescription": "",
+        "isCpcAuction": false
+      },
+      "categoriesIds": [
+        1000,
+        1100,
+        1110,
+        1111
+      ],
+      "publicationDate": 1747731366,
+      "creationDate": "2025-05-20T11:56:06.607",
+      "recoveryLink": "/razmestit-obyavlenie/317754437/",
+      "trackingData": {
+        "moId": 0,
+        "oblId": 2,
+        "cityId": 2,
+        "fbRegion": "Санкт-Петербург",
+        "fbCity": "Санкт-Петербург"
+      },
+      "editPhoto": "/realty/add2.aspx?id=317754437",
+      "newEdit": "/razmestit-obyavlenie/?realty_id=317754437",
+      "certificate": "https://www.cian.ru/newobjects/cian/certification/get?announcementId=317754437",
+      "edit": "/realty/add1.aspx?id=317754437",
+      "similarOffersLink": "",
+      "similarOffersCount": 0,
+      "buildersIds": [],
+      "isImported": false,
+      "userConfirmedFix": false,
+      "timezone": 3,
+      "isEnabledCallTracking": true,
+      "callTrackingProvider": "mts",
+      "isRentByParts": false,
+      "isDuplicate": false,
+      "userTrust": "notInvolved",
+      "userTrustLevel": "notInvolved",
+      "showWarningMessage": false,
+      "moderationInfo": {
+        "showContactWarningMessage": false
+      },
+      "isUnique": true,
+      "isUniqueCheckDate": "2026-09-08",
+      "isCianPartner": false,
+      "isIllegalConstruction": false,
+      "amenities": [],
+      "externalOfferUrl": "",
+      "cianLayouts": null,
+      "newbuilding": {
+        "id": 0,
+        "isFromBuilder": false,
+        "isFromDeveloper": false,
+        "isFromLeadFactory": false,
+        "isFromSeller": false,
+        "isReliable": false,
+        "isTariffPremium": false,
+        "isPremium": false,
+        "name": "",
+        "newbuildingFeatures": null,
+        "showJkReliableFlag": false
+      },
+      "demolishedInMoscowProgramm": false
+    },
+    "agent": {
+      "id": 131124249,
+      "cianUserId": 131124249,
+      "realtyUserId": 131124249,
+      "accountType": "agency",
+      "companyName": "SVET hotel",
+      "creationDate": "2025-05-16T10:56:17.787000Z",
+      "name": "SVET hotel",
+      "isPro": true,
+      "description": "Открытие отеля — 22 сентября 2025 года.\n\nНовый современный отель с богатой инфраструктурой.\n\nОтель SVET расположен в одном самом экологически чистом районе на севере Санкт-Петербурга и предлагает гостям 802 апартамента в категориях от «Стандарт Комфорт» до «Люкса» для долгосрочного проживания.\n\nВ 5 минутах ходьбы расположена станция метро Гражданский проспект, а путь до исторического центра займет не более 20 минут на автомобиле.\n\nНомера отеля предлагают современную эргономичную обстановку и оснащены всем необходимым для вашего комфортного отдыха.",
+      "phones": [
+        {
+          "confirmed": true
+        }
+      ],
+      "skills": [
+        {
+          "id": 712,
+          "name": "жилая",
+          "parentName": "Аренда недвижимости"
+        }
+      ],
+      "absoluteAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=71539216&t=2&p=2&timestamp=1787129417",
+      "absoluteMiniAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=71539216&t=2&p=1&timestamp=1787129417",
+      "isDeveloper": false,
+      "isRecidivist": false,
+      "isUserOffersHasErrors": false,
+      "offersCount": 5,
+      "offersLink": "https://www.cian.ru/company/131124249/",
+      "availableServices": {
+        "isUploadsAvailable": true,
+        "isCallTrackingAvailable": false,
+        "isPhoneChangingAvailable": false,
+        "isServicePackagesAvailable": true,
+        "canUseHiddenBase": true
+      },
+      "userType": "realtor_based",
+      "removeCompetitor": false,
+      "status": "published",
+      "isSubAgent": false,
+      "isMessagingEnabled": false,
+      "isPassportVerified": false,
+      "isSelfEmployed": false,
+      "isPrivateBroker": false,
+      "isCianPartner": false,
+      "canShowOnline": false,
+      "moderationInfo": {
+        "qualityLevelInfo": {
+          "levelSystemName": "low",
+          "levelName": "Низкий уровень",
+          "levelOrder": 1,
+          "hasVerifiedDocuments": true,
+          "highResponsibility": false,
+          "isSuperAgent": false,
+          "isSuperHost": false,
+          "isBlocked": false,
+          "showSuperHost": false,
+          "showSuperAgent": false,
+          "showHighResponsibility": false
+        },
+        "isUserIdentified": true,
+        "isUserIdentifiedByDocuments": true,
+        "showUserIdentifiedByDocuments": true
+      },
+      "isHidden": false,
+      "metrics": [
+        {
+          "title": "На Циан",
+          "value": "1 год"
+        },
+        {
+          "title": "Объектов в работе",
+          "value": "5"
+        }
+      ],
+      "agentLists": []
+    },
+    "company": null,
+    "user": {
+      "realtyUserId": null,
+      "isAuthenticated": false,
+      "permissions": {
+        "canModerateUsers": false,
+        "canModerateAnnouncements": false,
+        "canModerateAnnouncementsExpert": false,
+        "canViewUsers": false,
+        "canViewAnnouncements": false
+      },
+      "ga": {
+        "type": "",
+        "balance": 0,
+        "packages": [],
+        "emailMd5": ""
+      }
+    },
+    "priceChanges": [
+      {
+        "changeTime": "2026-08-21T11:06:56.997924Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 60000,
+          "paymentPeriod": "monthly"
+        }
+      },
+      {
+        "changeTime": "2026-07-23T14:50:07.591324Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 59000,
+          "paymentPeriod": "monthly"
+        }
+      },
+      {
+        "changeTime": "2026-04-20T10:38:18.188761Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 70000,
+          "paymentPeriod": "monthly"
+        }
+      },
+      {
+        "changeTime": "2025-12-27T13:41:51.074579Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 65900,
+          "paymentPeriod": "monthly"
+        }
+      },
+      {
+        "changeTime": "2025-08-22T10:50:43.550446Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 76704,
+          "paymentPeriod": "monthly"
+        }
+      },
+      {
+        "changeTime": "2025-05-21T06:55:53.566466Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 103400,
+          "paymentPeriod": "monthly"
+        }
+      }
+    ],
+    "stats": {
+      "totalViewsFormattedString": "3841 просмотр, 37 за сегодня"
+    }
+  }
+}

--- a/packages/cian-connector/tests/fixtures/card_rent_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/card_rent_live.provenance.json
@@ -1,0 +1,12 @@
+{
+  "captured": "2026-09-09",
+  "page": "https://spb.cian.ru/rent/flat/317754437/",
+  "source": "window._cianConfig['frontend-offer-card'] -> defaultState.offerData",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "displayed": {
+    "title": "Сдам двухкомнатные апартаменты 43м² просп. Просвещения, 83, Санкт-Петербург, р-н Калининский, Прометей м. Гражданский проспект - база ЦИАН, объявление 317754437",
+    "price": 60000,
+    "priceRur": null
+  },
+  "trimmed": "offerData reduced to offer/agent/company/user/priceChanges/stats; description 300 chars; photos 2"
+}

--- a/packages/cian-connector/tests/fixtures/card_sale_live.json
+++ b/packages/cian-connector/tests/fixtures/card_sale_live.json
@@ -1,0 +1,600 @@
+{
+  "offerData": {
+    "offer": {
+      "category": "newBuildingFlatSale",
+      "status": "published",
+      "dealType": "sale",
+      "offerType": "flat",
+      "geo": {
+        "address": [
+          {
+            "fullName": "Москва",
+            "id": 1,
+            "locationTypeId": 1,
+            "name": "Москва",
+            "shortName": "Москва",
+            "type": "location",
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&object_type%5B0%5D=2&offer_type=flat&region=1&room1=1"
+          },
+          {
+            "fullName": "НАО (Новомосковский)",
+            "id": 325,
+            "locationTypeId": -1,
+            "name": "НАО (Новомосковский)",
+            "shortName": "НАО (Новомосковский)",
+            "type": "okrug",
+            "url": "https://www.cian.ru/kupit-1-komnatnuyu-kvartiru-novostroyki-moskva-nao-novomoskovskiy-04325/"
+          },
+          {
+            "fullName": "Московский г.",
+            "id": 1224131,
+            "locationTypeId": 1,
+            "name": "Московский",
+            "shortName": "Московский",
+            "type": "location",
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&location%5B0%5D=1224131&object_type%5B0%5D=2&offer_type=flat&room1=1"
+          },
+          {
+            "fullName": "Первый Московский мкр",
+            "id": 252280,
+            "locationTypeId": 174,
+            "name": "Первый Московский",
+            "shortName": "Первый Московский микрорайон",
+            "type": "location",
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&location%5B0%5D=252280&object_type%5B0%5D=2&offer_type=flat&room1=1"
+          },
+          {
+            "fullName": "Первый Московский ЖК",
+            "id": 312653,
+            "locationTypeId": 213,
+            "name": "Первый Московский",
+            "shortName": "Первый Московский жилой комплекс",
+            "type": "location",
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&location%5B0%5D=312653&object_type%5B0%5D=2&offer_type=flat&room1=1"
+          },
+          {
+            "fullName": "11-я фаза",
+            "id": 470077,
+            "locationTypeId": 308,
+            "name": "11-я",
+            "shortName": "11-я фаза",
+            "type": "location",
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&location%5B0%5D=470077&object_type%5B0%5D=2&offer_type=flat&room1=1"
+          }
+        ],
+        "coordinates": {
+          "lat": 55.606802608988,
+          "lng": 37.3612718295558
+        },
+        "highways": [
+          {
+            "name": "Киевское",
+            "distance": 7,
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&highway%5B0%5D=12&object_type%5B0%5D=2&offer_type=flat&room1=1",
+            "id": 12
+          },
+          {
+            "name": "Боровское",
+            "distance": 12,
+            "url": "https://www.cian.ru/cat.php?deal_type=sale&engine_version=2&highway%5B0%5D=2&object_type%5B0%5D=2&offer_type=flat&room1=1",
+            "id": 2
+          }
+        ],
+        "jk": {
+          "id": 1448,
+          "name": "Город-парк Первый Московский",
+          "developer": {
+            "name": "Абсолют Недвижимость"
+          },
+          "house": {
+            "id": 10922142,
+            "name": "6 корпус (11 квартал)"
+          },
+          "gaGeo": {
+            "moId": 0,
+            "oblId": 1,
+            "cityId": 1224131
+          },
+          "fullUrl": "https://www.cian.ru/zhiloy-kompleks-gorodpark-pervyy-moskovskiy-moskva-1448/",
+          "fullUrlTemplate": "{request_scheme}://zhk-gorod-park-pervyy-moskovskiy-i.{host}/",
+          "webSiteUrl": "https://www.absrealty.ru/projects/pervyj-moskovskij"
+        },
+        "railways": [
+          {
+            "id": 848,
+            "directionIds": [
+              14
+            ],
+            "distance": "5.0",
+            "time": 70,
+            "name": "Аэропорт Внуково",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 848,
+            "directionIds": [
+              14
+            ],
+            "distance": "6.0",
+            "time": 10,
+            "name": "Аэропорт Внуково",
+            "travelType": "byCar"
+          },
+          {
+            "id": 778,
+            "directionIds": [
+              14
+            ],
+            "distance": "6.0",
+            "time": 77,
+            "name": "Мичуринец",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 766,
+            "directionIds": [
+              14
+            ],
+            "distance": "6.0",
+            "time": 80,
+            "name": "Новопеределкино",
+            "travelType": "byFoot"
+          },
+          {
+            "id": 766,
+            "directionIds": [
+              14
+            ],
+            "distance": "7.0",
+            "time": 10,
+            "name": "Новопеределкино",
+            "travelType": "byCar"
+          },
+          {
+            "id": 778,
+            "directionIds": [
+              14
+            ],
+            "distance": "11.0",
+            "time": 17,
+            "name": "Мичуринец",
+            "travelType": "byCar"
+          }
+        ],
+        "undergrounds": [
+          {
+            "id": 367,
+            "name": "Рассказовка",
+            "lineColor": "FFDF00",
+            "travelType": "transport",
+            "travelTime": 6,
+            "url": "https://www.cian.ru/kupit-1-komnatnuyu-kvartiru-novostroyki-moskva-metro-rasskazovka/",
+            "underConstruction": false
+          },
+          {
+            "id": 366,
+            "name": "Новопеределкино",
+            "lineColor": "FFDF00",
+            "travelType": "transport",
+            "travelTime": 9,
+            "url": "https://www.cian.ru/kupit-1-komnatnuyu-kvartiru-novostroyki-moskva-metro-novoperedelkino-366/",
+            "underConstruction": false
+          },
+          {
+            "id": 535,
+            "name": "Аэропорт Внуково",
+            "lineColor": "FFDF00",
+            "travelType": "transport",
+            "travelTime": 9,
+            "url": "https://www.cian.ru/kupit-1-komnatnuyu-kvartiru-novostroyki-moskva-metro-aeroport-vnukovo/",
+            "underConstruction": false
+          }
+        ]
+      },
+      "id": 331002424,
+      "objectGuid": "66abc10c-00eb-4af2-8a67-d2c9359ba4e8",
+      "cianId": 331002424,
+      "userId": 134642318,
+      "publishedUserId": 134642318,
+      "cianUserId": 134642318,
+      "description": "Продается однокомнатная квартира  в 11 квартале города-парка \"Первый Московский\". \nОбщая площадь квартиры - 38,1 кв. м, этаж 12 из 22. \nПланируемый срок ввода в эксплуатацию - 3 квартал 2029 года. \nТип дома - монолитный. \n \nТОЛЬКО ДО 30 СЕНТЯБРЯ выгодные условия на приобретение квартиры в ипотеку. \n",
+      "photos": [
+        {
+          "id": 2953413873,
+          "isDefault": false,
+          "fullUrl": "https://images.cdn-cian.ru/images/2953413873-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/2953413873-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/2953413873-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/2953413873-3.jpg",
+          "isLayout": true,
+          "isCianLayout": false
+        },
+        {
+          "id": 2958331459,
+          "isDefault": false,
+          "fullUrl": "https://images.cdn-cian.ru/images/2958331459-1.jpg",
+          "thumbnailUrl": "https://images.cdn-cian.ru/images/2958331459-2.jpg",
+          "thumbnail2Url": "https://images.cdn-cian.ru/images/2958331459-4.jpg",
+          "miniUrl": "https://images.cdn-cian.ru/images/2958331459-3.jpg",
+          "isLayout": false,
+          "isCianLayout": false
+        }
+      ],
+      "phones": [
+        {
+          "countryCode": "+7",
+          "number": "9230727409"
+        }
+      ],
+      "publishTerms": {
+        "terms": [
+          {
+            "services": [
+              "paid"
+            ],
+            "days": 30,
+            "type": "periodical"
+          }
+        ],
+        "autoprolong": true
+      },
+      "flatType": "rooms",
+      "isApartments": false,
+      "totalArea": "38.1",
+      "kitchenArea": "16.6",
+      "allRoomsArea": "12.2",
+      "windowsViewType": "yard",
+      "combinedWcsCount": 1,
+      "decoration": "without",
+      "flags": {
+        "isArchived": false,
+        "isCommercialOwnershipVerified": false
+      },
+      "kpnChatEnabled": true,
+      "specialty": {
+        "types": [],
+        "additionalTypes": []
+      },
+      "isNeedHideExactAddress": false,
+      "areaParts": [],
+      "roomsCount": 1,
+      "floorNumber": 12,
+      "bargainTerms": {
+        "price": 11985439,
+        "priceType": "all",
+        "currency": "rur",
+        "mortgageAllowed": true,
+        "saleType": "fz214",
+        "includedOptions": [],
+        "prices": {
+          "rur": 11985439,
+          "usd": 138604,
+          "eur": 119260
+        },
+        "tags": []
+      },
+      "building": {
+        "materialType": "monolith",
+        "floorsCount": 22,
+        "ceilingHeight": "2.73",
+        "totalArea": "38.1",
+        "liftTypes": [],
+        "cranageTypes": [],
+        "passengerLiftsCount": 2,
+        "cargoLiftsCount": 2,
+        "deadline": {
+          "year": 2029,
+          "quarter": "third",
+          "isComplete": false,
+          "quarterEnd": "2029-09-30"
+        },
+        "houseMaterialType": "monolith"
+      },
+      "editDate": "2026-09-08T22:25:42.932744Z",
+      "humanizedEditDate": "вчера, 22:25",
+      "isInCpd": false,
+      "isInHiddenBase": false,
+      "isObjectHidden": false,
+      "isClosedVisibility": false,
+      "videos": [
+        {
+          "id": "456239331",
+          "url": "https://vkvideo.ru/video_ext.php?oid=-34496106&id=456239331&hd=2&hash=f1f6731c9fa8e20f",
+          "type": "vk",
+          "previewUrl": "https://iv.okcdn.ru/getVideoPreview?id=9276621916909&idx=12&type=39&tkn=7SPc820List5MGet0stC8R89t4A&fn=vid_w"
+        }
+      ],
+      "priceTotal": 11985439,
+      "priceTotalRur": 11985439,
+      "exportLinks": {
+        "pdfUrl": "/export/pdf/sale/flat/331002424/",
+        "docxUrl": "/export/docx/sale/flat/331002424/"
+      },
+      "passengerLiftsCount": 2,
+      "cargoLiftsCount": 2,
+      "added": "4 сен, 22:10",
+      "categoriesIds": [
+        1,
+        100,
+        110,
+        113
+      ],
+      "publicationDate": 1781196144,
+      "creationDate": "2026-06-11T19:42:24.507",
+      "recoveryLink": "/razmestit-obyavlenie/331002424/?isFromXML=1",
+      "isFromBuilder": true,
+      "isFromSeller": false,
+      "isFromLeadFactory": false,
+      "trackingData": {
+        "moId": 0,
+        "oblId": 1,
+        "cityId": 470077,
+        "fbRegion": "Москва",
+        "fbCity": "11-я"
+      },
+      "editPhoto": "/realty/add2.aspx?id=331002424&isFromXML=1",
+      "newEdit": "/razmestit-obyavlenie/?realty_id=331002424&isFromXML=1",
+      "certificate": "https://www.cian.ru/newobjects/cian/certification/get?announcementId=331002424",
+      "edit": "/realty/add1.aspx?id=331002424&isFromXML=1",
+      "similarOffersLink": "",
+      "similarOffersCount": 0,
+      "buildersIds": [
+        5956
+      ],
+      "builderId": 5956,
+      "isImported": true,
+      "userConfirmedFix": false,
+      "newbuilding": {
+        "id": 1448,
+        "name": "Город-парк Первый Московский",
+        "house": {
+          "isReliable": false,
+          "isFinished": false,
+          "finishDate": {
+            "quarter": 3,
+            "year": 2029
+          },
+          "id": 10922142,
+          "name": "6 корпус (11 квартал)"
+        },
+        "isTariffPremium": false,
+        "isFromDeveloper": true,
+        "isFromBuilder": true,
+        "isFromSeller": false,
+        "isFromLeadFactory": false,
+        "showJkReliableFlag": false,
+        "isFichering": true,
+        "isFicheringPlus": false,
+        "isPremium": false,
+        "newbuildingFeatures": {
+          "imagesCount": 44,
+          "firstImageUrl": "https://images.cdn-cian.ru/images/gorodpark-pervyy-moskovskiy-moskva-jk-2356445413-6.jpg",
+          "videosCount": 0,
+          "deadlineInfo": "Сдача в 2026—2030, есть сданные"
+        },
+        "isReliable": false
+      },
+      "timezone": 3,
+      "isEnabledCallTracking": true,
+      "isRentByParts": false,
+      "isDuplicate": false,
+      "userTrust": "notInvolved",
+      "userTrustLevel": "notInvolved",
+      "showWarningMessage": false,
+      "moderationInfo": {
+        "showContactWarningMessage": false
+      },
+      "isUnique": true,
+      "isUniqueCheckDate": "2026-09-08",
+      "isCianPartner": false,
+      "externalId": "26201587",
+      "isIllegalConstruction": false,
+      "amenities": [],
+      "isFromDeveloperBooked": false,
+      "layoutKey": "5799e19f-2152-4b38-937d-6e55ade846ca",
+      "externalOfferUrl": "",
+      "cianLayouts": null,
+      "demolishedInMoscowProgramm": false
+    },
+    "agent": {
+      "id": 134642318,
+      "cianUserId": 134642318,
+      "realtyUserId": 134642318,
+      "accountType": "agency",
+      "companyName": "Абсолют Недвижимость",
+      "creationDate": "2025-09-01T12:35:58.743000Z",
+      "name": "Абсолют Недвижимость",
+      "isPro": false,
+      "phones": [
+        {
+          "confirmed": true
+        },
+        {
+          "confirmed": true
+        }
+      ],
+      "skills": [],
+      "absoluteAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=72650908&t=2&p=2&timestamp=1766554569",
+      "absoluteMiniAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=72650908&t=2&p=1&timestamp=1766554569",
+      "isDeveloper": true,
+      "isRecidivist": false,
+      "isUserOffersHasErrors": false,
+      "offersCount": 1500,
+      "offersLink": "",
+      "availableServices": {
+        "isUploadsAvailable": true,
+        "isCallTrackingAvailable": false,
+        "isPhoneChangingAvailable": true,
+        "isServicePackagesAvailable": true,
+        "canUseHiddenBase": false
+      },
+      "userType": "developer",
+      "removeCompetitor": false,
+      "status": "published",
+      "isSubAgent": false,
+      "isMessagingEnabled": false,
+      "isPassportVerified": false,
+      "isSelfEmployed": false,
+      "isPrivateBroker": false,
+      "isCianPartner": false,
+      "canShowOnline": false,
+      "moderationInfo": {
+        "isUserIdentified": false,
+        "isUserIdentifiedByDocuments": false,
+        "showUserIdentifiedByDocuments": false
+      },
+      "isHidden": false,
+      "metrics": [
+        {
+          "title": "На Циан",
+          "value": "1 год"
+        },
+        {
+          "title": "Объектов в работе",
+          "value": "более 1000"
+        }
+      ],
+      "agentLists": []
+    },
+    "company": {
+      "buildersAuctionRank": 1638558426,
+      "buildingStatus": [
+        {
+          "count": 6,
+          "housesCount": 193,
+          "statusId": 5004
+        },
+        {
+          "count": 3,
+          "housesCount": 17,
+          "statusId": 5002
+        }
+      ],
+      "categoryId": 2002,
+      "description": "Девелоперская компания «Абсолют Недвижимость» является партнером Инвестиционной Группы «Абсолют» и реализует крупные инвестиционные проекты жилой и коммерческой недвижимости, земельных участков в Москве и ближнем Подмосковье. В основе успеха компании – многолетний опыт и инновационный подход в продажах, который обеспечивает высокий уровень обслуживания. Финансовыми партнерами являются крупнейшие банки России, в числе которых «Сбербанк», «ВТБ 24», «РайффайзенБанк», «Уралсиб», «Возрождение» и другие. В каждом жилом комплексе создается полноценная инфраструктура с современными детскими садами, школами, безопасными спортивными и детскими площадками, благоустроенными дворами и авторскими интерьерами входных групп. Крупные реализуемые проекты жилой недвижимости – это города-парки «Переделкино Ближнее» и «Первый Московский», жилые комплексы бизнес-класса «Западное Кунцево» и Резиденции «Сколково», жилые комплексы «Внуково», «Химки 2019», «Люберцы» и «Новоград Павлино». Среди коттеджных поселков известны «Александровы Пруды», «Лисичкин лес», «Певчее» и «Цветочный», из объектов коммерческой недвижимости – БЦ «Омега Плаза».",
+      "fromDeveloperPropsCount": 1499,
+      "hasSpecProject": false,
+      "id": 5956,
+      "isTest": false,
+      "locationIds": [
+        1,
+        338625,
+        1224131,
+        1268067,
+        1224136,
+        1226664,
+        58347,
+        312814,
+        4593,
+        191990,
+        1268058
+      ],
+      "logoUrl": "/api/get-company-logo/?id=5956&rnd=405447",
+      "maxBet": 4000,
+      "name": "Абсолют Недвижимость",
+      "newobjectsCount": 6,
+      "offersCount": 1501,
+      "phones": [],
+      "promoCount": 0,
+      "specProjectNewobjectsCount": 0,
+      "status": 12,
+      "website": "http://www.absrealty.ru/",
+      "yearFoundation": 1990,
+      "url": "/zastroishchik-absoliut-nedvizhimost-5956/",
+      "isReliable": true,
+      "stats": {
+        "housesDone": {
+          "housesCount": 193,
+          "newbuildingCount": 6,
+          "qs": "builder=5956&deal_type=sale&engine_version=2&offer_type=newobject&show_old_newobjects=1&status[0]=5004"
+        },
+        "housesInProgress": {
+          "housesCount": 17,
+          "newbuildingCount": 3,
+          "qs": "builder=5956&deal_type=sale&engine_version=2&offer_type=newobject&status[0]=5002"
+        },
+        "newbuildingCount": {
+          "qs": "builder=5956&deal_type=sale&engine_version=2&offer_type=newobject&show_old_newobjects=1",
+          "text": "ЖК",
+          "value": 6
+        },
+        "newbuildingWithOffers": {
+          "qs": "builders[0]=5956&deal_type=sale&engine_version=2&from_developer=1&offer_type=newobject&show_old_newobjects=1",
+          "text": "ЖК в реализации",
+          "value": 3
+        }
+      },
+      "headerImageUrl": "https://images.cdn-cian.ru/images/gorodpark-pervyy-moskovskiy-moskva-jk-2356445413-10.jpg",
+      "newbuildingIds": [
+        1611,
+        1287,
+        1448,
+        1446,
+        1609,
+        5799
+      ],
+      "advantages": [],
+      "workYears": {
+        "text": "лет на рынке",
+        "value": 36
+      },
+      "reviewStats": {
+        "reviewCount": 532,
+        "reviewCountText": "532 отзыва",
+        "totalRate": 4.6
+      },
+      "email": null,
+      "emailForRequest": null
+    },
+    "user": {
+      "realtyUserId": null,
+      "isAuthenticated": false,
+      "permissions": {
+        "canModerateUsers": false,
+        "canModerateAnnouncements": false,
+        "canModerateAnnouncementsExpert": false,
+        "canViewUsers": false,
+        "canViewAnnouncements": false
+      },
+      "ga": {
+        "type": "",
+        "balance": 0,
+        "packages": [],
+        "emailMd5": ""
+      }
+    },
+    "priceChanges": [
+      {
+        "changeTime": "2026-09-01T19:14:33.257248Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 11985439
+        }
+      },
+      {
+        "changeTime": "2026-07-15T11:21:37.194579Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 11866772
+        }
+      },
+      {
+        "changeTime": "2026-07-01T16:16:07.692597Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 11633130
+        }
+      },
+      {
+        "changeTime": "2026-06-11T16:42:25.033456Z",
+        "priceData": {
+          "currency": "rur",
+          "price": 12417574
+        }
+      }
+    ],
+    "stats": {
+      "totalViewsFormattedString": "12907 просмотров, 98 за сегодня"
+    }
+  }
+}

--- a/packages/cian-connector/tests/fixtures/card_sale_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/card_sale_live.provenance.json
@@ -1,0 +1,12 @@
+{
+  "captured": "2026-09-09",
+  "page": "https://www.cian.ru/sale/flat/331002424/",
+  "source": "window._cianConfig['frontend-offer-card'] -> defaultState.offerData",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "displayed": {
+    "title": "Продажа однокомнатной квартиры 38.1м² Москва, НАО (Новомосковский), Московский, Первый Московский микрорайон, Первый Московский жилой комплекс, 11-я фаза м. Рассказовка - база ЦИАН, объявление 331002424",
+    "price": 11985439,
+    "priceRur": null
+  },
+  "trimmed": "offerData reduced to offer/agent/company/user/priceChanges/stats; description 300 chars; photos 2"
+}

--- a/packages/cian-connector/tests/fixtures/search_daily_live.json
+++ b/packages/cian-connector/tests/fixtures/search_daily_live.json
@@ -1,0 +1,2114 @@
+{
+  "status": "ok",
+  "data": {
+    "jsonQuery": {
+      "_type": "flatrent",
+      "engine_version": {
+        "type": "term",
+        "value": 2
+      },
+      "region": {
+        "type": "terms",
+        "value": [
+          1
+        ]
+      },
+      "page": {
+        "type": "term",
+        "value": 1
+      },
+      "for_day": {
+        "type": "term",
+        "value": "1"
+      }
+    },
+    "offerCount": 53453,
+    "aggregatedCount": 53441,
+    "offersSerialized": [
+      {
+        "descriptionMinhash": [
+          23631867,
+          8359824,
+          13184479,
+          31312792,
+          14030143,
+          107167424,
+          81907297,
+          2885405,
+          56920750,
+          37900519,
+          43445225,
+          39685766,
+          15850973,
+          4384957,
+          82870207,
+          15438368,
+          2237706,
+          105139689,
+          22218893,
+          55439485,
+          58035355,
+          41607337,
+          49312433,
+          38907129,
+          14007984,
+          12001902,
+          19658598,
+          77941595,
+          94368730,
+          65083295,
+          28700681,
+          69063018
+        ],
+        "jkUrl": "https://zhk-fili-grad-i.cian.ru/",
+        "externalId": null,
+        "similar": null,
+        "basicProfiScore": 0,
+        "isInHiddenBase": false,
+        "formattedFullPrice": "от 5 000 ₽/сут.",
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1113
+        ],
+        "id": 191071633,
+        "formattedFullInfo": "1-комн.кв.  ·  32,4 м²  ·  25/25 этаж",
+        "isSubsidisedMortgage": null,
+        "isApartments": false,
+        "showWarningMessage": false,
+        "roomsForSaleCount": null,
+        "monthlyIncome": null,
+        "isTop3": true,
+        "accessType": null,
+        "newbuildingVasPromotion": null,
+        "photos": [
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-4.jpg",
+            "isDefault": true,
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-2.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-3.jpg",
+            "rotateDegree": null,
+            "id": 2742596853,
+            "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-beregovoy-proezd-2742596853-1.jpg",
+            "isLayout": null
+          },
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-4.jpg",
+            "isDefault": false,
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-2.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-3.jpg",
+            "rotateDegree": null,
+            "id": 530398203,
+            "fullUrl": "https://images.cdn-cian.ru/images/2/893/035/kvartira-moskva-beregovoy-proezd-530398203-1.jpg",
+            "isLayout": null
+          }
+        ],
+        "descriptionWordsHighlighted": [],
+        "shareAmount": null,
+        "creationDate": "2018-07-30T18:33:53.143",
+        "roomArea": null,
+        "publishedUserId": 17548313,
+        "hasFurniture": true,
+        "formattedShortInfo": "1-комн.кв.  ·  25/25 этаж",
+        "geo": {
+          "userInput": "Россия, Москва, Береговой проезд, 5Ак2",
+          "countryId": 138,
+          "districts": [
+            {
+              "name": "Филевский парк",
+              "qs": "deal_type=rent&district%5B0%5D=123&engine_version=2&offer_type=flat&type=2",
+              "parentId": 11,
+              "type": "raion",
+              "fullName": "р-н Филевский парк",
+              "id": 123,
+              "locationId": 1,
+              "geoType": "district",
+              "title": "р-н Филевский парк"
+            },
+            {
+              "name": "ЗАО",
+              "qs": "deal_type=rent&district%5B0%5D=11&engine_version=2&offer_type=flat&type=2",
+              "parentId": null,
+              "type": "okrug",
+              "fullName": "ЗАО",
+              "id": 11,
+              "locationId": 1,
+              "geoType": "district",
+              "title": "ЗАО"
+            }
+          ],
+          "highways": [],
+          "address": [
+            {
+              "name": "Москва",
+              "shortName": "Москва",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&region=1&type=2",
+              "isFormingAddress": true,
+              "geoType": "location",
+              "type": "location",
+              "fullName": "Москва",
+              "id": 1,
+              "locationTypeId": 1,
+              "title": "Москва"
+            },
+            {
+              "name": "ЗАО",
+              "shortName": "ЗАО",
+              "qs": "deal_type=rent&district%5B0%5D=11&engine_version=2&offer_type=flat&type=2",
+              "isFormingAddress": null,
+              "geoType": "district",
+              "type": "okrug",
+              "fullName": "ЗАО",
+              "id": 11,
+              "locationTypeId": null,
+              "title": "ЗАО"
+            },
+            {
+              "name": "Филевский парк",
+              "shortName": "р-н Филевский парк",
+              "qs": "deal_type=rent&district%5B0%5D=123&engine_version=2&offer_type=flat&type=2",
+              "isFormingAddress": null,
+              "geoType": "district",
+              "type": "raion",
+              "fullName": "р-н Филевский парк",
+              "id": 123,
+              "locationTypeId": null,
+              "title": "р-н Филевский парк"
+            },
+            {
+              "name": "Фили",
+              "shortName": "м. Фили",
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=142&offer_type=flat&only_foot=2&type=2",
+              "isFormingAddress": null,
+              "geoType": "underground",
+              "type": "metro",
+              "fullName": "м. Фили",
+              "id": 142,
+              "locationTypeId": null,
+              "title": "м. Фили"
+            },
+            {
+              "name": "Береговой",
+              "shortName": "Береговой проезд",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&street%5B0%5D=684&type=2",
+              "isFormingAddress": true,
+              "geoType": "street",
+              "type": "street",
+              "fullName": "Береговой проезд",
+              "id": 684,
+              "locationTypeId": null,
+              "title": "Береговой проезд"
+            },
+            {
+              "name": "5Ак2",
+              "shortName": "5Ак2",
+              "qs": "deal_type=rent&engine_version=2&house%5B0%5D=3067547&offer_type=flat&type=2",
+              "isFormingAddress": true,
+              "geoType": "house",
+              "type": "house",
+              "fullName": "5Ак2",
+              "id": 3067547,
+              "locationTypeId": null,
+              "title": "5Ак2"
+            }
+          ],
+          "railways": [
+            {
+              "name": "Фили",
+              "travelType": "byCar",
+              "time": 5,
+              "directionIds": [
+                11
+              ],
+              "id": 708,
+              "geoType": "railway",
+              "distance": 2.0,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=708&type=2"
+            },
+            {
+              "name": "Тестовская",
+              "travelType": "byCar",
+              "time": 8,
+              "directionIds": [
+                11
+              ],
+              "id": 707,
+              "geoType": "railway",
+              "distance": 4.0,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=707&type=2"
+            },
+            {
+              "name": "Москва-Сортировочная",
+              "travelType": "byCar",
+              "time": 18,
+              "directionIds": [
+                14
+              ],
+              "id": 706,
+              "geoType": "railway",
+              "distance": 11.0,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=706&type=2"
+            }
+          ],
+          "undergrounds": [
+            {
+              "name": "Фили",
+              "lineColor": "009BD5",
+              "underConstruction": false,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=142&offer_type=flat&only_foot=2&type=2",
+              "isDefault": true,
+              "releaseYear": null,
+              "time": 14,
+              "lineId": 12,
+              "id": 142,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Шелепиха",
+              "lineColor": "7ACDCE",
+              "underConstruction": false,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=453&offer_type=flat&only_foot=2&type=2",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 19,
+              "lineId": 27,
+              "id": 453,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Шелепиха",
+              "lineColor": "FA6F9E",
+              "underConstruction": false,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=311&offer_type=flat&only_foot=2&type=2",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 19,
+              "lineId": 22,
+              "id": 311,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": "mck"
+            }
+          ],
+          "jk": {
+            "name": "Фили Град",
+            "house": {
+              "name": "Береговой, 5Ак2",
+              "id": 2790
+            },
+            "developer": null,
+            "gaGeo": {
+              "moId": 0,
+              "cityId": 1,
+              "oblId": 1
+            },
+            "webSiteUrl": null,
+            "displayName": "ЖК «Фили Град»",
+            "id": 5489,
+            "fullUrl": "https://zhk-fili-grad-i.cian.ru/",
+            "webSiteUrlUtm": null
+          },
+          "buildingAddress": null,
+          "coordinates": {
+            "lat": 55.755459,
+            "lng": 37.509334
+          },
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 142
+            },
+            {
+              "type": "underground",
+              "id": 453
+            },
+            {
+              "type": "underground",
+              "id": 311
+            },
+            {
+              "type": "railway",
+              "id": 708
+            },
+            {
+              "type": "railway",
+              "id": 707
+            },
+            {
+              "type": "railway",
+              "id": 706
+            },
+            {
+              "type": "district",
+              "id": 123
+            },
+            {
+              "type": "district",
+              "id": 11
+            }
+          ]
+        },
+        "loggiasCount": null,
+        "newbuilding": {
+          "name": "Фили Град",
+          "house": {
+            "name": "Береговой, 5Ак2",
+            "isFinished": true,
+            "section": null,
+            "finishDate": {
+              "year": 2017,
+              "quarter": 3
+            },
+            "id": 2790
+          },
+          "isFichering": false,
+          "isSalesLeader": null,
+          "isFromBuilder": false,
+          "isFromDeveloper": false,
+          "isFromLeadFactory": false,
+          "isFromSeller": false,
+          "id": 5489,
+          "showJkReliableFlag": false,
+          "comparisonStatus": null,
+          "hasFlatTourBooking": false,
+          "isPremium": false
+        },
+        "isCalltrackingEnabled": true,
+        "buildingCadastralNumber": null,
+        "land": null,
+        "commercialOwnership": null,
+        "rentByPartsDescription": null,
+        "workTimeInfo": null,
+        "permittedUseType": null,
+        "isInCpd": null,
+        "formattedAdditionalInfo": "Посуточно",
+        "description": "Сдается квартира - студия в современном комплексе бизнес класса ЖК Филиград. В квартире можно расположить до 4 человек. Оборудована всем необходимым для комфортного проживания:\n- Холодильник\n- Посудомоечная,стиральная машины,микроволновая \nпечь,эл.чайник .\n-кондиционер ( сплит - система )!!!\n-ТВ,Wi-",
+        "isCommercialOwnershipVerified": null,
+        "dealType": "rent",
+        "isAuction": true,
+        "rosreestrCheck": null,
+        "booking": null,
+        "offerType": "flat",
+        "fromDeveloper": null,
+        "newbuildingCplLayer": null,
+        "buildersIds": [
+          6008
+        ],
+        "fullUrl": "https://www.cian.ru/rent/flat/191071633/?mlSearchSessionGuid=0a844ba9ae762b9fe351e5219e161d42",
+        "roomsCount": 1,
+        "offerInDeal": false,
+        "offerFeatureLabelsV2": null,
+        "bargainTerms": {
+          "paymentPeriod": null,
+          "clientFee": null,
+          "saleType": null,
+          "priceType": "all",
+          "utilitiesTerms": {
+            "includedInPrice": true,
+            "price": 0,
+            "flowMetersNotIncludedInPrice": null
+          },
+          "vatPrice": null,
+          "agentFee": null,
+          "price": 5000,
+          "priceRur": 5000,
+          "priceForWorkplace": null,
+          "leaseTermType": null,
+          "agentBonus": null,
+          "vatType": null,
+          "tags": [],
+          "mortgageAllowed": null,
+          "leaseType": null,
+          "bargainAllowed": null,
+          "deposit": null,
+          "currency": "rur"
+        },
+        "isColorized": false,
+        "minArea": null,
+        "auction": {},
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9230758879"
+          }
+        ],
+        "isImported": false,
+        "flatType": "rooms",
+        "layout": null,
+        "dealRentVersion": null,
+        "coworking": null,
+        "kitchenArea": null,
+        "cianUserId": 17548313,
+        "isNeedHideExactAddress": false,
+        "isRecidivist": false,
+        "isCianPartner": false,
+        "villageMortgageAllowed": null,
+        "totalArea": "32.4",
+        "addedTimestamp": 1788977130,
+        "category": "dailyFlatRent",
+        "building": {
+          "cargoLiftsCount": 2,
+          "heatingType": null,
+          "materialType": "monolith",
+          "deadline": null,
+          "passengerLiftsCount": null,
+          "floorsCount": 25,
+          "type": null,
+          "buildYear": 2017,
+          "classType": null,
+          "parking": null,
+          "accessType": null
+        },
+        "newbuildingWithExtendedFeatures": null,
+        "businessShoppingCenter": null,
+        "isPremium": false,
+        "balconiesCount": null,
+        "status": "published",
+        "floorNumber": 25,
+        "isBookedFromDeveloper": false,
+        "humanizedTimedelta": "вчера",
+        "isByHomeowner": false,
+        "garage": null,
+        "readyBusinessType": null,
+        "coworkingOfferType": null,
+        "moderationInfo": {
+          "showContactWarningMessage": false,
+          "warningMessage": null,
+          "photoStub": null
+        },
+        "isNew": false,
+        "areaParts": null,
+        "cianId": 191071633,
+        "allFromOffrep": null,
+        "videos": [],
+        "kp": null,
+        "bedroomsCount": null,
+        "isStandard": false,
+        "decoration": null,
+        "officeType": null,
+        "isEarlyAccessEnabled": false,
+        "livingArea": null,
+        "title": null,
+        "specialty": {
+          "types": [],
+          "additionalTypes": [],
+          "specialties": []
+        },
+        "workplaceCount": null,
+        "demolishedInMoscowProgramm": null,
+        "cadastralNumber": null,
+        "promoInfo": null,
+        "tradingLink": null,
+        "isRentByParts": false,
+        "isByCommercialOwner": null,
+        "added": "вчера, 21:05",
+        "userId": 17548313,
+        "isExcludedFromAction": false,
+        "isLayoutApproved": null,
+        "formattedShortPrice": "от 5 000 ₽/сут.",
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "17548313",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": true,
+          "isSubAgent": false,
+          "userId": 17548313,
+          "userTrustLevel": "notInvolved",
+          "accountType": "specialist",
+          "agencyName": "Наталья  Ярышкина",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": false,
+              "isSuperHost": true,
+              "levelName": "Суперхозяин",
+              "levelOrder": 4,
+              "levelSystemName": "max",
+              "showSuperAgent": false,
+              "showHighResponsibility": true,
+              "showSuperHost": true
+            },
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 0,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Москва и ближнее Подмосковье",
+                "locationId": 1,
+                "packageTypeId": 1,
+                "packageTypeName": "Некоммерческий"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9128541333"
+            }
+          ],
+          "profileUri": "agents/17548313/",
+          "userType": "realtor_not_commerce",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 17548313,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": false,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=1/city_id=1/object_type=1/ga_obj_type=1/spec=agent/rent_type=daily/191071633/from_developer=0/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid4": "offer_type_1",
+          "puid5": "obl_id_1",
+          "puid6": "1_50",
+          "puid7": "2323",
+          "puid8": 5000,
+          "puid9": 142,
+          "puid10": "no_agent",
+          "puid16": "true",
+          "puid17": "true",
+          "puid18": 5489,
+          "puid19": "not_video",
+          "puid36": 1
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "Сдан"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "Береговой, 5Ак2"
+          }
+        ],
+        "dailyrent": {
+          "actionType": "otaCheckDates",
+          "hotelData": {
+            "isHotel": false
+          },
+          "isOnlineBooking": true,
+          "isVerifiedByCian": true,
+          "offerLabels": [
+            "instantBooking"
+          ],
+          "priceInfo": {
+            "finalPrice": "5 000 ₽",
+            "finalPricePerNight": "от 5 000 ₽/сут."
+          },
+          "realtyId": 191071633,
+          "guestsInfo": {
+            "guestsCount": 1,
+            "maxGuestsCount": 4
+          },
+          "rating": {
+            "rating": "5,0",
+            "reviewsCount": "7 отзывов"
+          }
+        },
+        "isVerifiedByCian": true,
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "newbuildingDynamicCalltracking": {
+          "siteBlockId": null,
+          "newbuildingId": null
+        },
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      },
+      {
+        "descriptionMinhash": [
+          343527,
+          3173382,
+          3583066,
+          4831008,
+          29331269,
+          36150648,
+          10357415,
+          20606574,
+          11679811,
+          37900519,
+          22560835,
+          17304062,
+          14490383,
+          27405120,
+          77425371,
+          90946905,
+          14850229,
+          11649512,
+          61898119,
+          25534808,
+          40632402,
+          6596859,
+          944162,
+          5837452,
+          36465122,
+          11152441,
+          8088586,
+          17358135,
+          23909840,
+          18561244,
+          16575688,
+          15067180
+        ],
+        "loggiasCount": null,
+        "isColorized": false,
+        "description": "Атмосфера Монако в центре Москвы.\n\nДобро пожаловать в пространство, где роскошь встречается с искусством, а каждый день начинается с панорамного вида на Москва-Сити.\n\nНовая трехкомнатная квартира премиум-класса в ЦАО, расположенная в современном жилом комплексе бизнес-класса Хедлайнер, создана для т",
+        "businessShoppingCenter": null,
+        "booking": null,
+        "isSubsidisedMortgage": null,
+        "videos": [
+          {
+            "uploadDate": null,
+            "id": "4d343c8f-a6ae-4fcd-b594-3bd371ea2384",
+            "duration": 12,
+            "url": "https://kinescope.io/embed/awWDmedrUywuYjj45dKMNd",
+            "previewUrl": "https://kinescopecdn.net/f9f281e3-5528-474a-b760-2c5cecf2ce98/posters/d5adca8e-f78c-42fa-88e1-dea3983f7fdf/md/01a047ad-db47-7c72-9d3e-3145301c0700.jpg",
+            "type": "kinescope"
+          }
+        ],
+        "garage": null,
+        "balconiesCount": null,
+        "decoration": null,
+        "similar": null,
+        "isInHiddenBase": false,
+        "roomsCount": 3,
+        "isRentByParts": false,
+        "totalArea": "77.0",
+        "isExcludedFromAction": false,
+        "fullUrl": "https://www.cian.ru/rent/flat/331744103/?mlSearchSessionGuid=0a844ba9ae762b9fe351e5219e161d42",
+        "moderationInfo": {
+          "showContactWarningMessage": false,
+          "warningMessage": null,
+          "photoStub": null
+        },
+        "isStandard": false,
+        "auction": {},
+        "rentByPartsDescription": null,
+        "offerInDeal": false,
+        "tradingLink": null,
+        "isPremium": false,
+        "workTimeInfo": null,
+        "promoInfo": null,
+        "building": {
+          "heatingType": null,
+          "classType": null,
+          "buildYear": null,
+          "deadline": null,
+          "floorsCount": 53,
+          "parking": null,
+          "materialType": null,
+          "accessType": null,
+          "type": null,
+          "cargoLiftsCount": null,
+          "passengerLiftsCount": null
+        },
+        "kp": null,
+        "buildingCadastralNumber": null,
+        "bargainTerms": {
+          "clientFee": null,
+          "bargainAllowed": null,
+          "saleType": null,
+          "priceType": "all",
+          "price": 15000,
+          "utilitiesTerms": {
+            "includedInPrice": true,
+            "price": 0,
+            "flowMetersNotIncludedInPrice": null
+          },
+          "paymentPeriod": null,
+          "agentFee": null,
+          "currency": "rur",
+          "vatType": null,
+          "agentBonus": null,
+          "leaseType": null,
+          "priceRur": 15000,
+          "deposit": 10000,
+          "mortgageAllowed": null,
+          "tags": [],
+          "leaseTermType": null,
+          "priceForWorkplace": null,
+          "vatPrice": null
+        },
+        "rosreestrCheck": null,
+        "isInCpd": null,
+        "basicProfiScore": 1,
+        "specialty": {
+          "specialties": [],
+          "types": [],
+          "additionalTypes": []
+        },
+        "formattedFullPrice": "от 15 000 ₽/сут.",
+        "commercialOwnership": null,
+        "isTop3": true,
+        "formattedFullInfo": "3-комн.кв.  ·  77 м²  ·  5/53 этаж",
+        "isCalltrackingEnabled": true,
+        "publishedUserId": 82978482,
+        "land": null,
+        "isNeedHideExactAddress": false,
+        "formattedShortInfo": "3-комн.кв.  ·  5/53 этаж",
+        "title": "Премиум апартаменты Монако",
+        "layout": null,
+        "isBookedFromDeveloper": false,
+        "permittedUseType": null,
+        "isNew": false,
+        "minArea": null,
+        "category": "dailyFlatRent",
+        "status": "published",
+        "allFromOffrep": null,
+        "coworking": null,
+        "externalId": null,
+        "formattedAdditionalInfo": "Залог 10 000 ₽, посуточно",
+        "cianId": 331744103,
+        "demolishedInMoscowProgramm": null,
+        "isLayoutApproved": null,
+        "geo": {
+          "jk": {
+            "house": {
+              "name": "Шмитовский, 39к8 (Корпус 10)",
+              "id": 581734
+            },
+            "id": 26654,
+            "gaGeo": {
+              "oblId": 1,
+              "moId": 0,
+              "cityId": 1
+            },
+            "displayName": "ЖК «Headliner»",
+            "name": "Headliner",
+            "fullUrl": "https://zhk-headliner-i.cian.ru/",
+            "developer": null,
+            "webSiteUrlUtm": null,
+            "webSiteUrl": null
+          },
+          "undergrounds": [
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 512,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=512&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 6,
+              "lineId": 34,
+              "lineColor": "40B280",
+              "isDefault": true,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mcd4"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 311,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=311&offer_type=flat&only_foot=2&type=2",
+              "name": "Шелепиха",
+              "time": 8,
+              "lineId": 22,
+              "lineColor": "FA6F9E",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mck"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 35,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=35&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 12,
+              "lineId": 12,
+              "lineColor": "009BD5",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 453,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=453&offer_type=flat&only_foot=2&type=2",
+              "name": "Шелепиха",
+              "time": 12,
+              "lineId": 27,
+              "lineColor": "7ACDCE",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 400,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=400&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 19,
+              "lineId": 30,
+              "lineColor": "DE9C4E",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mcd1"
+            }
+          ],
+          "coordinates": {
+            "lng": 37.525827,
+            "lat": 55.752425
+          },
+          "districts": [
+            {
+              "id": 18,
+              "locationId": 1,
+              "qs": "deal_type=rent&district%5B0%5D=18&engine_version=2&offer_type=flat&type=2",
+              "parentId": 4,
+              "title": "р-н Пресненский",
+              "name": "Пресненский",
+              "fullName": "р-н Пресненский",
+              "type": "raion",
+              "geoType": "district"
+            },
+            {
+              "id": 4,
+              "locationId": 1,
+              "qs": "deal_type=rent&district%5B0%5D=4&engine_version=2&offer_type=flat&type=2",
+              "parentId": null,
+              "title": "ЦАО",
+              "name": "ЦАО",
+              "fullName": "ЦАО",
+              "type": "okrug",
+              "geoType": "district"
+            }
+          ],
+          "buildingAddress": null,
+          "countryId": 138,
+          "userInput": "Россия, Москва, Шмитовский проезд, 39к8",
+          "address": [
+            {
+              "isFormingAddress": true,
+              "id": 1,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&region=1&type=2",
+              "title": "Москва",
+              "name": "Москва",
+              "fullName": "Москва",
+              "shortName": "Москва",
+              "type": "location",
+              "locationTypeId": 1,
+              "geoType": "location"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 4,
+              "qs": "deal_type=rent&district%5B0%5D=4&engine_version=2&offer_type=flat&type=2",
+              "title": "ЦАО",
+              "name": "ЦАО",
+              "fullName": "ЦАО",
+              "shortName": "ЦАО",
+              "type": "okrug",
+              "locationTypeId": null,
+              "geoType": "district"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 18,
+              "qs": "deal_type=rent&district%5B0%5D=18&engine_version=2&offer_type=flat&type=2",
+              "title": "р-н Пресненский",
+              "name": "Пресненский",
+              "fullName": "р-н Пресненский",
+              "shortName": "р-н Пресненский",
+              "type": "raion",
+              "locationTypeId": null,
+              "geoType": "district"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 512,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=512&offer_type=flat&only_foot=2&type=2",
+              "title": "м. Москва-Сити",
+              "name": "Москва-Сити",
+              "fullName": "м. Москва-Сити",
+              "shortName": "м. Москва-Сити",
+              "type": "metro",
+              "locationTypeId": null,
+              "geoType": "underground"
+            },
+            {
+              "isFormingAddress": true,
+              "id": 2456,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&street%5B0%5D=2456&type=2",
+              "title": "Шмитовский проезд",
+              "name": "Шмитовский",
+              "fullName": "Шмитовский проезд",
+              "shortName": "Шмитовский проезд",
+              "type": "street",
+              "locationTypeId": null,
+              "geoType": "street"
+            },
+            {
+              "isFormingAddress": true,
+              "id": 906981,
+              "qs": "deal_type=rent&engine_version=2&house%5B0%5D=906981&offer_type=flat&type=2",
+              "title": "39к8",
+              "name": "39к8",
+              "fullName": "39к8",
+              "shortName": "39к8",
+              "type": "house",
+              "locationTypeId": null,
+              "geoType": "house"
+            }
+          ],
+          "railways": [
+            {
+              "id": 707,
+              "travelType": "byFoot",
+              "name": "Тестовская",
+              "time": 15,
+              "distance": 1.0,
+              "directionIds": [
+                11
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=707&type=2"
+            },
+            {
+              "id": 708,
+              "travelType": "byCar",
+              "name": "Фили",
+              "time": 5,
+              "distance": 2.0,
+              "directionIds": [
+                11
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=708&type=2"
+            },
+            {
+              "id": 699,
+              "travelType": "byCar",
+              "name": "Беговая",
+              "time": 8,
+              "distance": 5.0,
+              "directionIds": [
+                11
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=699&type=2"
+            }
+          ],
+          "highways": [],
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 512
+            },
+            {
+              "type": "underground",
+              "id": 311
+            },
+            {
+              "type": "underground",
+              "id": 35
+            },
+            {
+              "type": "underground",
+              "id": 453
+            },
+            {
+              "type": "underground",
+              "id": 400
+            },
+            {
+              "type": "railway",
+              "id": 707
+            },
+            {
+              "type": "railway",
+              "id": 708
+            },
+            {
+              "type": "railway",
+              "id": 699
+            },
+            {
+              "type": "district",
+              "id": 18
+            },
+            {
+              "type": "district",
+              "id": 4
+            }
+          ]
+        },
+        "accessType": null,
+        "readyBusinessType": null,
+        "newbuildingVasPromotion": null,
+        "added": "3 сен, 21:43",
+        "isImported": false,
+        "officeType": null,
+        "newbuildingWithExtendedFeatures": null,
+        "roomsForSaleCount": null,
+        "floorNumber": 5,
+        "humanizedTimedelta": "шесть дней назад",
+        "photos": [
+          {
+            "isLayout": false,
+            "id": 2957365075,
+            "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365075-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365075-2.jpg",
+            "isDefault": true,
+            "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365075-1.jpg",
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365075-4.jpg",
+            "rotateDegree": null
+          },
+          {
+            "isLayout": false,
+            "id": 2957365383,
+            "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365383-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365383-2.jpg",
+            "isDefault": false,
+            "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365383-1.jpg",
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-shmitovskiy-proezd-2957365383-4.jpg",
+            "rotateDegree": null
+          }
+        ],
+        "dealType": "rent",
+        "coworkingOfferType": null,
+        "roomArea": null,
+        "areaParts": null,
+        "newbuilding": {
+          "house": {
+            "id": 581734,
+            "name": "Шмитовский, 39к8 (Корпус 10)",
+            "finishDate": {
+              "quarter": 1,
+              "year": 2023
+            },
+            "isFinished": true,
+            "section": null
+          },
+          "isFichering": false,
+          "id": 26654,
+          "isFromSeller": false,
+          "showJkReliableFlag": false,
+          "name": "Headliner (Хедлайнер)",
+          "comparisonStatus": null,
+          "isSalesLeader": null,
+          "isFromBuilder": false,
+          "isFromLeadFactory": false,
+          "isPremium": false,
+          "isFromDeveloper": false,
+          "hasFlatTourBooking": false
+        },
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9810868105"
+          }
+        ],
+        "cadastralNumber": null,
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1113
+        ],
+        "descriptionWordsHighlighted": [],
+        "monthlyIncome": null,
+        "villageMortgageAllowed": null,
+        "addedTimestamp": 1788461005,
+        "formattedShortPrice": "от 15 000 ₽/сут.",
+        "dealRentVersion": null,
+        "newbuildingCplLayer": null,
+        "livingArea": null,
+        "fromDeveloper": null,
+        "creationDate": "2026-07-06T18:35:20.627",
+        "isCommercialOwnershipVerified": null,
+        "kitchenArea": null,
+        "isByCommercialOwner": null,
+        "isRecidivist": false,
+        "workplaceCount": null,
+        "isEarlyAccessEnabled": false,
+        "isAuction": true,
+        "showWarningMessage": false,
+        "userId": 82978482,
+        "jkUrl": "https://zhk-headliner-i.cian.ru/",
+        "offerFeatureLabelsV2": null,
+        "bedroomsCount": null,
+        "isByHomeowner": false,
+        "offerType": "flat",
+        "isApartments": false,
+        "id": 331744103,
+        "isCianPartner": false,
+        "hasFurniture": null,
+        "cianUserId": 82978482,
+        "shareAmount": null,
+        "buildersIds": [
+          7043
+        ],
+        "flatType": "rooms",
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "82978482",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": false,
+          "isSubAgent": false,
+          "userId": 82978482,
+          "userTrustLevel": "involved",
+          "accountType": "agency",
+          "agencyName": "Алис",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=48440392&t=2&p=2&timestamp=1769078938",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": true,
+              "isSuperHost": true,
+              "levelName": "Суперагент",
+              "levelOrder": 4,
+              "levelSystemName": "max",
+              "showSuperAgent": false,
+              "showHighResponsibility": true,
+              "showSuperHost": true
+            },
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 1,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Россия",
+                "packageTypeId": 2,
+                "packageTypeName": "Базовый"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "Алис",
+          "experience": "2019",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9645593399"
+            },
+            {
+              "countryCode": "+7",
+              "number": "4950329232"
+            }
+          ],
+          "profileUri": "company/82978482/",
+          "userType": "realtor_based",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 82978482,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": true,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=1/city_id=1/object_type=1/ga_obj_type=3/spec=company/rent_type=daily/331744103/from_developer=0/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid4": "offer_type_3",
+          "puid5": "obl_id_1",
+          "puid6": "1_50",
+          "puid7": "2323",
+          "puid8": 15000,
+          "puid9": 512,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid18": 26654,
+          "puid19": "not_video",
+          "puid36": 1
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": true,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [
+          {
+            "type": "hasVideo",
+            "text": "Объявление с видео",
+            "link": "https://www.cian.ru/rent/flat/331744103/"
+          }
+        ],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "Сдан"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "Шмитовский, 39к8 (Корпус 10)"
+          }
+        ],
+        "dailyrent": {
+          "actionType": "otaCheckDates",
+          "hotelData": {
+            "isHotel": false
+          },
+          "isOnlineBooking": true,
+          "isVerifiedByCian": true,
+          "offerLabels": [
+            "instantBooking"
+          ],
+          "priceInfo": {
+            "finalPrice": "15 000 ₽",
+            "finalPricePerNight": "от 15 000 ₽/сут."
+          },
+          "realtyId": 331744103,
+          "guestsInfo": {
+            "guestsCount": 1,
+            "maxGuestsCount": 4
+          }
+        },
+        "isVerifiedByCian": true,
+        "brandingLevel": "thirdLevel",
+        "isRosreestrChecked": false,
+        "newbuildingDynamicCalltracking": {
+          "siteBlockId": null,
+          "newbuildingId": null
+        },
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      },
+      {
+        "descriptionMinhash": [
+          7271919,
+          19965460,
+          41763141,
+          1115077,
+          2088518,
+          13162573,
+          2242720,
+          3351022,
+          56920750,
+          37342448,
+          28420684,
+          15240597,
+          4178831,
+          2285990,
+          8565558,
+          18872239,
+          2237706,
+          12370780,
+          4926574,
+          5573487,
+          23010934,
+          3842294,
+          944162,
+          8692421,
+          28131336,
+          20249216,
+          9953071,
+          57527,
+          3534384,
+          4088320,
+          3813664,
+          21828491
+        ],
+        "loggiasCount": null,
+        "isColorized": false,
+        "description": "Ванная у oкна | Бaшня HEВА ТАУЭPС | Вид на город с 7 этажа | Кондиционер | Ортопедический матрас | Высокоскоростной Wi-Fi | Полный пакет отчетных документов с чеками | Высокий Рейтинг | Скидки при длительном проживании | \n\nЗабронируйте прямо сейчас! В календаре только актуальные цены! \nВыбирайте дат",
+        "businessShoppingCenter": null,
+        "booking": null,
+        "isSubsidisedMortgage": null,
+        "videos": [
+          {
+            "uploadDate": null,
+            "id": "5e54110e-7580-41c7-9b03-342ddbcacbc9",
+            "duration": 19,
+            "url": "https://kinescope.io/embed/cDA7sD6hfGfdmrTPfyC4Aa",
+            "previewUrl": "https://kinescopecdn.net/f9f281e3-5528-474a-b760-2c5cecf2ce98/posters/fd5f4b3a-7eee-4e77-816d-55630c26f3e6/md/fb5526c3-e8ae-4918-8aff-1b03be15e6e9.jpg",
+            "type": "kinescope"
+          }
+        ],
+        "garage": null,
+        "balconiesCount": null,
+        "decoration": null,
+        "similar": null,
+        "isInHiddenBase": false,
+        "roomsCount": null,
+        "isRentByParts": false,
+        "totalArea": "28.0",
+        "isExcludedFromAction": false,
+        "fullUrl": "https://www.cian.ru/rent/flat/298900566/?mlSearchSessionGuid=0a844ba9ae762b9fe351e5219e161d42",
+        "moderationInfo": {
+          "showContactWarningMessage": false,
+          "warningMessage": null,
+          "photoStub": null
+        },
+        "isStandard": false,
+        "auction": {},
+        "rentByPartsDescription": null,
+        "offerInDeal": false,
+        "tradingLink": null,
+        "isPremium": false,
+        "workTimeInfo": null,
+        "promoInfo": null,
+        "building": {
+          "heatingType": null,
+          "classType": null,
+          "buildYear": 2020,
+          "deadline": null,
+          "floorsCount": 68,
+          "parking": null,
+          "materialType": "monolith",
+          "accessType": null,
+          "type": null,
+          "cargoLiftsCount": null,
+          "passengerLiftsCount": null
+        },
+        "kp": null,
+        "buildingCadastralNumber": null,
+        "bargainTerms": {
+          "clientFee": null,
+          "bargainAllowed": null,
+          "saleType": null,
+          "priceType": "all",
+          "price": 7990,
+          "utilitiesTerms": {
+            "includedInPrice": true,
+            "price": 0,
+            "flowMetersNotIncludedInPrice": null
+          },
+          "paymentPeriod": null,
+          "agentFee": null,
+          "currency": "rur",
+          "vatType": null,
+          "agentBonus": null,
+          "leaseType": null,
+          "priceRur": 7990,
+          "deposit": 5000,
+          "mortgageAllowed": null,
+          "tags": [],
+          "leaseTermType": null,
+          "priceForWorkplace": null,
+          "vatPrice": null
+        },
+        "rosreestrCheck": null,
+        "isInCpd": null,
+        "basicProfiScore": 0,
+        "specialty": {
+          "specialties": [],
+          "types": [],
+          "additionalTypes": []
+        },
+        "formattedFullPrice": "от 7 990 ₽/сут.",
+        "commercialOwnership": null,
+        "isTop3": true,
+        "formattedFullInfo": "Студия  ·  28 м²  ·  7/68 этаж",
+        "isCalltrackingEnabled": true,
+        "publishedUserId": 112566994,
+        "land": null,
+        "isNeedHideExactAddress": false,
+        "formattedShortInfo": "Студия  ·  7/68 этаж",
+        "title": "Большой выбор апартов Москва и МО",
+        "layout": null,
+        "isBookedFromDeveloper": false,
+        "permittedUseType": null,
+        "isNew": false,
+        "minArea": null,
+        "category": "dailyFlatRent",
+        "status": "published",
+        "allFromOffrep": null,
+        "coworking": null,
+        "externalId": null,
+        "formattedAdditionalInfo": "Залог 5 000 ₽, посуточно",
+        "cianId": 298900566,
+        "demolishedInMoscowProgramm": null,
+        "isLayoutApproved": null,
+        "geo": {
+          "jk": {
+            "house": {
+              "name": "1-й Красногвардейский, 22с2 (Башня Т2)",
+              "id": 10478
+            },
+            "id": 8825,
+            "gaGeo": {
+              "oblId": 1,
+              "moId": 0,
+              "cityId": 1
+            },
+            "displayName": "ЖК «NEVA TOWERS»",
+            "name": "NEVA TOWERS",
+            "fullUrl": "https://zhk-neva-towers-i.cian.ru/",
+            "developer": null,
+            "webSiteUrlUtm": "https://www.nevatowers.ru/?utm_source=cian&utm_medium=kartochka_cian&utm_campaign=8825",
+            "webSiteUrl": "https://www.nevatowers.ru/"
+          },
+          "undergrounds": [
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 400,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=400&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 3,
+              "lineId": 30,
+              "lineColor": "DE9C4E",
+              "isDefault": true,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mcd1"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 35,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=35&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 4,
+              "lineId": 12,
+              "lineColor": "009BD5",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 70,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=70&offer_type=flat&only_foot=2&type=2",
+              "name": "Деловой центр",
+              "time": 6,
+              "lineId": 12,
+              "lineColor": "009BD5",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 444,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=444&offer_type=flat&only_foot=2&type=2",
+              "name": "Деловой центр",
+              "time": 6,
+              "lineId": 27,
+              "lineColor": "7ACDCE",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 272,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=272&offer_type=flat&only_foot=2&type=2",
+              "name": "Деловой центр",
+              "time": 6,
+              "lineId": 22,
+              "lineColor": "FA6F9E",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mck"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 512,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=512&offer_type=flat&only_foot=2&type=2",
+              "name": "Москва-Сити",
+              "time": 10,
+              "lineId": 34,
+              "lineColor": "40B280",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mcd4"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 311,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=311&offer_type=flat&only_foot=2&type=2",
+              "name": "Шелепиха",
+              "time": 16,
+              "lineId": 22,
+              "lineColor": "FA6F9E",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": "mck"
+            },
+            {
+              "releaseYear": null,
+              "cianId": null,
+              "id": 453,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=453&offer_type=flat&only_foot=2&type=2",
+              "name": "Шелепиха",
+              "time": 20,
+              "lineId": 27,
+              "lineColor": "7ACDCE",
+              "isDefault": false,
+              "underConstruction": false,
+              "transportType": "walk",
+              "lineType": null
+            }
+          ],
+          "coordinates": {
+            "lng": 37.535332,
+            "lat": 55.751584
+          },
+          "districts": [
+            {
+              "id": 18,
+              "locationId": 1,
+              "qs": "deal_type=rent&district%5B0%5D=18&engine_version=2&offer_type=flat&type=2",
+              "parentId": 4,
+              "title": "р-н Пресненский",
+              "name": "Пресненский",
+              "fullName": "р-н Пресненский",
+              "type": "raion",
+              "geoType": "district"
+            },
+            {
+              "id": 4,
+              "locationId": 1,
+              "qs": "deal_type=rent&district%5B0%5D=4&engine_version=2&offer_type=flat&type=2",
+              "parentId": null,
+              "title": "ЦАО",
+              "name": "ЦАО",
+              "fullName": "ЦАО",
+              "type": "okrug",
+              "geoType": "district"
+            }
+          ],
+          "buildingAddress": null,
+          "countryId": 138,
+          "userInput": "Россия, Москва, 1-й Красногвардейский проезд, 22с2",
+          "address": [
+            {
+              "isFormingAddress": true,
+              "id": 1,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&region=1&type=2",
+              "title": "Москва",
+              "name": "Москва",
+              "fullName": "Москва",
+              "shortName": "Москва",
+              "type": "location",
+              "locationTypeId": 1,
+              "geoType": "location"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 4,
+              "qs": "deal_type=rent&district%5B0%5D=4&engine_version=2&offer_type=flat&type=2",
+              "title": "ЦАО",
+              "name": "ЦАО",
+              "fullName": "ЦАО",
+              "shortName": "ЦАО",
+              "type": "okrug",
+              "locationTypeId": null,
+              "geoType": "district"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 18,
+              "qs": "deal_type=rent&district%5B0%5D=18&engine_version=2&offer_type=flat&type=2",
+              "title": "р-н Пресненский",
+              "name": "Пресненский",
+              "fullName": "р-н Пресненский",
+              "shortName": "р-н Пресненский",
+              "type": "raion",
+              "locationTypeId": null,
+              "geoType": "district"
+            },
+            {
+              "isFormingAddress": null,
+              "id": 400,
+              "qs": "deal_type=rent&engine_version=2&foot_min=25&metro%5B0%5D=400&offer_type=flat&only_foot=2&type=2",
+              "title": "м. Москва-Сити",
+              "name": "Москва-Сити",
+              "fullName": "м. Москва-Сити",
+              "shortName": "м. Москва-Сити",
+              "type": "metro",
+              "locationTypeId": null,
+              "geoType": "underground"
+            },
+            {
+              "isFormingAddress": true,
+              "id": 1265,
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&street%5B0%5D=1265&type=2",
+              "title": "1-й Красногвардейский проезд",
+              "name": "1-й Красногвардейский",
+              "fullName": "1-й Красногвардейский проезд",
+              "shortName": "1-й Красногвардейский проезд",
+              "type": "street",
+              "locationTypeId": null,
+              "geoType": "street"
+            },
+            {
+              "isFormingAddress": true,
+              "id": 5731398,
+              "qs": "deal_type=rent&engine_version=2&house%5B0%5D=5731398&offer_type=flat&type=2",
+              "title": "22с2",
+              "name": "22с2",
+              "fullName": "22с2",
+              "shortName": "22с2",
+              "type": "house",
+              "locationTypeId": null,
+              "geoType": "house"
+            }
+          ],
+          "railways": [
+            {
+              "id": 707,
+              "travelType": "byFoot",
+              "name": "Тестовская",
+              "time": 7,
+              "distance": 1.0,
+              "directionIds": [
+                11
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=707&type=2"
+            },
+            {
+              "id": 708,
+              "travelType": "byCar",
+              "name": "Фили",
+              "time": 6,
+              "distance": 4.0,
+              "directionIds": [
+                11
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=708&type=2"
+            },
+            {
+              "id": 693,
+              "travelType": "byCar",
+              "name": "Москва (Киевский вокзал)",
+              "time": 7,
+              "distance": 5.0,
+              "directionIds": [
+                14
+              ],
+              "geoType": "railway",
+              "qs": "deal_type=rent&engine_version=2&offer_type=flat&railway%5B0%5D=693&type=2"
+            }
+          ],
+          "highways": [],
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 400
+            },
+            {
+              "type": "underground",
+              "id": 35
+            },
+            {
+              "type": "underground",
+              "id": 70
+            },
+            {
+              "type": "underground",
+              "id": 444
+            },
+            {
+              "type": "underground",
+              "id": 272
+            },
+            {
+              "type": "underground",
+              "id": 512
+            },
+            {
+              "type": "underground",
+              "id": 311
+            },
+            {
+              "type": "underground",
+              "id": 453
+            },
+            {
+              "type": "railway",
+              "id": 707
+            },
+            {
+              "type": "railway",
+              "id": 708
+            },
+            {
+              "type": "railway",
+              "id": 693
+            },
+            {
+              "type": "district",
+              "id": 18
+            },
+            {
+              "type": "district",
+              "id": 4
+            }
+          ]
+        },
+        "accessType": null,
+        "readyBusinessType": null,
+        "newbuildingVasPromotion": null,
+        "added": "вчера, 17:58",
+        "isImported": false,
+        "officeType": null,
+        "newbuildingWithExtendedFeatures": null,
+        "roomsForSaleCount": null,
+        "floorNumber": 7,
+        "humanizedTimedelta": "вчера",
+        "photos": [
+          {
+            "isLayout": null,
+            "id": 2107685005,
+            "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685005-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685005-2.jpg",
+            "isDefault": false,
+            "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685005-1.jpg",
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685005-4.jpg",
+            "rotateDegree": null
+          },
+          {
+            "isLayout": null,
+            "id": 2107685023,
+            "miniUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685023-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685023-2.jpg",
+            "isDefault": false,
+            "fullUrl": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685023-1.jpg",
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/posutochnaja-kvartira-moskva-1y-krasnogvardeyskiy-proezd-2107685023-4.jpg",
+            "rotateDegree": null
+          }
+        ],
+        "dealType": "rent",
+        "coworkingOfferType": null,
+        "roomArea": null,
+        "areaParts": null,
+        "newbuilding": {
+          "house": {
+            "id": 10478,
+            "name": "1-й Красногвардейский, 22с2 (Башня Т2)",
+            "finishDate": {
+              "quarter": 4,
+              "year": 2019
+            },
+            "isFinished": true,
+            "section": null
+          },
+          "isFichering": false,
+          "id": 8825,
+          "isFromSeller": false,
+          "showJkReliableFlag": false,
+          "name": "NEVA TOWERS (Нева Тауэрс)",
+          "comparisonStatus": null,
+          "isSalesLeader": null,
+          "isFromBuilder": false,
+          "isFromLeadFactory": false,
+          "isPremium": false,
+          "isFromDeveloper": false,
+          "hasFlatTourBooking": false
+        },
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9339384779"
+          }
+        ],
+        "cadastralNumber": null,
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1113
+        ],
+        "descriptionWordsHighlighted": [],
+        "monthlyIncome": null,
+        "villageMortgageAllowed": null,
+        "addedTimestamp": 1788965922,
+        "formattedShortPrice": "от 7 990 ₽/сут.",
+        "dealRentVersion": null,
+        "newbuildingCplLayer": null,
+        "livingArea": null,
+        "fromDeveloper": null,
+        "creationDate": "2024-02-23T12:34:20.627",
+        "isCommercialOwnershipVerified": null,
+        "kitchenArea": null,
+        "isByCommercialOwner": null,
+        "isRecidivist": false,
+        "workplaceCount": null,
+        "isEarlyAccessEnabled": false,
+        "isAuction": true,
+        "showWarningMessage": false,
+        "userId": 112566994,
+        "jkUrl": "https://zhk-neva-towers-i.cian.ru/",
+        "offerFeatureLabelsV2": null,
+        "bedroomsCount": null,
+        "isByHomeowner": false,
+        "offerType": "flat",
+        "isApartments": false,
+        "id": 298900566,
+        "isCianPartner": false,
+        "hasFurniture": true,
+        "cianUserId": 112566994,
+        "shareAmount": null,
+        "buildersIds": [
+          9621
+        ],
+        "flatType": "studio",
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "112566994",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": false,
+          "isSubAgent": false,
+          "userId": 112566994,
+          "userTrustLevel": "notInvolved",
+          "accountType": "agency",
+          "agencyName": "ФУЛЛ ХАУС",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=61619977&t=2&p=2&timestamp=1772282392",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": true,
+              "isSuperHost": true,
+              "levelName": "Суперагент",
+              "levelOrder": 4,
+              "levelSystemName": "max",
+              "showSuperAgent": false,
+              "showHighResponsibility": true,
+              "showSuperHost": true
+            },
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 1,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Россия",
+                "packageTypeId": 1,
+                "packageTypeName": "Некоммерческий"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "ФУЛЛ ХАУС",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9254809517"
+            }
+          ],
+          "profileUri": "company/112566994/",
+          "userType": "realtor_not_commerce",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 112566994,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": false,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=1/city_id=1/object_type=1/ga_obj_type=None/spec=company/rent_type=daily/298900566/from_developer=0/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid5": "obl_id_1",
+          "puid6": "1_50",
+          "puid7": "2323",
+          "puid8": 7990,
+          "puid9": 400,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid18": 8825,
+          "puid19": "not_video",
+          "puid36": 1
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [
+          {
+            "type": "hasVideo",
+            "text": "Объявление с видео",
+            "link": "https://www.cian.ru/rent/flat/298900566/"
+          }
+        ],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "Сдан"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "1-й Красногвардейский, 22с2 (Башня Т2)"
+          }
+        ],
+        "dailyrent": {
+          "actionType": "otaCheckDates",
+          "hotelData": {
+            "isHotel": false
+          },
+          "isOnlineBooking": true,
+          "isVerifiedByCian": true,
+          "offerLabels": [
+            "instantBooking"
+          ],
+          "priceInfo": {
+            "finalPrice": "7 990 ₽",
+            "finalPricePerNight": "от 7 990 ₽/сут."
+          },
+          "realtyId": 298900566,
+          "guestsInfo": {
+            "guestsCount": 1,
+            "maxGuestsCount": 2
+          },
+          "rating": {
+            "rating": "4,9",
+            "reviewsCount": "36 отзывов"
+          }
+        },
+        "isVerifiedByCian": true,
+        "brandingLevel": "thirdLevel",
+        "isRosreestrChecked": false,
+        "newbuildingDynamicCalltracking": {
+          "siteBlockId": null,
+          "newbuildingId": null
+        },
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      }
+    ]
+  }
+}

--- a/packages/cian-connector/tests/fixtures/search_daily_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/search_daily_live.provenance.json
@@ -1,0 +1,51 @@
+{
+  "captured": "2026-09-10",
+  "endpoint": "https://api.cian.ru/search-offers/v2/search-offers-desktop/",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "jsonQuery": {
+    "_type": "flatrent",
+    "engine_version": {
+      "type": "term",
+      "value": 2
+    },
+    "region": {
+      "type": "terms",
+      "value": [
+        1
+      ]
+    },
+    "page": {
+      "type": "term",
+      "value": 1
+    },
+    "for_day": {
+      "type": "term",
+      "value": "1"
+    }
+  },
+  "displayed": {
+    "aggregatedCount": 53441,
+    "offers": [
+      {
+        "id": 191071633,
+        "price": 5000,
+        "category": "dailyFlatRent",
+        "addr": "Россия, Москва, Береговой проезд, 5Ак2"
+      },
+      {
+        "id": 331744103,
+        "price": 15000,
+        "category": "dailyFlatRent",
+        "addr": "Россия, Москва, Шмитовский проезд, 39к8"
+      },
+      {
+        "id": 298900566,
+        "price": 7990,
+        "category": "dailyFlatRent",
+        "addr": "Россия, Москва, 1-й Красногвардейский проезд, 22с2"
+      }
+    ]
+  },
+  "note": "Daily rent: bargainTerms carries price (no priceRur), paymentPeriod and leaseTermType are null, category dailyFlatRent. The price is per NIGHT.",
+  "trimmed": "first 3 offers; description cut to 300 chars; photos cut to 2"
+}

--- a/packages/cian-connector/tests/fixtures/search_rent_live.json
+++ b/packages/cian-connector/tests/fixtures/search_rent_live.json
@@ -1,0 +1,1970 @@
+{
+  "status": "ok",
+  "data": {
+    "jsonQuery": {
+      "_type": "flatrent",
+      "engine_version": {
+        "type": "term",
+        "value": 2
+      },
+      "region": {
+        "type": "terms",
+        "value": [
+          2
+        ]
+      },
+      "price": {
+        "type": "range",
+        "value": {
+          "gte": 40000,
+          "lte": 60000
+        }
+      },
+      "page": {
+        "type": "term",
+        "value": 1
+      },
+      "for_day": {
+        "type": "term",
+        "value": "!1"
+      },
+      "room": {
+        "type": "terms",
+        "value": [
+          2
+        ]
+      }
+    },
+    "offerCount": 1228,
+    "aggregatedCount": 1227,
+    "fullUrl": "https://spb.cian.ru/cat.php?currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&p=1&region=2&room2=1&type=4",
+    "avgPriceInformer": {
+      "price": 50000,
+      "currency": "rur"
+    },
+    "offersSerialized": [
+      {
+        "title": "Сдаются впервые после ремонта",
+        "kitchenArea": null,
+        "demolishedInMoscowProgramm": null,
+        "isBookedFromDeveloper": false,
+        "isExcludedFromAction": false,
+        "kp": null,
+        "tradingLink": null,
+        "businessShoppingCenter": null,
+        "minArea": null,
+        "readyBusinessType": null,
+        "roomArea": null,
+        "isApartments": true,
+        "isCalltrackingEnabled": true,
+        "formattedShortInfo": "2-комн.кв.  ·  14/23 этаж",
+        "rosreestrCheck": null,
+        "cianUserId": 131124249,
+        "humanizedTimedelta": "6 часов назад",
+        "formattedAdditionalInfo": "Залог 50 000 ₽, без комиссии, предоплата 1 месяц, на несколько месяцев",
+        "isTop3": true,
+        "roomsCount": 2,
+        "workplaceCount": null,
+        "isNew": false,
+        "newbuildingCplLayer": null,
+        "booking": null,
+        "buildersIds": [],
+        "workTimeInfo": null,
+        "isRentByParts": false,
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1111
+        ],
+        "land": null,
+        "layout": null,
+        "floorNumber": 14,
+        "buildingCadastralNumber": null,
+        "loggiasCount": 0,
+        "bargainTerms": {
+          "priceForWorkplace": null,
+          "leaseTermType": "fewMonths",
+          "leaseType": null,
+          "agentFee": 0,
+          "agentBonus": null,
+          "vatPrice": null,
+          "price": 60000,
+          "deposit": 50000,
+          "vatType": null,
+          "priceRur": 60000,
+          "paymentPeriod": "monthly",
+          "utilitiesTerms": {
+            "price": 0,
+            "flowMetersNotIncludedInPrice": false,
+            "includedInPrice": true
+          },
+          "mortgageAllowed": null,
+          "clientFee": 0,
+          "bargainAllowed": null,
+          "tags": [],
+          "saleType": null,
+          "currency": "rur",
+          "priceType": "all"
+        },
+        "villageMortgageAllowed": null,
+        "balconiesCount": 0,
+        "officeType": null,
+        "isByCommercialOwner": null,
+        "building": {
+          "deadline": null,
+          "type": null,
+          "materialType": null,
+          "parking": {
+            "type": "ground",
+            "purposeType": null,
+            "isFree": null,
+            "locationType": null,
+            "priceEntry": null,
+            "priceMonthly": null,
+            "placesCount": null,
+            "currency": null,
+            "isAvailable": null
+          },
+          "cargoLiftsCount": 0,
+          "buildYear": null,
+          "heatingType": null,
+          "floorsCount": 23,
+          "passengerLiftsCount": 3,
+          "classType": null,
+          "accessType": null
+        },
+        "flatType": "rooms",
+        "newbuilding": null,
+        "added": "сегодня, 14:25",
+        "isStandard": false,
+        "auction": {},
+        "basicProfiScore": 1,
+        "dealType": "rent",
+        "isEarlyAccessEnabled": false,
+        "isInCpd": null,
+        "offerInDeal": false,
+        "isCommercialOwnershipVerified": null,
+        "isPremium": false,
+        "specialty": {
+          "types": [],
+          "additionalTypes": [],
+          "specialties": []
+        },
+        "dealRentVersion": null,
+        "commercialOwnership": null,
+        "areaParts": null,
+        "newbuildingWithExtendedFeatures": null,
+        "jkUrl": null,
+        "coworkingOfferType": null,
+        "publishedUserId": 131124249,
+        "isLayoutApproved": null,
+        "addedTimestamp": 1788953119,
+        "shareAmount": null,
+        "fromDeveloper": null,
+        "isImported": false,
+        "offerType": "flat",
+        "isInHiddenBase": false,
+        "rentByPartsDescription": null,
+        "hasFurniture": true,
+        "bedroomsCount": null,
+        "totalArea": "43.0",
+        "moderationInfo": {
+          "photoStub": null,
+          "showContactWarningMessage": false,
+          "warningMessage": null
+        },
+        "accessType": null,
+        "monthlyIncome": null,
+        "category": "flatRent",
+        "isNeedHideExactAddress": false,
+        "garage": null,
+        "isCianPartner": false,
+        "formattedFullInfo": "2-комн.кв.  ·  43 м²  ·  14/23 этаж",
+        "description": "Сдаются двухкомнатные апартаменты площадью 43 м² без комиссии и посредников. В стоимость аренды уже включены коммунальные услуги, уборка раз в две недели, Wi-Fi. \n\nАпартаменты идеально подойдут для семейного проживания или пары, ценящей тишину, уют и порядок. В Вашем распоряжении — отдельная спальня",
+        "userId": 131124249,
+        "offerFeatureLabelsV2": null,
+        "descriptionWordsHighlighted": [],
+        "externalId": null,
+        "newbuildingVasPromotion": null,
+        "cianId": 317754437,
+        "isByHomeowner": false,
+        "coworking": null,
+        "phones": [
+          {
+            "number": "9119664962",
+            "countryCode": "7"
+          }
+        ],
+        "isSubsidisedMortgage": null,
+        "cadastralNumber": null,
+        "roomsForSaleCount": null,
+        "livingArea": null,
+        "photos": [
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-4.jpg",
+            "isLayout": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-2.jpg",
+            "id": 2495568875,
+            "isDefault": true,
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495568875-3.jpg",
+            "rotateDegree": null
+          },
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-4.jpg",
+            "isLayout": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-2.jpg",
+            "id": 2495555177,
+            "isDefault": false,
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-prospekt-prosveshceniya-2495555177-3.jpg",
+            "rotateDegree": null
+          }
+        ],
+        "videos": [],
+        "descriptionMinhash": [
+          11657364,
+          60079018,
+          41763141,
+          28932783,
+          2088518,
+          4134826,
+          62457250,
+          16422298,
+          12009655,
+          37900519,
+          11419043,
+          80418541,
+          4178831,
+          2039279,
+          27505215,
+          53222516,
+          9153089,
+          79825488,
+          7576996,
+          8855208,
+          8686384,
+          14305239,
+          5793994,
+          5003345,
+          4548529,
+          26005222,
+          225344,
+          39160761,
+          21531700,
+          10473298,
+          3706214,
+          33465035
+        ],
+        "creationDate": "2025-05-20T11:56:06.607",
+        "isRecidivist": false,
+        "geo": {
+          "coordinates": {
+            "lat": 60.036793,
+            "lng": 30.407317
+          },
+          "undergrounds": [
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=168&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "D70834",
+              "id": 168,
+              "time": 10,
+              "name": "Гражданский проспект",
+              "isDefault": true,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "walk",
+              "underConstruction": false,
+              "lineId": 13,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=169&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "D70834",
+              "id": 169,
+              "time": 7,
+              "name": "Академическая",
+              "isDefault": false,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "transport",
+              "underConstruction": false,
+              "lineId": 13,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=167&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "D70834",
+              "id": 167,
+              "time": 7,
+              "name": "Девяткино",
+              "isDefault": false,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "transport",
+              "underConstruction": false,
+              "lineId": 13,
+              "lineType": null
+            }
+          ],
+          "railways": [
+            {
+              "travelType": "byCar",
+              "distance": 2.0,
+              "id": 284,
+              "time": 4,
+              "name": "Мурино",
+              "directionIds": [
+                10
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=284&room2=1&type=4"
+            },
+            {
+              "travelType": "byCar",
+              "distance": 4.0,
+              "id": 277,
+              "time": 6,
+              "name": "Депо Ручьи",
+              "directionIds": [
+                10
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=277&room2=1&type=4"
+            },
+            {
+              "travelType": "byCar",
+              "distance": 7.0,
+              "id": 296,
+              "time": 11,
+              "name": "Девяткино",
+              "directionIds": [
+                10
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=296&room2=1&type=4"
+            }
+          ],
+          "districts": [
+            {
+              "type": "okrug",
+              "title": "Прометей",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=768&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 768,
+              "locationId": 2,
+              "fullName": "Прометей",
+              "name": "Прометей",
+              "parentId": 147,
+              "geoType": "district"
+            },
+            {
+              "type": "raion",
+              "title": "р-н Калининский",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=147&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 147,
+              "locationId": 2,
+              "fullName": "р-н Калининский",
+              "name": "Калининский",
+              "parentId": null,
+              "geoType": "district"
+            }
+          ],
+          "countryId": 138,
+          "jk": null,
+          "buildingAddress": null,
+          "address": [
+            {
+              "type": "location",
+              "locationTypeId": 1,
+              "title": "Санкт-Петербург",
+              "isFormingAddress": true,
+              "shortName": "Санкт-Петербург",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&region=2&room2=1&type=4",
+              "id": 2,
+              "fullName": "Санкт-Петербург",
+              "name": "Санкт-Петербург",
+              "geoType": "location"
+            },
+            {
+              "type": "raion",
+              "locationTypeId": null,
+              "title": "р-н Калининский",
+              "isFormingAddress": null,
+              "shortName": "р-н Калининский",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=147&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 147,
+              "fullName": "р-н Калининский",
+              "name": "Калининский",
+              "geoType": "district"
+            },
+            {
+              "type": "okrug",
+              "locationTypeId": null,
+              "title": "Прометей",
+              "isFormingAddress": null,
+              "shortName": "Прометей",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=768&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 768,
+              "fullName": "Прометей",
+              "name": "Прометей",
+              "geoType": "district"
+            },
+            {
+              "type": "metro",
+              "locationTypeId": null,
+              "title": "м. Гражданский проспект",
+              "isFormingAddress": null,
+              "shortName": "м. Гражданский проспект",
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=168&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "id": 168,
+              "fullName": "м. Гражданский проспект",
+              "name": "Гражданский проспект",
+              "geoType": "underground"
+            },
+            {
+              "type": "street",
+              "locationTypeId": null,
+              "title": "проспект Просвещения",
+              "isFormingAddress": true,
+              "shortName": "просп. Просвещения",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&street%5B0%5D=4636&type=4",
+              "id": 4636,
+              "fullName": "проспект Просвещения",
+              "name": "Просвещения",
+              "geoType": "street"
+            },
+            {
+              "type": "house",
+              "locationTypeId": null,
+              "title": "83",
+              "isFormingAddress": true,
+              "shortName": "83",
+              "qs": "currency=2&deal_type=rent&engine_version=2&house%5B0%5D=3722&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 3722,
+              "fullName": "83",
+              "name": "83",
+              "geoType": "house"
+            }
+          ],
+          "userInput": "Россия, Санкт-Петербург, проспект Просвещения, 83",
+          "highways": [],
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 168
+            },
+            {
+              "type": "underground",
+              "id": 169
+            },
+            {
+              "type": "underground",
+              "id": 167
+            },
+            {
+              "type": "railway",
+              "id": 284
+            },
+            {
+              "type": "railway",
+              "id": 277
+            },
+            {
+              "type": "railway",
+              "id": 296
+            },
+            {
+              "type": "district",
+              "id": 768
+            },
+            {
+              "type": "district",
+              "id": 147
+            }
+          ]
+        },
+        "status": "published",
+        "formattedShortPrice": "60 000 ₽/мес.",
+        "promoInfo": null,
+        "isAuction": true,
+        "allFromOffrep": null,
+        "formattedFullPrice": "60 000 ₽/мес.",
+        "isColorized": false,
+        "showWarningMessage": false,
+        "fullUrl": "https://spb.cian.ru/rent/flat/317754437/?mlSearchSessionGuid=04cee7065c9de1921e1e12b67e121d18",
+        "decoration": null,
+        "id": 317754437,
+        "permittedUseType": null,
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "131124249",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": false,
+          "isSubAgent": false,
+          "userId": 131124249,
+          "userTrustLevel": "notInvolved",
+          "accountType": "agency",
+          "agencyName": "SVET hotel",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=71539216&t=2&p=2&timestamp=1787129417",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": false,
+              "isBlocked": false,
+              "isSuperAgent": false,
+              "isSuperHost": false,
+              "levelName": "Низкий уровень",
+              "levelOrder": 1,
+              "levelSystemName": "low",
+              "showHighResponsibility": false,
+              "showSuperAgent": false,
+              "showSuperHost": false
+            },
+            "showUserIdentifiedByDocuments": true
+          },
+          "billingInfo": {
+            "accountType": 1,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Санкт-Петербург и область",
+                "locationId": 2,
+                "packageTypeId": 2,
+                "packageTypeName": "Базовый"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "SVET hotel",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9523724431"
+            }
+          ],
+          "profileUri": "company/131124249/",
+          "userType": "realtor_based",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": false,
+            "availableFrom": "2026-09-10T09:00:00+03:00",
+            "availableTo": "2026-09-10T18:00:00+03:00",
+            "message": "Напишите ему или позвоните завтра.",
+            "title": "Специалист работает с 9:00 по 18:00.",
+            "userId": 131124249,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": true,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=2/city_id=2/object_type=1/ga_obj_type=2/spec=company/rent_type=/317754437/from_developer=0/repres=0/owner=0/pod_snos=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid4": "offer_type_2",
+          "puid5": "obl_id_2",
+          "puid6": "51_100",
+          "puid8": 60000,
+          "puid9": 168,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid19": "not_video",
+          "puid21": 168,
+          "puid36": 2
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": true,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [],
+        "factoids": [],
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "isOnlineRentalAgreementEnabled": null,
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      },
+      {
+        "title": "Без депозита! Пешком до метро",
+        "kitchenArea": "6.0",
+        "demolishedInMoscowProgramm": false,
+        "isBookedFromDeveloper": false,
+        "isExcludedFromAction": false,
+        "kp": null,
+        "tradingLink": null,
+        "businessShoppingCenter": null,
+        "minArea": null,
+        "readyBusinessType": null,
+        "roomArea": null,
+        "isApartments": null,
+        "isCalltrackingEnabled": true,
+        "formattedShortInfo": "2-комн.кв.  ·  9/11 этаж",
+        "rosreestrCheck": null,
+        "cianUserId": 107398974,
+        "humanizedTimedelta": "2 часа назад",
+        "formattedAdditionalInfo": "Без депозита, комиссия 60%(agent_fee), предоплата 1 месяц, на длительный срок",
+        "isTop3": true,
+        "roomsCount": 2,
+        "workplaceCount": null,
+        "isNew": false,
+        "newbuildingCplLayer": null,
+        "booking": null,
+        "buildersIds": [
+          9
+        ],
+        "workTimeInfo": null,
+        "isRentByParts": false,
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1111
+        ],
+        "land": null,
+        "layout": null,
+        "floorNumber": 9,
+        "buildingCadastralNumber": null,
+        "loggiasCount": 0,
+        "bargainTerms": {
+          "priceForWorkplace": null,
+          "leaseTermType": "longTerm",
+          "leaseType": null,
+          "agentFee": 50,
+          "agentBonus": null,
+          "vatPrice": null,
+          "price": 49000,
+          "deposit": 0,
+          "vatType": null,
+          "priceRur": 49000,
+          "paymentPeriod": "monthly",
+          "utilitiesTerms": {
+            "price": 0,
+            "flowMetersNotIncludedInPrice": true,
+            "includedInPrice": false
+          },
+          "mortgageAllowed": null,
+          "clientFee": 60,
+          "bargainAllowed": null,
+          "tags": [],
+          "saleType": null,
+          "currency": "rur",
+          "priceType": "all"
+        },
+        "villageMortgageAllowed": null,
+        "balconiesCount": 1,
+        "officeType": null,
+        "isByCommercialOwner": null,
+        "building": {
+          "deadline": null,
+          "type": null,
+          "materialType": "panel",
+          "parking": {
+            "type": "ground",
+            "purposeType": null,
+            "isFree": null,
+            "locationType": null,
+            "priceEntry": null,
+            "priceMonthly": null,
+            "placesCount": null,
+            "currency": null,
+            "isAvailable": null
+          },
+          "cargoLiftsCount": 1,
+          "buildYear": 2025,
+          "heatingType": null,
+          "floorsCount": 11,
+          "passengerLiftsCount": 1,
+          "classType": null,
+          "accessType": null
+        },
+        "flatType": "rooms",
+        "newbuilding": {
+          "comparisonStatus": null,
+          "isFromSeller": false,
+          "house": {
+            "section": null,
+            "finishDate": {
+              "quarter": 1,
+              "year": 2025
+            },
+            "isFinished": true,
+            "id": 7882195,
+            "name": "Корпус 3"
+          },
+          "showJkReliableFlag": false,
+          "isPremium": false,
+          "isFromLeadFactory": false,
+          "id": 4026695,
+          "hasFlatTourBooking": false,
+          "name": "Витебский парк",
+          "isFichering": false,
+          "isFromDeveloper": false,
+          "isSalesLeader": null,
+          "isFromBuilder": false
+        },
+        "added": "сегодня, 18:25",
+        "isStandard": false,
+        "auction": {},
+        "basicProfiScore": 1,
+        "dealType": "rent",
+        "isEarlyAccessEnabled": false,
+        "isInCpd": null,
+        "offerInDeal": false,
+        "isCommercialOwnershipVerified": null,
+        "isPremium": false,
+        "specialty": {
+          "types": [],
+          "additionalTypes": [],
+          "specialties": []
+        },
+        "dealRentVersion": null,
+        "commercialOwnership": null,
+        "areaParts": null,
+        "newbuildingWithExtendedFeatures": null,
+        "jkUrl": "https://zhk-vitebskiy-park-spb-i.cian.ru/",
+        "coworkingOfferType": null,
+        "publishedUserId": 117832788,
+        "isLayoutApproved": null,
+        "addedTimestamp": 1788967540,
+        "shareAmount": null,
+        "fromDeveloper": null,
+        "isImported": true,
+        "offerType": "flat",
+        "isInHiddenBase": false,
+        "rentByPartsDescription": null,
+        "hasFurniture": true,
+        "bedroomsCount": null,
+        "totalArea": "35.6",
+        "moderationInfo": {
+          "photoStub": null,
+          "showContactWarningMessage": false,
+          "warningMessage": null
+        },
+        "accessType": null,
+        "monthlyIncome": null,
+        "category": "flatRent",
+        "isNeedHideExactAddress": false,
+        "garage": null,
+        "isCianPartner": false,
+        "formattedFullInfo": "2-комн.кв.  ·  35,6 м²  ·  9/11 этаж",
+        "description": "Сдаётся светлая 2-комнатная квартира с хорошим ремонтом, без депозита! Квартира свободна, готова к заселению. Подойдёт одному человеку или паре с ребенком.\n\nКоммунальные услуги и счётчики оплачиваются отдельно. Изолированная спальня, просторная кухня-гостиная, балкон и совмещённый санузел. Полы - ла",
+        "userId": 107398974,
+        "offerFeatureLabelsV2": null,
+        "descriptionWordsHighlighted": [],
+        "externalId": null,
+        "newbuildingVasPromotion": null,
+        "cianId": 332754245,
+        "isByHomeowner": null,
+        "coworking": null,
+        "phones": [
+          {
+            "number": "9820937453",
+            "countryCode": "7"
+          }
+        ],
+        "isSubsidisedMortgage": null,
+        "cadastralNumber": null,
+        "roomsForSaleCount": null,
+        "livingArea": "20.0",
+        "photos": [
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2939982694-4.jpg",
+            "isLayout": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/2939982694-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2939982694-2.jpg",
+            "id": 2939982694,
+            "isDefault": false,
+            "miniUrl": "https://images.cdn-cian.ru/images/2939982694-3.jpg",
+            "rotateDegree": null
+          },
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2939982705-4.jpg",
+            "isLayout": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/2939982705-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2939982705-2.jpg",
+            "id": 2939982705,
+            "isDefault": false,
+            "miniUrl": "https://images.cdn-cian.ru/images/2939982705-3.jpg",
+            "rotateDegree": null
+          }
+        ],
+        "videos": [],
+        "descriptionMinhash": [
+          2313326,
+          5781654,
+          6160837,
+          42337346,
+          2088518,
+          28636284,
+          14072187,
+          13892692,
+          57588588,
+          37900519,
+          11419043,
+          39685766,
+          4178831,
+          72348985,
+          1842657,
+          15438368,
+          21211329,
+          52883763,
+          46276819,
+          68225272,
+          8262839,
+          9879729,
+          5793994,
+          38907129,
+          40658430,
+          10065804,
+          14425114,
+          33686360,
+          11334613,
+          57684938,
+          6976463,
+          54770475
+        ],
+        "creationDate": "2026-08-08T18:07:28.787",
+        "isRecidivist": false,
+        "geo": {
+          "coordinates": {
+            "lat": 59.9021,
+            "lng": 30.342306
+          },
+          "undergrounds": [
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=241&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "700579",
+              "id": 241,
+              "time": 19,
+              "name": "Обводный канал",
+              "isDefault": true,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "walk",
+              "underConstruction": false,
+              "lineId": 17,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=197&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "087DCD",
+              "id": 197,
+              "time": 6,
+              "name": "Фрунзенская",
+              "isDefault": null,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "transport",
+              "underConstruction": false,
+              "lineId": 14,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=230&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "lineColor": "700579",
+              "id": 230,
+              "time": 8,
+              "name": "Волковская",
+              "isDefault": null,
+              "releaseYear": null,
+              "cianId": null,
+              "transportType": "transport",
+              "underConstruction": false,
+              "lineId": 17,
+              "lineType": null
+            }
+          ],
+          "railways": [
+            {
+              "travelType": "byFoot",
+              "distance": 1.0,
+              "id": 235,
+              "time": 9,
+              "name": "Боровая",
+              "directionIds": [
+                5
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=235&room2=1&type=4"
+            },
+            {
+              "travelType": "byFoot",
+              "distance": 1.0,
+              "id": 237,
+              "time": 16,
+              "name": "Воздухоплавательный парк",
+              "directionIds": [
+                5
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=237&room2=1&type=4"
+            },
+            {
+              "travelType": "byCar",
+              "distance": 3.0,
+              "id": 226,
+              "time": 4,
+              "name": "Санкт-Петербург (Витебский вокзал)",
+              "directionIds": [
+                5
+              ],
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=226&room2=1&type=4"
+            }
+          ],
+          "districts": [
+            {
+              "type": "okrug",
+              "title": "Волковское",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=765&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 765,
+              "locationId": 2,
+              "fullName": "Волковское",
+              "name": "Волковское",
+              "parentId": 134,
+              "geoType": "district"
+            },
+            {
+              "type": "raion",
+              "title": "р-н Фрунзенский",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=134&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 134,
+              "locationId": 2,
+              "fullName": "р-н Фрунзенский",
+              "name": "Фрунзенский",
+              "parentId": null,
+              "geoType": "district"
+            }
+          ],
+          "countryId": 138,
+          "jk": {
+            "house": {
+              "name": "Корпус 3",
+              "id": 7882195
+            },
+            "fullUrl": "https://zhk-vitebskiy-park-spb-i.cian.ru/",
+            "gaGeo": {
+              "cityId": 2,
+              "oblId": 2,
+              "moId": 0
+            },
+            "webSiteUrl": null,
+            "id": 4026695,
+            "displayName": "ЖК «Витебский парк»",
+            "name": "Витебский парк",
+            "developer": null,
+            "webSiteUrlUtm": null
+          },
+          "buildingAddress": null,
+          "address": [
+            {
+              "type": "location",
+              "locationTypeId": 1,
+              "title": "Санкт-Петербург",
+              "isFormingAddress": true,
+              "shortName": "Санкт-Петербург",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&region=2&room2=1&type=4",
+              "id": 2,
+              "fullName": "Санкт-Петербург",
+              "name": "Санкт-Петербург",
+              "geoType": "location"
+            },
+            {
+              "type": "raion",
+              "locationTypeId": null,
+              "title": "р-н Фрунзенский",
+              "isFormingAddress": null,
+              "shortName": "р-н Фрунзенский",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=134&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 134,
+              "fullName": "р-н Фрунзенский",
+              "name": "Фрунзенский",
+              "geoType": "district"
+            },
+            {
+              "type": "okrug",
+              "locationTypeId": null,
+              "title": "Волковское",
+              "isFormingAddress": null,
+              "shortName": "Волковское",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=765&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 765,
+              "fullName": "Волковское",
+              "name": "Волковское",
+              "geoType": "district"
+            },
+            {
+              "type": "metro",
+              "locationTypeId": null,
+              "title": "м. Обводный канал",
+              "isFormingAddress": null,
+              "shortName": "м. Обводный канал",
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=241&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "id": 241,
+              "fullName": "м. Обводный канал",
+              "name": "Обводный канал",
+              "geoType": "underground"
+            },
+            {
+              "type": "street",
+              "locationTypeId": null,
+              "title": "Лиговский проспект",
+              "isFormingAddress": true,
+              "shortName": "Лиговский просп.",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&street%5B0%5D=4191&type=4",
+              "id": 4191,
+              "fullName": "Лиговский проспект",
+              "name": "Лиговский",
+              "geoType": "street"
+            },
+            {
+              "type": "house",
+              "locationTypeId": null,
+              "title": "242",
+              "isFormingAddress": true,
+              "shortName": "242",
+              "qs": "currency=2&deal_type=rent&engine_version=2&house%5B0%5D=100119&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "id": 100119,
+              "fullName": "242",
+              "name": "242",
+              "geoType": "house"
+            }
+          ],
+          "userInput": "г Санкт-Петербург, пр-кт Лиговский, д 242",
+          "highways": [],
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 241
+            },
+            {
+              "type": "underground",
+              "id": 197
+            },
+            {
+              "type": "underground",
+              "id": 230
+            },
+            {
+              "type": "railway",
+              "id": 235
+            },
+            {
+              "type": "railway",
+              "id": 237
+            },
+            {
+              "type": "railway",
+              "id": 226
+            },
+            {
+              "type": "district",
+              "id": 765
+            },
+            {
+              "type": "district",
+              "id": 134
+            }
+          ]
+        },
+        "status": "published",
+        "formattedShortPrice": "49 000 ₽/мес.",
+        "promoInfo": null,
+        "isAuction": true,
+        "allFromOffrep": null,
+        "formattedFullPrice": "49 000 ₽/мес.",
+        "isColorized": false,
+        "showWarningMessage": false,
+        "fullUrl": "https://spb.cian.ru/rent/flat/332754245/?mlSearchSessionGuid=04cee7065c9de1921e1e12b67e121d18",
+        "decoration": null,
+        "id": 332754245,
+        "permittedUseType": null,
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "117832788",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": true,
+          "isPassportVerified": false,
+          "isSubAgent": true,
+          "userId": 117832788,
+          "userTrustLevel": "involved",
+          "accountType": "specialist",
+          "agencyName": "Дмитрий Шубин",
+          "agentModerationInfo": {
+            "isUserIdentified": false,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": false,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": false,
+              "isSuperHost": false,
+              "levelName": "Высокий уровень",
+              "levelOrder": 3,
+              "levelSystemName": "high",
+              "showHighResponsibility": true,
+              "showSuperAgent": false,
+              "showSuperHost": false
+            },
+            "showUserIdentifiedByDocuments": true
+          },
+          "billingInfo": {
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Москва и ближнее Подмосковье",
+                "locationId": 1,
+                "packageTypeId": 2,
+                "packageTypeName": "Базовый"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "hide",
+          "companyName": "Циан х ПИК-Аренда",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "masterAgent": {
+            "absoluteAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=59029046&t=2&p=2&timestamp=1757150436",
+            "absoluteMiniAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=59029046&t=2&p=1&timestamp=1757150436",
+            "accountType": "agency",
+            "avatarUrl": "/api/get-avatar/?i=59029046&t=2&p=2&timestamp=1757150436",
+            "id": 107398974,
+            "isModerationPassed": true,
+            "miniAvatarUrl": "/api/get-avatar/?i=59029046&t=2&p=1&timestamp=1757150436",
+            "name": "Циан х ПИК-Аренда",
+            "profileUri": "company/107398974/"
+          },
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9609919856"
+            },
+            {
+              "countryCode": "+7",
+              "number": "4951563586"
+            }
+          ],
+          "subAgentCompanyName": "Циан х ПИК-Аренда",
+          "userType": "realtor_based",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 117832788,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": true,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=2/city_id=2/object_type=1/ga_obj_type=2/spec=agent/rent_type=/332754245/from_developer=0/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid4": "offer_type_2",
+          "puid5": "obl_id_2",
+          "puid6": "1_50",
+          "puid8": 49000,
+          "puid9": 241,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid18": 4026695,
+          "puid19": "not_video",
+          "puid21": 241,
+          "puid36": 2
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "Сдан"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "Корпус 3"
+          },
+          {
+            "type": "livingArea",
+            "title": "Жилая пл.",
+            "text": "20.0 м2"
+          }
+        ],
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "isOnlineRentalAgreementEnabled": null,
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      },
+      {
+        "descriptionMinhash": [
+          7670570,
+          169631854,
+          45446420,
+          181143664,
+          2088518,
+          234015424,
+          133101555,
+          146991052,
+          56920750,
+          80102118,
+          56374716,
+          39685766,
+          4178831,
+          187931150,
+          334388014,
+          15438368,
+          53258488,
+          58200472,
+          74236807,
+          195232547,
+          8262839,
+          97805799,
+          5793994,
+          52673459,
+          189413599,
+          20249216,
+          14611990,
+          294726568,
+          98192669,
+          146302257,
+          204406583,
+          253496168
+        ],
+        "jkUrl": null,
+        "externalId": null,
+        "basicProfiScore": 1,
+        "isInHiddenBase": false,
+        "formattedFullPrice": "55 000 ₽/мес.",
+        "categoriesIds": [
+          1000,
+          1100,
+          1110,
+          1111
+        ],
+        "id": 333183294,
+        "formattedFullInfo": "2-комн.кв.  ·  46,7 м²  ·  6/6 этаж",
+        "isSubsidisedMortgage": null,
+        "isApartments": false,
+        "showWarningMessage": false,
+        "roomsForSaleCount": null,
+        "monthlyIncome": null,
+        "isTop3": false,
+        "accessType": null,
+        "newbuildingVasPromotion": null,
+        "photos": [
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948772174-4.jpg",
+            "isDefault": true,
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948772174-2.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948772174-3.jpg",
+            "rotateDegree": null,
+            "id": 2948772174,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948772174-1.jpg",
+            "isLayout": null
+          },
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948763724-4.jpg",
+            "isDefault": false,
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948763724-2.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948763724-3.jpg",
+            "rotateDegree": null,
+            "id": 2948763724,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-sanktpeterburg-pereulok-apraksin-2948763724-1.jpg",
+            "isLayout": null
+          }
+        ],
+        "descriptionWordsHighlighted": [],
+        "shareAmount": null,
+        "creationDate": "2026-08-21T18:52:49.46",
+        "roomArea": null,
+        "publishedUserId": 47557313,
+        "hasFurniture": true,
+        "formattedShortInfo": "2-комн.кв.  ·  6/6 этаж",
+        "geo": {
+          "userInput": "Россия, Санкт-Петербург, Апраксин переулок, 3",
+          "countryId": 138,
+          "districts": [
+            {
+              "name": "№ 78",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=687&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "parentId": 133,
+              "type": "okrug",
+              "fullName": "№ 78",
+              "id": 687,
+              "locationId": 2,
+              "geoType": "district",
+              "title": "№ 78"
+            },
+            {
+              "name": "Центральный",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=133&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "parentId": null,
+              "type": "raion",
+              "fullName": "р-н Центральный",
+              "id": 133,
+              "locationId": 2,
+              "geoType": "district",
+              "title": "р-н Центральный"
+            }
+          ],
+          "highways": [],
+          "address": [
+            {
+              "name": "Санкт-Петербург",
+              "shortName": "Санкт-Петербург",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&region=2&room2=1&type=4",
+              "isFormingAddress": true,
+              "geoType": "location",
+              "type": "location",
+              "fullName": "Санкт-Петербург",
+              "id": 2,
+              "locationTypeId": 1,
+              "title": "Санкт-Петербург"
+            },
+            {
+              "name": "Центральный",
+              "shortName": "р-н Центральный",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=133&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "isFormingAddress": null,
+              "geoType": "district",
+              "type": "raion",
+              "fullName": "р-н Центральный",
+              "id": 133,
+              "locationTypeId": null,
+              "title": "р-н Центральный"
+            },
+            {
+              "name": "№ 78",
+              "shortName": "№ 78",
+              "qs": "currency=2&deal_type=rent&district%5B0%5D=687&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "isFormingAddress": null,
+              "geoType": "district",
+              "type": "okrug",
+              "fullName": "№ 78",
+              "id": 687,
+              "locationTypeId": null,
+              "title": "№ 78"
+            },
+            {
+              "name": "Сенная площадь",
+              "shortName": "м. Сенная площадь",
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=195&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isFormingAddress": null,
+              "geoType": "underground",
+              "type": "metro",
+              "fullName": "м. Сенная площадь",
+              "id": 195,
+              "locationTypeId": null,
+              "title": "м. Сенная площадь"
+            },
+            {
+              "name": "Апраксин",
+              "shortName": "пер. Апраксин",
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&room2=1&street%5B0%5D=3517&type=4",
+              "isFormingAddress": true,
+              "geoType": "street",
+              "type": "street",
+              "fullName": "переулок Апраксин",
+              "id": 3517,
+              "locationTypeId": null,
+              "title": "переулок Апраксин"
+            },
+            {
+              "name": "3",
+              "shortName": "3",
+              "qs": "currency=2&deal_type=rent&engine_version=2&house%5B0%5D=1699672&maxprice=60000&minprice=40000&offer_type=flat&room2=1&type=4",
+              "isFormingAddress": true,
+              "geoType": "house",
+              "type": "house",
+              "fullName": "3",
+              "id": 1699672,
+              "locationTypeId": null,
+              "title": "3"
+            }
+          ],
+          "railways": [
+            {
+              "name": "Санкт-Петербург (Витебский вокзал)",
+              "travelType": "byFoot",
+              "time": 18,
+              "directionIds": [
+                5
+              ],
+              "id": 226,
+              "geoType": "railway",
+              "distance": 1.0,
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=226&room2=1&type=4"
+            },
+            {
+              "name": "Санкт-Петербург (Московский вокзал)",
+              "travelType": "byCar",
+              "time": 5,
+              "directionIds": [
+                6
+              ],
+              "id": 230,
+              "geoType": "railway",
+              "distance": 2.0,
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=230&room2=1&type=4"
+            },
+            {
+              "name": "Боровая",
+              "travelType": "byCar",
+              "time": 6,
+              "directionIds": [
+                5
+              ],
+              "id": 235,
+              "geoType": "railway",
+              "distance": 3.0,
+              "qs": "currency=2&deal_type=rent&engine_version=2&maxprice=60000&minprice=40000&offer_type=flat&railway%5B0%5D=235&room2=1&type=4"
+            }
+          ],
+          "undergrounds": [
+            {
+              "name": "Сенная площадь",
+              "lineColor": "087DCD",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=195&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": true,
+              "releaseYear": null,
+              "time": 6,
+              "lineId": 14,
+              "id": 195,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Спасская",
+              "lineColor": "DF6E08",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=232&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 7,
+              "lineId": 16,
+              "id": 232,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Садовая",
+              "lineColor": "700579",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=220&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 7,
+              "lineId": 17,
+              "id": 220,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Гостиный двор",
+              "lineColor": "069857",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=206&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 9,
+              "lineId": 15,
+              "id": 206,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Невский проспект",
+              "lineColor": "087DCD",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=194&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 10,
+              "lineId": 14,
+              "id": 194,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Звенигородская",
+              "lineColor": "700579",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=231&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 14,
+              "lineId": 17,
+              "id": 231,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Адмиралтейская",
+              "lineColor": "700579",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=242&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 16,
+              "lineId": 17,
+              "id": 242,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Пушкинская",
+              "lineColor": "D70834",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=178&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 16,
+              "lineId": 13,
+              "id": 178,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Достоевская",
+              "lineColor": "DF6E08",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=221&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 17,
+              "lineId": 16,
+              "id": 221,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "name": "Владимирская",
+              "lineColor": "D70834",
+              "underConstruction": false,
+              "qs": "currency=2&deal_type=rent&engine_version=2&foot_min=25&maxprice=60000&metro%5B0%5D=177&minprice=40000&offer_type=flat&only_foot=2&room2=1&type=4",
+              "isDefault": false,
+              "releaseYear": null,
+              "time": 19,
+              "lineId": 13,
+              "id": 177,
+              "transportType": "walk",
+              "cianId": null,
+              "lineType": null
+            }
+          ],
+          "jk": null,
+          "buildingAddress": null,
+          "coordinates": {
+            "lat": 59.92865,
+            "lng": 30.325121
+          },
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 195
+            },
+            {
+              "type": "underground",
+              "id": 232
+            },
+            {
+              "type": "underground",
+              "id": 220
+            },
+            {
+              "type": "underground",
+              "id": 206
+            },
+            {
+              "type": "underground",
+              "id": 194
+            },
+            {
+              "type": "underground",
+              "id": 231
+            },
+            {
+              "type": "underground",
+              "id": 242
+            },
+            {
+              "type": "underground",
+              "id": 178
+            },
+            {
+              "type": "underground",
+              "id": 221
+            },
+            {
+              "type": "underground",
+              "id": 177
+            },
+            {
+              "type": "railway",
+              "id": 226
+            },
+            {
+              "type": "railway",
+              "id": 230
+            },
+            {
+              "type": "railway",
+              "id": 235
+            },
+            {
+              "type": "district",
+              "id": 687
+            },
+            {
+              "type": "district",
+              "id": 133
+            }
+          ]
+        },
+        "loggiasCount": 0,
+        "newbuilding": null,
+        "isCalltrackingEnabled": true,
+        "buildingCadastralNumber": null,
+        "land": null,
+        "commercialOwnership": null,
+        "rentByPartsDescription": null,
+        "workTimeInfo": null,
+        "permittedUseType": null,
+        "isInCpd": null,
+        "formattedAdditionalInfo": "Залог 55 000 ₽, комиссия 70%(agent_fee), предоплата 1 месяц, на несколько месяцев",
+        "description": "Квартира сдаётся до 1 мая 2027 года.\n\nКвартира будет свободна с 3 сентября.\n\nВ квартире есть все необходимое для комфортного проживания \n\nПо планировке кухня- гостиная и две изолированные комнаты.\n\nВ доме есть лифт\n\nДо метро Сенная площадь 6 минут пешком \n\nКоммунальные платежи оплачиваются отдельно.",
+        "isCommercialOwnershipVerified": null,
+        "dealType": "rent",
+        "isAuction": false,
+        "rosreestrCheck": null,
+        "booking": null,
+        "offerType": "flat",
+        "fromDeveloper": null,
+        "newbuildingCplLayer": null,
+        "buildersIds": [],
+        "fullUrl": "https://spb.cian.ru/rent/flat/333183294/?mlSearchSessionGuid=04cee7065c9de1921e1e12b67e121d18",
+        "roomsCount": 2,
+        "offerInDeal": false,
+        "offerFeatureLabelsV2": null,
+        "bargainTerms": {
+          "paymentPeriod": "monthly",
+          "clientFee": 70,
+          "saleType": null,
+          "priceType": "all",
+          "utilitiesTerms": {
+            "includedInPrice": false,
+            "price": 0,
+            "flowMetersNotIncludedInPrice": true
+          },
+          "vatPrice": null,
+          "agentFee": 70,
+          "price": 55000,
+          "priceRur": 55000,
+          "priceForWorkplace": null,
+          "leaseTermType": "fewMonths",
+          "agentBonus": null,
+          "vatType": null,
+          "tags": [],
+          "mortgageAllowed": null,
+          "leaseType": null,
+          "bargainAllowed": null,
+          "deposit": 55000,
+          "currency": "rur"
+        },
+        "isColorized": false,
+        "minArea": null,
+        "auction": {},
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9119520225"
+          }
+        ],
+        "isImported": false,
+        "flatType": "rooms",
+        "layout": null,
+        "dealRentVersion": null,
+        "coworking": null,
+        "kitchenArea": "10.0",
+        "cianUserId": 47557313,
+        "isNeedHideExactAddress": false,
+        "isRecidivist": false,
+        "isCianPartner": false,
+        "villageMortgageAllowed": null,
+        "totalArea": "46.7",
+        "addedTimestamp": 1788854858,
+        "category": "flatRent",
+        "building": {
+          "cargoLiftsCount": null,
+          "heatingType": null,
+          "materialType": "brick",
+          "deadline": null,
+          "passengerLiftsCount": 1,
+          "floorsCount": 6,
+          "type": null,
+          "buildYear": 1852,
+          "classType": null,
+          "parking": {
+            "purposeType": null,
+            "currency": null,
+            "isAvailable": null,
+            "isFree": null,
+            "type": "ground",
+            "placesCount": null,
+            "priceMonthly": null,
+            "priceEntry": null,
+            "locationType": null
+          },
+          "accessType": null
+        },
+        "newbuildingWithExtendedFeatures": null,
+        "businessShoppingCenter": null,
+        "isPremium": true,
+        "balconiesCount": 0,
+        "status": "published",
+        "floorNumber": 6,
+        "isBookedFromDeveloper": false,
+        "humanizedTimedelta": "вчера",
+        "isByHomeowner": false,
+        "garage": null,
+        "readyBusinessType": null,
+        "coworkingOfferType": null,
+        "moderationInfo": {
+          "showContactWarningMessage": false,
+          "warningMessage": null,
+          "photoStub": null
+        },
+        "isNew": false,
+        "areaParts": null,
+        "cianId": 333183294,
+        "allFromOffrep": null,
+        "videos": [],
+        "kp": null,
+        "bedroomsCount": null,
+        "isStandard": false,
+        "decoration": null,
+        "officeType": null,
+        "isEarlyAccessEnabled": false,
+        "livingArea": null,
+        "title": null,
+        "specialty": {
+          "types": [],
+          "additionalTypes": [],
+          "specialties": []
+        },
+        "workplaceCount": null,
+        "demolishedInMoscowProgramm": false,
+        "cadastralNumber": null,
+        "promoInfo": null,
+        "tradingLink": null,
+        "isRentByParts": false,
+        "isByCommercialOwner": null,
+        "added": "вчера, 11:07",
+        "userId": 47557313,
+        "isExcludedFromAction": false,
+        "isLayoutApproved": null,
+        "formattedShortPrice": "55 000 ₽/мес.",
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "47557313",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": true,
+          "isPassportVerified": true,
+          "isSubAgent": true,
+          "userId": 47557313,
+          "userTrustLevel": "involved",
+          "accountType": "specialist",
+          "agencyName": "Игорь Соснин",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=51820428&t=2&p=2&timestamp=1656583167",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": true,
+              "isSuperHost": false,
+              "levelName": "Суперагент",
+              "levelOrder": 4,
+              "levelSystemName": "max",
+              "showHighResponsibility": true,
+              "showSuperAgent": true,
+              "showSuperHost": false
+            },
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 0,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Санкт-Петербург и область",
+                "locationId": 2,
+                "packageTypeId": 2,
+                "packageTypeName": "Базовый"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": true,
+          "cianProfileStatus": "hide",
+          "companyName": "8 ЭТАЖ",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "masterAgent": {
+            "absoluteAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=212842&t=2&p=2&timestamp=1713628688",
+            "absoluteMiniAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=212842&t=2&p=1&timestamp=1713628688",
+            "accountType": "agency",
+            "avatarUrl": "/api/get-avatar/?i=212842&t=2&p=2&timestamp=1713628688",
+            "id": 12478232,
+            "isModerationPassed": true,
+            "miniAvatarUrl": "/api/get-avatar/?i=212842&t=2&p=1&timestamp=1713628688",
+            "name": "8 ЭТАЖ",
+            "profileUri": "company/12478232/"
+          },
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9523873161"
+            }
+          ],
+          "subAgentCompanyName": "8 ЭТАЖ",
+          "userType": "realtor_based",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 47557313,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": true,
+        "gaLabel": "/rent/flat/mo_id=0/obl_id=2/city_id=2/object_type=1/ga_obj_type=2/spec=agent/rent_type=/333183294/from_developer=0/repres=0/owner=0/pod_snos=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_rent",
+          "puid2": "offer_flat",
+          "puid4": "offer_type_2",
+          "puid5": "obl_id_2",
+          "puid6": "51_100",
+          "puid8": 55000,
+          "puid9": 195,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid19": "not_video",
+          "puid21": 195,
+          "puid36": 2
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": false,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": null,
+        "photoFeatureIcons": [],
+        "factoids": [],
+        "brandingLevel": "firstLevel",
+        "isRosreestrChecked": false,
+        "isOnlineRentalAgreementEnabled": null,
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": false
+      }
+    ]
+  }
+}

--- a/packages/cian-connector/tests/fixtures/search_rent_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/search_rent_live.provenance.json
@@ -1,0 +1,54 @@
+{
+  "captured": "2026-09-09",
+  "endpoint": "https://api.cian.ru/search-offers/v2/search-offers-desktop/",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "jsonQuery": {
+    "_type": "flatrent",
+    "engine_version": {
+      "type": "term",
+      "value": 2
+    },
+    "region": {
+      "type": "terms",
+      "value": [
+        2
+      ]
+    },
+    "page": {
+      "type": "term",
+      "value": 1
+    },
+    "for_day": {
+      "type": "term",
+      "value": "!1"
+    },
+    "room": {
+      "type": "terms",
+      "value": [
+        2
+      ]
+    },
+    "price": {
+      "type": "range",
+      "value": {
+        "gte": 40000,
+        "lte": 60000
+      }
+    }
+  },
+  "displayed": {
+    "status": 200,
+    "count": 28,
+    "offerCount": 1228,
+    "aggregatedCount": 1227,
+    "first": {
+      "id": 317754437,
+      "priceRur": 60000,
+      "price": 60000,
+      "userInput": "Россия, Санкт-Петербург, проспект Просвещения, 83",
+      "category": "flatRent",
+      "fullUrl": "https://spb.cian.ru/rent/flat/317754437/?mlSearchSessionGuid=04cee7065c9de1921e1e12b67e121d18"
+    }
+  },
+  "trimmed": "first 3 offers; description cut to 300 chars; photos cut to 2"
+}

--- a/packages/cian-connector/tests/fixtures/search_sale_live.json
+++ b/packages/cian-connector/tests/fixtures/search_sale_live.json
@@ -1,0 +1,2021 @@
+{
+  "status": "ok",
+  "data": {
+    "jsonQuery": {
+      "_type": "flatsale",
+      "engine_version": {
+        "type": "term",
+        "value": 2
+      },
+      "region": {
+        "type": "terms",
+        "value": [
+          1
+        ]
+      },
+      "price": {
+        "type": "range",
+        "value": {
+          "gte": 10000000,
+          "lte": 12000000
+        }
+      },
+      "page": {
+        "type": "term",
+        "value": 1
+      },
+      "room": {
+        "type": "terms",
+        "value": [
+          1
+        ]
+      }
+    },
+    "offerCount": 636,
+    "aggregatedCount": 501,
+    "fullUrl": "https://www.cian.ru/cat.php?currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&p=1&region=1&room1=1",
+    "avgPriceInformer": {
+      "price": 11400000,
+      "currency": "rur"
+    },
+    "offersSerialized": [
+      {
+        "newbuildingVasPromotion": null,
+        "isExcludedFromAction": false,
+        "isByHomeowner": null,
+        "isNeedHideExactAddress": false,
+        "promoInfo": null,
+        "dealType": "sale",
+        "flatType": "rooms",
+        "minArea": null,
+        "phones": [
+          {
+            "number": "9230727409",
+            "countryCode": "7"
+          }
+        ],
+        "fromDeveloper": true,
+        "fullUrl": "https://www.cian.ru/sale/flat/331002424/?mlSearchSessionGuid=5de2db838918a063854e163ee9623af6",
+        "readyBusinessType": null,
+        "formattedFullPrice": "11 985 439 ₽",
+        "formattedShortPrice": "11 985 439 ₽",
+        "isNew": false,
+        "dealRentVersion": null,
+        "roomArea": null,
+        "cadastralNumber": null,
+        "formattedShortInfo": "1-комн.кв.  ·  12/22 этаж",
+        "title": null,
+        "roomsCount": 1,
+        "offerFeatureLabelsV2": [],
+        "shareAmount": null,
+        "hasFurniture": null,
+        "balconiesCount": null,
+        "videos": [
+          {
+            "id": "456239331",
+            "uploadDate": "2025-10-30T13:14:38+00:00",
+            "url": "https://vkvideo.ru/video_ext.php?oid=-34496106&id=456239331&hd=2&hash=f1f6731c9fa8e20f",
+            "type": "vk",
+            "duration": 170,
+            "previewUrl": "https://iv.okcdn.ru/getVideoPreview?id=9276621916909&idx=12&type=39&tkn=7SPc820List5MGet0stC8R89t4A&fn=vid_w"
+          }
+        ],
+        "newbuildingCplLayer": "otherPromoted",
+        "newbuilding": {
+          "showJkReliableFlag": false,
+          "id": 1448,
+          "isPremium": false,
+          "isSalesLeader": true,
+          "hasFlatTourBooking": false,
+          "comparisonStatus": null,
+          "isFichering": true,
+          "isFromSeller": false,
+          "isFromBuilder": true,
+          "name": "Город-парк Первый Московский",
+          "isFromLeadFactory": false,
+          "house": {
+            "section": "Секция 1",
+            "id": 10922142,
+            "isFinished": false,
+            "finishDate": {
+              "year": 2029,
+              "quarter": 3
+            },
+            "name": "6 корпус (11 квартал)"
+          },
+          "isFromDeveloper": true,
+          "countPromos": 8,
+          "snippetType": "advanced"
+        },
+        "photos": [
+          {
+            "isLayout": true,
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2953413873-4.jpg",
+            "id": 2953413873,
+            "rotateDegree": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/2953413873-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2953413873-2.jpg",
+            "isDefault": false,
+            "miniUrl": "https://images.cdn-cian.ru/images/2953413873-3.jpg"
+          },
+          {
+            "isLayout": false,
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2958331459-4.jpg",
+            "id": 2958331459,
+            "rotateDegree": null,
+            "fullUrl": "https://images.cdn-cian.ru/images/2958331459-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2958331459-2.jpg",
+            "isDefault": false,
+            "miniUrl": "https://images.cdn-cian.ru/images/2958331459-3.jpg"
+          }
+        ],
+        "isEarlyAccessEnabled": null,
+        "rosreestrCheck": null,
+        "isLayoutApproved": null,
+        "jkUrl": "https://zhk-gorod-park-pervyy-moskovskiy-i.cian.ru/",
+        "kitchenArea": "16.6",
+        "externalId": null,
+        "isPremium": false,
+        "offerType": "flat",
+        "creationDate": "2026-06-11T19:42:24.507",
+        "kp": null,
+        "isAuction": false,
+        "buildingCadastralNumber": null,
+        "buildersIds": [
+          5956
+        ],
+        "loggiasCount": null,
+        "building": {
+          "cargoLiftsCount": 2,
+          "materialType": "monolith",
+          "heatingType": null,
+          "parking": null,
+          "deadline": {
+            "isComplete": false,
+            "quarterEnd": "2029-09-30",
+            "year": 2029,
+            "quarter": "third"
+          },
+          "buildYear": null,
+          "type": null,
+          "passengerLiftsCount": 2,
+          "floorsCount": 22,
+          "accessType": null,
+          "classType": null
+        },
+        "newbuildingWithExtendedFeatures": false,
+        "monthlyIncome": null,
+        "workplaceCount": null,
+        "descriptionWordsHighlighted": [],
+        "decoration": "without",
+        "land": null,
+        "addedTimestamp": 1788549007,
+        "cianUserId": 134642318,
+        "added": "4 сен, 22:10",
+        "auction": {},
+        "villageMortgageAllowed": false,
+        "layout": null,
+        "commercialOwnership": null,
+        "formattedAdditionalInfo": "Долевое участие (214-ФЗ), возможна ипотека",
+        "isSubsidisedMortgage": null,
+        "categoriesIds": [
+          1,
+          100,
+          110,
+          113
+        ],
+        "userId": 134642318,
+        "booking": null,
+        "isBookedFromDeveloper": false,
+        "coworking": null,
+        "descriptionMinhash": [
+          18308017,
+          7301773,
+          3583066,
+          9618444,
+          4619971,
+          13162573,
+          3461634,
+          45820160,
+          33951044,
+          48014802,
+          7735558,
+          13033977,
+          2852019,
+          7517558,
+          49087523,
+          12481266,
+          15159853,
+          3574582,
+          20509280,
+          6351486,
+          117996751,
+          33389951,
+          5584062,
+          38130276,
+          30266932,
+          29275567,
+          43367606,
+          794253,
+          23909840,
+          31010081,
+          12218809,
+          18591719
+        ],
+        "showWarningMessage": false,
+        "areaParts": null,
+        "isCommercialOwnershipVerified": null,
+        "officeType": null,
+        "moderationInfo": {
+          "showContactWarningMessage": false,
+          "photoStub": null,
+          "warningMessage": null
+        },
+        "tradingLink": null,
+        "isRecidivist": false,
+        "isRentByParts": false,
+        "rentByPartsDescription": null,
+        "demolishedInMoscowProgramm": null,
+        "floorNumber": 12,
+        "isStandard": false,
+        "allFromOffrep": null,
+        "permittedUseType": null,
+        "isImported": true,
+        "isInCpd": false,
+        "garage": null,
+        "livingArea": null,
+        "isInHiddenBase": false,
+        "description": "Продается однокомнатная квартира  в 11 квартале города-парка \"Первый Московский\". \nОбщая площадь квартиры - 38,1 кв. м, этаж 12 из 22. \nПланируемый срок ввода в эксплуатацию - 3 квартал 2029 года. \nТип дома - монолитный. \n \nТОЛЬКО ДО 30 СЕНТЯБРЯ выгодные условия на приобретение квартиры в ипотеку. \n",
+        "bedroomsCount": null,
+        "isTop3": false,
+        "businessShoppingCenter": null,
+        "cianId": 331002424,
+        "coworkingOfferType": null,
+        "roomsForSaleCount": null,
+        "isApartments": false,
+        "status": "published",
+        "formattedFullInfo": "1-комн.кв.  ·  38,1 м²  ·  12/22 этаж",
+        "isCalltrackingEnabled": true,
+        "isColorized": false,
+        "isByCommercialOwner": null,
+        "totalArea": "38.1",
+        "publishedUserId": 134642318,
+        "workTimeInfo": {
+          "callFrom": "09:00:00",
+          "callTo": "21:00:00",
+          "isAvailable": false,
+          "timezoneText": "Московскому"
+        },
+        "specialty": {
+          "specialties": [],
+          "additionalTypes": [],
+          "types": []
+        },
+        "basicProfiScore": 0,
+        "bargainTerms": {
+          "bargainAllowed": null,
+          "saleType": "fz214",
+          "leaseType": null,
+          "clientFee": null,
+          "paymentPeriod": null,
+          "leaseTermType": null,
+          "priceForWorkplace": null,
+          "utilitiesTerms": null,
+          "mortgageAllowed": true,
+          "priceRur": 11985439,
+          "agentFee": null,
+          "vatType": null,
+          "priceType": "all",
+          "tags": [],
+          "agentBonus": null,
+          "price": 11985439,
+          "vatPrice": null,
+          "currency": "rur",
+          "deposit": null
+        },
+        "isCianPartner": false,
+        "accessType": null,
+        "humanizedTimedelta": "четыре дня назад",
+        "offerInDeal": false,
+        "category": "newBuildingFlatSale",
+        "id": 331002424,
+        "geo": {
+          "coordinates": {
+            "lng": 37.3612718295558,
+            "lat": 55.606802608988
+          },
+          "districts": [
+            {
+              "fullName": "Московский",
+              "id": 332,
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=332&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "title": "Московский",
+              "geoType": "district",
+              "parentId": 325,
+              "type": "poselenie",
+              "locationId": 1,
+              "name": "Московский"
+            },
+            {
+              "fullName": "НАО (Новомосковский)",
+              "id": 325,
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=325&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "title": "НАО (Новомосковский)",
+              "geoType": "district",
+              "parentId": null,
+              "type": "okrug",
+              "locationId": 1,
+              "name": "НАО (Новомосковский)"
+            }
+          ],
+          "highways": [
+            {
+              "id": 12,
+              "isDefault": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&highway%5B0%5D=12&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "geoType": "highway",
+              "distance": "7.0",
+              "name": "Киевское"
+            },
+            {
+              "id": 2,
+              "isDefault": null,
+              "qs": "currency=2&deal_type=sale&engine_version=2&highway%5B0%5D=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "geoType": "highway",
+              "distance": "12.0",
+              "name": "Боровское"
+            }
+          ],
+          "countryId": 138,
+          "buildingAddress": null,
+          "userInput": "Москва, Московский, микрорайон Первый Московский",
+          "railways": [
+            {
+              "directionIds": [
+                14
+              ],
+              "id": 848,
+              "time": 10,
+              "geoType": "railway",
+              "travelType": "byCar",
+              "distance": 6.0,
+              "name": "Аэропорт Внуково",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=848&room1=1"
+            },
+            {
+              "directionIds": [
+                14
+              ],
+              "id": 766,
+              "time": 10,
+              "geoType": "railway",
+              "travelType": "byCar",
+              "distance": 7.0,
+              "name": "Новопеределкино",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=766&room1=1"
+            },
+            {
+              "directionIds": [
+                14
+              ],
+              "id": 778,
+              "time": 17,
+              "geoType": "railway",
+              "travelType": "byCar",
+              "distance": 11.0,
+              "name": "Мичуринец",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=778&room1=1"
+            }
+          ],
+          "undergrounds": [
+            {
+              "id": 367,
+              "releaseYear": null,
+              "isDefault": true,
+              "lineId": 4,
+              "time": 6,
+              "lineColor": "FFDF00",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=367&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "cianId": null,
+              "name": "Рассказовка",
+              "transportType": "transport",
+              "lineType": null
+            },
+            {
+              "id": 366,
+              "releaseYear": null,
+              "isDefault": null,
+              "lineId": 4,
+              "time": 9,
+              "lineColor": "FFDF00",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=366&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "cianId": null,
+              "name": "Новопеределкино",
+              "transportType": "transport",
+              "lineType": null
+            },
+            {
+              "id": 535,
+              "releaseYear": null,
+              "isDefault": null,
+              "lineId": 4,
+              "time": 9,
+              "lineColor": "FFDF00",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=535&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "cianId": null,
+              "name": "Аэропорт Внуково",
+              "transportType": "transport",
+              "lineType": null
+            }
+          ],
+          "address": [
+            {
+              "fullName": "Москва",
+              "id": 1,
+              "isFormingAddress": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&region=1&room1=1",
+              "shortName": "Москва",
+              "locationTypeId": 1,
+              "title": "Москва",
+              "geoType": "location",
+              "type": "location",
+              "name": "Москва"
+            },
+            {
+              "fullName": "НАО (Новомосковский)",
+              "id": 325,
+              "isFormingAddress": null,
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=325&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "НАО (Новомосковский)",
+              "locationTypeId": null,
+              "title": "НАО (Новомосковский)",
+              "geoType": "district",
+              "type": "okrug",
+              "name": "НАО (Новомосковский)"
+            },
+            {
+              "fullName": "м. Рассказовка",
+              "id": 367,
+              "isFormingAddress": null,
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=367&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "м. Рассказовка",
+              "locationTypeId": null,
+              "title": "м. Рассказовка",
+              "geoType": "underground",
+              "type": "metro",
+              "name": "Рассказовка"
+            },
+            {
+              "fullName": "Московский г.",
+              "id": 1224131,
+              "isFormingAddress": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=1224131&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "Московский",
+              "locationTypeId": 1,
+              "title": "Московский г.",
+              "geoType": "location",
+              "type": "location",
+              "name": "Московский"
+            },
+            {
+              "fullName": "Первый Московский мкр",
+              "id": 252280,
+              "isFormingAddress": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=252280&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "Первый Московский микрорайон",
+              "locationTypeId": 174,
+              "title": "Первый Московский мкр",
+              "geoType": "location",
+              "type": "location",
+              "name": "Первый Московский"
+            },
+            {
+              "fullName": "Первый Московский ЖК",
+              "id": 312653,
+              "isFormingAddress": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=312653&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "Первый Московский жилой комплекс",
+              "locationTypeId": 213,
+              "title": "Первый Московский ЖК",
+              "geoType": "location",
+              "type": "location",
+              "name": "Первый Московский"
+            },
+            {
+              "fullName": "11-я фаза",
+              "id": 470077,
+              "isFormingAddress": true,
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=470077&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "shortName": "11-я фаза",
+              "locationTypeId": 308,
+              "title": "11-я фаза",
+              "geoType": "location",
+              "type": "location",
+              "name": "11-я"
+            }
+          ],
+          "jk": {
+            "id": 1448,
+            "webSiteUrl": "https://www.absrealty.ru/projects/pervyj-moskovskij",
+            "webSiteUrlUtm": "https://www.absrealty.ru/projects/pervyj-moskovskij?utm_source=cian&utm_medium=kartochka_cian&utm_campaign=1448",
+            "fullUrl": "https://zhk-gorod-park-pervyy-moskovskiy-i.cian.ru/",
+            "displayName": "ЖК «Город-парк Первый Московский»",
+            "developer": {
+              "name": "Абсолют Недвижимость",
+              "id": null
+            },
+            "gaGeo": {
+              "moId": 0,
+              "cityId": 1224131,
+              "oblId": 1
+            },
+            "name": "Город-парк Первый Московский",
+            "house": {
+              "name": "6 корпус (11 квартал)",
+              "id": 10922142
+            }
+          },
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 367
+            },
+            {
+              "type": "underground",
+              "id": 366
+            },
+            {
+              "type": "underground",
+              "id": 535
+            },
+            {
+              "type": "railway",
+              "id": 848
+            },
+            {
+              "type": "railway",
+              "id": 766
+            },
+            {
+              "type": "railway",
+              "id": 778
+            },
+            {
+              "type": "highway",
+              "id": 12
+            },
+            {
+              "type": "highway",
+              "id": 2
+            },
+            {
+              "type": "district",
+              "id": 332
+            },
+            {
+              "type": "district",
+              "id": 325
+            }
+          ]
+        },
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "134642318",
+          "isAgent": true,
+          "isBuilder": true,
+          "isCallbackUser": true,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": false,
+          "isSubAgent": false,
+          "userId": 134642318,
+          "userTrustLevel": "notInvolved",
+          "accountType": "agency",
+          "agencyName": "Абсолют Недвижимость",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=72650908&t=2&p=2&timestamp=1766554569",
+          "agentModerationInfo": {
+            "isUserIdentified": false,
+            "isUserIdentifiedByDocuments": false,
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 1,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Москва и ближнее Подмосковье",
+                "locationId": 1,
+                "packageTypeId": 5,
+                "packageTypeName": "Застройщик"
+              },
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Дальнее Подмосковье",
+                "locationId": 4593,
+                "packageTypeId": 5,
+                "packageTypeName": "Застройщик"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": true
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "Абсолют Недвижимость",
+          "isChatsEnabled": false,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9253532887"
+            },
+            {
+              "countryCode": "+7",
+              "number": "9263483889"
+            }
+          ],
+          "userType": "developer",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 134642318,
+            "vacationTo": null
+          },
+          "agentLists": [],
+          "profileUri": "zastroishchik-absolyut-nedvizhimost-5956/"
+        },
+        "isPro": true,
+        "gaLabel": "/sale/flat/mo_id=0/obl_id=1/city_id=470077/object_type=2/ga_obj_type=1/spec=company/331002424/from_developer=1/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_sale",
+          "puid2": "offer_flat",
+          "puid3": "sale_type_first",
+          "puid4": "offer_type_1",
+          "puid5": "obl_id_1",
+          "puid6": "10001_15000",
+          "puid7": "2323",
+          "puid8": 11985439,
+          "puid9": 367,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid18": 1448,
+          "puid19": "not_video",
+          "puid36": 1,
+          "puid41": "business"
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": false
+        },
+        "isUnique": true,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": true,
+        "isExternalTourAvailable": true,
+        "comparisonStatus": {
+          "status": "available",
+          "description": "Добавить к сравнению"
+        },
+        "photoFeatureIcons": [
+          {
+            "type": "has3dTour",
+            "text": "Объявление с 3D-туром",
+            "link": "https://www.cian.ru/sale/flat/331002424/"
+          },
+          {
+            "type": "hasVideo",
+            "text": "Объявление с видео",
+            "link": "https://www.cian.ru/sale/flat/331002424/"
+          }
+        ],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "3 кв 2029"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "6 корпус (11 квартал)"
+          }
+        ],
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": {
+          "title": "В ипотеку от 55 885 ₽/мес",
+          "programTypeWithRate": "Семейная 5,75%",
+          "descriptionDialog": {
+            "title": "Семейная ипотека 5,75%"
+          }
+        },
+        "newbuildingBroker": {
+          "bookingEnabled": true
+        },
+        "offerFeatureLabels": [
+          "ЖК лидер продаж"
+        ],
+        "isNewLabel": false
+      },
+      {
+        "layout": null,
+        "rentByPartsDescription": null,
+        "description": "Продаётся 1-комнатная квартира в Северном Измайлово по адресу: Москва, Сиреневый бульвар, 27к1.\n\nКвартира общей площадью 31,3 м², жилая площадь — 21,2 м², кухня — 5,2 м². Расположена на комфортном 3 этаже 9-этажного дома. Квартира светлая, с удобной планировкой и хорошим соотношением жилой площади. ",
+        "isCalltrackingEnabled": true,
+        "tradingLink": null,
+        "rosreestrCheck": null,
+        "offerType": "flat",
+        "showWarningMessage": false,
+        "cianUserId": 132219853,
+        "isInCpd": true,
+        "isNew": false,
+        "flatType": "rooms",
+        "bargainTerms": {
+          "bargainAllowed": null,
+          "mortgageAllowed": true,
+          "paymentPeriod": null,
+          "saleType": "free",
+          "agentBonus": null,
+          "leaseTermType": null,
+          "vatType": null,
+          "clientFee": null,
+          "priceType": "all",
+          "utilitiesTerms": null,
+          "tags": [],
+          "agentFee": null,
+          "vatPrice": null,
+          "leaseType": null,
+          "priceRur": 11900000,
+          "priceForWorkplace": null,
+          "price": 11900000,
+          "deposit": null,
+          "currency": "rur"
+        },
+        "auction": {},
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9863239225"
+          }
+        ],
+        "kitchenArea": "5.2",
+        "isByCommercialOwner": null,
+        "isNeedHideExactAddress": false,
+        "publishedUserId": 132219853,
+        "hasFurniture": true,
+        "land": null,
+        "businessShoppingCenter": null,
+        "loggiasCount": 0,
+        "floorNumber": 3,
+        "monthlyIncome": null,
+        "workTimeInfo": null,
+        "isImported": false,
+        "newbuildingVasPromotion": null,
+        "formattedFullInfo": "1-комн.кв.  ·  31,3 м²  ·  3/9 этаж",
+        "villageMortgageAllowed": false,
+        "basicProfiScore": 0,
+        "offerInDeal": false,
+        "category": "flatSale",
+        "videos": [],
+        "isColorized": false,
+        "id": 333761512,
+        "cadastralNumber": null,
+        "isSubsidisedMortgage": null,
+        "isAuction": false,
+        "geo": {
+          "buildingAddress": null,
+          "userInput": "Россия, Москва, Сиреневый бульвар, 27к1",
+          "highways": [],
+          "jk": null,
+          "coordinates": {
+            "lng": 37.796355,
+            "lat": 55.803418
+          },
+          "railways": [
+            {
+              "travelType": "byCar",
+              "id": 771,
+              "distance": 8.0,
+              "name": "Стройка",
+              "directionIds": [
+                12
+              ],
+              "time": 10,
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=771&room1=1"
+            },
+            {
+              "travelType": "byCar",
+              "id": 701,
+              "distance": 8.0,
+              "name": "Электрозаводская",
+              "directionIds": [
+                13
+              ],
+              "time": 13,
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=701&room1=1"
+            },
+            {
+              "travelType": "byCar",
+              "id": 737,
+              "distance": 9.0,
+              "name": "Новогиреево",
+              "directionIds": [
+                12
+              ],
+              "time": 13,
+              "geoType": "railway",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=737&room1=1"
+            }
+          ],
+          "countryId": 138,
+          "districts": [
+            {
+              "fullName": "р-н Северное Измайлово",
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=69&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "type": "raion",
+              "id": 69,
+              "title": "р-н Северное Измайлово",
+              "name": "Северное Измайлово",
+              "parentId": 7,
+              "locationId": 1,
+              "geoType": "district"
+            },
+            {
+              "fullName": "ВАО",
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=7&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "type": "okrug",
+              "id": 7,
+              "title": "ВАО",
+              "name": "ВАО",
+              "parentId": null,
+              "locationId": 1,
+              "geoType": "district"
+            }
+          ],
+          "undergrounds": [
+            {
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=153&minprice=10000000&offer_type=flat&room1=1",
+              "lineColor": "03238B",
+              "transportType": "walk",
+              "releaseYear": null,
+              "underConstruction": false,
+              "id": 153,
+              "lineId": 1,
+              "name": "Щёлковская",
+              "time": 7,
+              "isDefault": true,
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=89&minprice=10000000&offer_type=flat&room1=1",
+              "lineColor": "03238B",
+              "transportType": "walk",
+              "releaseYear": null,
+              "underConstruction": false,
+              "id": 89,
+              "lineId": 1,
+              "name": "Первомайская",
+              "time": 12,
+              "isDefault": false,
+              "cianId": null,
+              "lineType": null
+            },
+            {
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=41&minprice=10000000&offer_type=flat&room1=1",
+              "lineColor": "03238B",
+              "transportType": "transport",
+              "releaseYear": null,
+              "underConstruction": false,
+              "id": 41,
+              "lineId": 1,
+              "name": "Измайловская",
+              "time": 4,
+              "isDefault": false,
+              "cianId": null,
+              "lineType": null
+            }
+          ],
+          "address": [
+            {
+              "fullName": "Москва",
+              "locationTypeId": 1,
+              "shortName": "Москва",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&region=1&room1=1",
+              "type": "location",
+              "id": 1,
+              "title": "Москва",
+              "name": "Москва",
+              "isFormingAddress": true,
+              "geoType": "location"
+            },
+            {
+              "fullName": "ВАО",
+              "locationTypeId": null,
+              "shortName": "ВАО",
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=7&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "type": "okrug",
+              "id": 7,
+              "title": "ВАО",
+              "name": "ВАО",
+              "isFormingAddress": null,
+              "geoType": "district"
+            },
+            {
+              "fullName": "р-н Северное Измайлово",
+              "locationTypeId": null,
+              "shortName": "р-н Северное Измайлово",
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=69&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "type": "raion",
+              "id": 69,
+              "title": "р-н Северное Измайлово",
+              "name": "Северное Измайлово",
+              "isFormingAddress": null,
+              "geoType": "district"
+            },
+            {
+              "fullName": "м. Щёлковская",
+              "locationTypeId": null,
+              "shortName": "м. Щёлковская",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=153&minprice=10000000&offer_type=flat&room1=1",
+              "type": "metro",
+              "id": 153,
+              "title": "м. Щёлковская",
+              "name": "Щёлковская",
+              "isFormingAddress": null,
+              "geoType": "underground"
+            },
+            {
+              "fullName": "Сиреневый бульвар",
+              "locationTypeId": null,
+              "shortName": "Сиреневый бул.",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1&street%5B0%5D=2094",
+              "type": "street",
+              "id": 2094,
+              "title": "Сиреневый бульвар",
+              "name": "Сиреневый",
+              "isFormingAddress": true,
+              "geoType": "street"
+            },
+            {
+              "fullName": "27К1",
+              "locationTypeId": null,
+              "shortName": "27К1",
+              "qs": "currency=2&deal_type=sale&engine_version=2&house%5B0%5D=73810&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "type": "house",
+              "id": 73810,
+              "title": "27К1",
+              "name": "27К1",
+              "isFormingAddress": true,
+              "geoType": "house"
+            }
+          ],
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 153
+            },
+            {
+              "type": "underground",
+              "id": 89
+            },
+            {
+              "type": "underground",
+              "id": 41
+            },
+            {
+              "type": "railway",
+              "id": 771
+            },
+            {
+              "type": "railway",
+              "id": 701
+            },
+            {
+              "type": "railway",
+              "id": 737
+            },
+            {
+              "type": "district",
+              "id": 69
+            },
+            {
+              "type": "district",
+              "id": 7
+            }
+          ]
+        },
+        "roomsForSaleCount": null,
+        "shareAmount": null,
+        "cianId": 333761512,
+        "booking": null,
+        "isCianPartner": false,
+        "buildingCadastralNumber": null,
+        "isCommercialOwnershipVerified": null,
+        "userId": 132219853,
+        "addedTimestamp": 1788960260,
+        "offerFeatureLabelsV2": [],
+        "isTop3": true,
+        "promoInfo": null,
+        "humanizedTimedelta": "4 часа назад",
+        "commercialOwnership": null,
+        "formattedShortPrice": "11 900 000 ₽",
+        "kp": null,
+        "dealType": "sale",
+        "coworking": null,
+        "formattedShortInfo": "1-комн.кв.  ·  3/9 этаж",
+        "isApartments": false,
+        "bedroomsCount": null,
+        "workplaceCount": null,
+        "totalArea": "31.3",
+        "added": "сегодня, 16:24",
+        "isRentByParts": false,
+        "balconiesCount": 1,
+        "dealRentVersion": null,
+        "creationDate": "2026-09-09T15:13:58.317",
+        "moderationInfo": {
+          "photoStub": null,
+          "showContactWarningMessage": false,
+          "warningMessage": null
+        },
+        "specialty": {
+          "additionalTypes": [],
+          "types": [],
+          "specialties": []
+        },
+        "formattedFullPrice": "11 900 000 ₽",
+        "coworkingOfferType": null,
+        "minArea": null,
+        "formattedAdditionalInfo": "Свободная продажа, возможна ипотека",
+        "photos": [
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961468085-4.jpg",
+            "rotateDegree": null,
+            "isLayout": false,
+            "id": 2961468085,
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961468085-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961468085-2.jpg",
+            "isDefault": true,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961468085-1.jpg"
+          },
+          {
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961466350-4.jpg",
+            "rotateDegree": null,
+            "isLayout": false,
+            "id": 2961466350,
+            "miniUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961466350-3.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961466350-2.jpg",
+            "isDefault": false,
+            "fullUrl": "https://images.cdn-cian.ru/images/kvartira-moskva-sirenevyy-bulvar-2961466350-1.jpg"
+          }
+        ],
+        "fromDeveloper": false,
+        "fullUrl": "https://www.cian.ru/sale/flat/333761512/?mlSearchSessionGuid=5de2db838918a063854e163ee9623af6",
+        "accessType": null,
+        "isPremium": false,
+        "categoriesIds": [
+          1,
+          100,
+          110,
+          111
+        ],
+        "newbuildingCplLayer": null,
+        "title": "однушка в Северном Измайлово",
+        "newbuildingWithExtendedFeatures": null,
+        "readyBusinessType": null,
+        "externalId": null,
+        "isStandard": false,
+        "isInHiddenBase": false,
+        "jkUrl": null,
+        "isBookedFromDeveloper": null,
+        "roomArea": null,
+        "isLayoutApproved": null,
+        "officeType": null,
+        "isEarlyAccessEnabled": null,
+        "allFromOffrep": null,
+        "status": "published",
+        "isRecidivist": false,
+        "livingArea": "21.2",
+        "descriptionMinhash": [
+          14467733,
+          4828131,
+          20734870,
+          42337346,
+          19619075,
+          15707023,
+          48336418,
+          53523005,
+          9230228,
+          48195840,
+          22965245,
+          1006418,
+          5958311,
+          2039279,
+          5165062,
+          15438368,
+          48790356,
+          4960642,
+          74236807,
+          6983705,
+          56828475,
+          136142293,
+          1611909,
+          38907129,
+          89496755,
+          17152915,
+          27025535,
+          131947161,
+          60077067,
+          51652993,
+          117625516,
+          25429645
+        ],
+        "areaParts": null,
+        "permittedUseType": null,
+        "demolishedInMoscowProgramm": false,
+        "roomsCount": 1,
+        "buildersIds": [],
+        "building": {
+          "accessType": null,
+          "heatingType": null,
+          "buildYear": 1963,
+          "classType": null,
+          "type": null,
+          "passengerLiftsCount": 1,
+          "deadline": null,
+          "parking": {
+            "purposeType": null,
+            "isFree": null,
+            "locationType": null,
+            "isAvailable": null,
+            "priceMonthly": null,
+            "placesCount": null,
+            "type": "ground",
+            "currency": null,
+            "priceEntry": null
+          },
+          "cargoLiftsCount": null,
+          "floorsCount": 9,
+          "materialType": "block"
+        },
+        "newbuilding": null,
+        "descriptionWordsHighlighted": [],
+        "garage": null,
+        "isByHomeowner": false,
+        "isExcludedFromAction": false,
+        "decoration": null,
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "132219853",
+          "isAgent": true,
+          "isBuilder": false,
+          "isCallbackUser": false,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": true,
+          "isSubAgent": false,
+          "userId": 132219853,
+          "userTrustLevel": "notInvolved",
+          "accountType": "agency",
+          "agencyName": "GK Недвижимость",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=71906879&t=2&p=2&timestamp=1751039985",
+          "agentModerationInfo": {
+            "isUserIdentified": true,
+            "isUserIdentifiedByDocuments": true,
+            "qualityLevelInfo": {
+              "hasVerifiedDocuments": true,
+              "highResponsibility": true,
+              "isBlocked": false,
+              "isSuperAgent": true,
+              "isSuperHost": false,
+              "levelName": "Суперагент",
+              "levelOrder": 4,
+              "levelSystemName": "max",
+              "showHighResponsibility": true,
+              "showSuperAgent": true,
+              "showSuperHost": false
+            },
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 0,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Россия",
+                "packageTypeId": 1,
+                "packageTypeName": "Некоммерческий"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": false
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "GK Недвижимость",
+          "experience": "2020",
+          "isChatsEnabled": true,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9160332434"
+            }
+          ],
+          "profileUri": "company/132219853/",
+          "userType": "realtor_not_commerce",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 132219853,
+            "vacationTo": null
+          },
+          "agentLists": []
+        },
+        "isPro": false,
+        "gaLabel": "/sale/flat/mo_id=0/obl_id=1/city_id=1/object_type=1/ga_obj_type=1/spec=company/333761512/from_developer=0/repres=0/owner=0/pod_snos=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_sale",
+          "puid2": "offer_flat",
+          "puid3": "sale_type_second",
+          "puid4": "offer_type_1",
+          "puid5": "obl_id_1",
+          "puid6": "10001_15000",
+          "puid7": "2323",
+          "puid8": 11900000,
+          "puid9": 153,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid19": "not_video",
+          "puid36": 1,
+          "puid41": "business"
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": true
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": false,
+        "isExternalTourAvailable": false,
+        "comparisonStatus": {
+          "status": "available",
+          "description": "Добавить к сравнению"
+        },
+        "photoFeatureIcons": [],
+        "factoids": [
+          {
+            "type": "livingArea",
+            "title": "Жилая пл.",
+            "text": "21.2 м2"
+          }
+        ],
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "goodPrice": {
+          "priceLabel": "Хорошая цена",
+          "estimationRange": "11,2—13,7 млн ₽"
+        },
+        "isSoldFurnished": true,
+        "bestPlaceAnalyticsAvailable": null,
+        "mortgagePayment": null,
+        "offerFeatureLabels": [],
+        "isNewLabel": true
+      },
+      {
+        "categoriesIds": [
+          1,
+          100,
+          110,
+          113
+        ],
+        "decoration": "without",
+        "isRecidivist": false,
+        "formattedFullInfo": "1-комн.кв.  ·  42,1 м²  ·  7/22 этаж",
+        "kitchenArea": "14.2",
+        "livingArea": null,
+        "auction": {},
+        "newbuilding": {
+          "isFromSeller": false,
+          "id": 1448,
+          "isFromBuilder": true,
+          "name": "Город-парк Первый Московский",
+          "house": {
+            "id": 7538830,
+            "name": "5 корпус (11 квартал)",
+            "isFinished": false,
+            "finishDate": {
+              "quarter": 1,
+              "year": 2029
+            },
+            "section": "Секция 1"
+          },
+          "isFromLeadFactory": false,
+          "comparisonStatus": null,
+          "showJkReliableFlag": false,
+          "isSalesLeader": true,
+          "isFromDeveloper": true,
+          "isPremium": false,
+          "hasFlatTourBooking": false,
+          "isFichering": true,
+          "countPromos": 8,
+          "snippetType": "advanced"
+        },
+        "newbuildingVasPromotion": null,
+        "flatType": "rooms",
+        "balconiesCount": null,
+        "isInCpd": false,
+        "externalId": null,
+        "villageMortgageAllowed": false,
+        "showWarningMessage": false,
+        "formattedShortPrice": "11 887 164 ₽",
+        "fromDeveloper": true,
+        "promoInfo": null,
+        "isPremium": false,
+        "tradingLink": null,
+        "businessShoppingCenter": null,
+        "rentByPartsDescription": null,
+        "coworking": null,
+        "isImported": true,
+        "isAuction": false,
+        "dealType": "sale",
+        "offerType": "flat",
+        "shareAmount": null,
+        "isExcludedFromAction": false,
+        "isStandard": false,
+        "descriptionWordsHighlighted": [],
+        "fullUrl": "https://www.cian.ru/sale/flat/331001739/?mlSearchSessionGuid=5de2db838918a063854e163ee9623af6",
+        "isNew": false,
+        "cadastralNumber": null,
+        "status": "published",
+        "permittedUseType": null,
+        "rosreestrCheck": null,
+        "basicProfiScore": 0,
+        "bedroomsCount": null,
+        "description": "Продается однокомнатная квартира  в 11 квартале города-парка \"Первый Московский\". \nОбщая площадь квартиры - 42,1 кв. м, этаж 7 из 22. \nПланируемый срок ввода в эксплуатацию - 1 квартал 2029 года. \nТип дома - монолитный. \n \nТОЛЬКО ДО 30 СЕНТЯБРЯ выгодные условия на приобретение квартиры в ипотеку. \nЗ",
+        "isApartments": false,
+        "isCianPartner": false,
+        "accessType": null,
+        "isBookedFromDeveloper": false,
+        "demolishedInMoscowProgramm": null,
+        "moderationInfo": {
+          "photoStub": null,
+          "warningMessage": null,
+          "showContactWarningMessage": false
+        },
+        "areaParts": null,
+        "isByCommercialOwner": null,
+        "formattedShortInfo": "1-комн.кв.  ·  7/22 этаж",
+        "publishedUserId": 134642318,
+        "booking": null,
+        "added": "1 сен, 21:58",
+        "newbuildingWithExtendedFeatures": false,
+        "category": "newBuildingFlatSale",
+        "offerInDeal": false,
+        "hasFurniture": null,
+        "isTop3": false,
+        "cianUserId": 134642318,
+        "land": null,
+        "addedTimestamp": 1788289122,
+        "newbuildingCplLayer": "otherPromoted",
+        "isInHiddenBase": false,
+        "minArea": null,
+        "workplaceCount": null,
+        "buildersIds": [
+          5956
+        ],
+        "workTimeInfo": {
+          "callFrom": "09:00:00",
+          "callTo": "21:00:00",
+          "timezoneText": "Московскому",
+          "isAvailable": false
+        },
+        "roomsCount": 1,
+        "offerFeatureLabelsV2": [],
+        "garage": null,
+        "jkUrl": "https://zhk-gorod-park-pervyy-moskovskiy-i.cian.ru/",
+        "kp": null,
+        "id": 331001739,
+        "videos": [
+          {
+            "type": "vk",
+            "id": "456239331",
+            "previewUrl": "https://iv.okcdn.ru/getVideoPreview?id=9276621916909&idx=12&type=39&tkn=7SPc820List5MGet0stC8R89t4A&fn=vid_w",
+            "url": "https://vkvideo.ru/video_ext.php?oid=-34496106&id=456239331&hd=2&hash=f1f6731c9fa8e20f",
+            "uploadDate": "2025-10-30T13:14:38+00:00",
+            "duration": 170
+          }
+        ],
+        "humanizedTimedelta": "неделю назад",
+        "photos": [
+          {
+            "id": 2953399021,
+            "fullUrl": "https://images.cdn-cian.ru/images/2953399021-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2953399021-2.jpg",
+            "rotateDegree": null,
+            "isLayout": true,
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2953399021-4.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/2953399021-3.jpg",
+            "isDefault": false
+          },
+          {
+            "id": 2951001719,
+            "fullUrl": "https://images.cdn-cian.ru/images/2951001719-1.jpg",
+            "thumbnailUrl": "https://images.cdn-cian.ru/images/2951001719-2.jpg",
+            "rotateDegree": null,
+            "isLayout": false,
+            "thumbnail2Url": "https://images.cdn-cian.ru/images/2951001719-4.jpg",
+            "miniUrl": "https://images.cdn-cian.ru/images/2951001719-3.jpg",
+            "isDefault": false
+          }
+        ],
+        "allFromOffrep": null,
+        "userId": 134642318,
+        "coworkingOfferType": null,
+        "geo": {
+          "undergrounds": [
+            {
+              "id": 377,
+              "lineId": 10,
+              "time": 9,
+              "name": "Филатов Луг",
+              "cianId": null,
+              "transportType": "transport",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=377&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "lineColor": "CF0000",
+              "releaseYear": null,
+              "isDefault": true,
+              "lineType": null
+            },
+            {
+              "id": 367,
+              "lineId": 4,
+              "time": 9,
+              "name": "Рассказовка",
+              "cianId": null,
+              "transportType": "transport",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=367&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "lineColor": "FFDF00",
+              "releaseYear": null,
+              "isDefault": null,
+              "lineType": null
+            },
+            {
+              "id": 535,
+              "lineId": 4,
+              "time": 9,
+              "name": "Аэропорт Внуково",
+              "cianId": null,
+              "transportType": "transport",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=535&minprice=10000000&offer_type=flat&room1=1",
+              "underConstruction": false,
+              "lineColor": "FFDF00",
+              "releaseYear": null,
+              "isDefault": null,
+              "lineType": null
+            }
+          ],
+          "address": [
+            {
+              "id": 1,
+              "type": "location",
+              "geoType": "location",
+              "name": "Москва",
+              "shortName": "Москва",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&region=1&room1=1",
+              "fullName": "Москва",
+              "locationTypeId": 1,
+              "isFormingAddress": true,
+              "title": "Москва"
+            },
+            {
+              "id": 325,
+              "type": "okrug",
+              "geoType": "district",
+              "name": "НАО (Новомосковский)",
+              "shortName": "НАО (Новомосковский)",
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=325&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "НАО (Новомосковский)",
+              "locationTypeId": null,
+              "isFormingAddress": null,
+              "title": "НАО (Новомосковский)"
+            },
+            {
+              "id": 377,
+              "type": "metro",
+              "geoType": "underground",
+              "name": "Филатов Луг",
+              "shortName": "м. Филатов Луг",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&metro%5B0%5D=377&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "м. Филатов Луг",
+              "locationTypeId": null,
+              "isFormingAddress": null,
+              "title": "м. Филатов Луг"
+            },
+            {
+              "id": 1224131,
+              "type": "location",
+              "geoType": "location",
+              "name": "Московский",
+              "shortName": "Московский",
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=1224131&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "Московский г.",
+              "locationTypeId": 1,
+              "isFormingAddress": true,
+              "title": "Московский г."
+            },
+            {
+              "id": 252280,
+              "type": "location",
+              "geoType": "location",
+              "name": "Первый Московский",
+              "shortName": "Первый Московский микрорайон",
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=252280&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "Первый Московский мкр",
+              "locationTypeId": 174,
+              "isFormingAddress": true,
+              "title": "Первый Московский мкр"
+            },
+            {
+              "id": 312653,
+              "type": "location",
+              "geoType": "location",
+              "name": "Первый Московский",
+              "shortName": "Первый Московский жилой комплекс",
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=312653&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "Первый Московский ЖК",
+              "locationTypeId": 213,
+              "isFormingAddress": true,
+              "title": "Первый Московский ЖК"
+            },
+            {
+              "id": 470077,
+              "type": "location",
+              "geoType": "location",
+              "name": "11-я",
+              "shortName": "11-я фаза",
+              "qs": "currency=2&deal_type=sale&engine_version=2&location%5B0%5D=470077&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "11-я фаза",
+              "locationTypeId": 308,
+              "isFormingAddress": true,
+              "title": "11-я фаза"
+            }
+          ],
+          "buildingAddress": null,
+          "highways": [
+            {
+              "id": 12,
+              "geoType": "highway",
+              "name": "Киевское",
+              "qs": "currency=2&deal_type=sale&engine_version=2&highway%5B0%5D=12&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "distance": "8.0",
+              "isDefault": true
+            },
+            {
+              "id": 2,
+              "geoType": "highway",
+              "name": "Боровское",
+              "qs": "currency=2&deal_type=sale&engine_version=2&highway%5B0%5D=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "distance": "12.0",
+              "isDefault": null
+            }
+          ],
+          "jk": {
+            "developer": {
+              "name": "Абсолют Недвижимость",
+              "id": null
+            },
+            "id": 1448,
+            "fullUrl": "https://zhk-gorod-park-pervyy-moskovskiy-i.cian.ru/",
+            "webSiteUrl": "https://www.absrealty.ru/projects/pervyj-moskovskij",
+            "name": "Город-парк Первый Московский",
+            "house": {
+              "name": "5 корпус (11 квартал)",
+              "id": 7538830
+            },
+            "displayName": "ЖК «Город-парк Первый Московский»",
+            "gaGeo": {
+              "oblId": 1,
+              "moId": 0,
+              "cityId": 1224131
+            },
+            "webSiteUrlUtm": "https://www.absrealty.ru/projects/pervyj-moskovskij?utm_source=cian&utm_medium=kartochka_cian&utm_campaign=1448"
+          },
+          "districts": [
+            {
+              "id": 332,
+              "type": "poselenie",
+              "geoType": "district",
+              "name": "Московский",
+              "locationId": 1,
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=332&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "Московский",
+              "title": "Московский",
+              "parentId": 325
+            },
+            {
+              "id": 325,
+              "type": "okrug",
+              "geoType": "district",
+              "name": "НАО (Новомосковский)",
+              "locationId": 1,
+              "qs": "currency=2&deal_type=sale&district%5B0%5D=325&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&room1=1",
+              "fullName": "НАО (Новомосковский)",
+              "title": "НАО (Новомосковский)",
+              "parentId": null
+            }
+          ],
+          "railways": [
+            {
+              "id": 848,
+              "geoType": "railway",
+              "time": 9,
+              "directionIds": [
+                14
+              ],
+              "name": "Аэропорт Внуково",
+              "distance": 6.0,
+              "travelType": "byCar",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=848&room1=1"
+            },
+            {
+              "id": 766,
+              "geoType": "railway",
+              "time": 9,
+              "directionIds": [
+                14
+              ],
+              "name": "Новопеределкино",
+              "distance": 7.0,
+              "travelType": "byCar",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=766&room1=1"
+            },
+            {
+              "id": 778,
+              "geoType": "railway",
+              "time": 17,
+              "directionIds": [
+                14
+              ],
+              "name": "Мичуринец",
+              "distance": 11.0,
+              "travelType": "byCar",
+              "qs": "currency=2&deal_type=sale&engine_version=2&maxprice=12000000&minprice=10000000&offer_type=flat&railway%5B0%5D=778&room1=1"
+            }
+          ],
+          "coordinates": {
+            "lat": 55.606695940061,
+            "lng": 37.3625227742378
+          },
+          "userInput": "Москва, Московский, микрорайон Первый Московский, жилой комплекс Первый Московский",
+          "countryId": 138,
+          "sortedGeoIds": [
+            {
+              "type": "underground",
+              "id": 377
+            },
+            {
+              "type": "underground",
+              "id": 367
+            },
+            {
+              "type": "underground",
+              "id": 535
+            },
+            {
+              "type": "railway",
+              "id": 848
+            },
+            {
+              "type": "railway",
+              "id": 766
+            },
+            {
+              "type": "railway",
+              "id": 778
+            },
+            {
+              "type": "highway",
+              "id": 12
+            },
+            {
+              "type": "highway",
+              "id": 2
+            },
+            {
+              "type": "district",
+              "id": 332
+            },
+            {
+              "type": "district",
+              "id": 325
+            }
+          ]
+        },
+        "roomArea": null,
+        "cianId": 331001739,
+        "buildingCadastralNumber": null,
+        "isSubsidisedMortgage": null,
+        "loggiasCount": null,
+        "creationDate": "2026-06-11T19:30:26.74",
+        "isColorized": false,
+        "isEarlyAccessEnabled": null,
+        "descriptionMinhash": [
+          18308017,
+          7301773,
+          13184479,
+          9618444,
+          14636232,
+          13162573,
+          3461634,
+          45820160,
+          33951044,
+          48014802,
+          7735558,
+          18733810,
+          2852019,
+          7517558,
+          47918621,
+          12481266,
+          15159853,
+          3574582,
+          20509280,
+          6351486,
+          117996751,
+          33389951,
+          26750612,
+          38130276,
+          30266932,
+          5740363,
+          30659955,
+          794253,
+          23909840,
+          31010081,
+          12218809,
+          18591719
+        ],
+        "title": null,
+        "layout": null,
+        "isNeedHideExactAddress": false,
+        "floorNumber": 7,
+        "roomsForSaleCount": null,
+        "isLayoutApproved": null,
+        "isByHomeowner": null,
+        "phones": [
+          {
+            "countryCode": "7",
+            "number": "9230727409"
+          }
+        ],
+        "bargainTerms": {
+          "mortgageAllowed": true,
+          "clientFee": null,
+          "priceRur": 11887164,
+          "agentFee": null,
+          "tags": [],
+          "saleType": "fz214",
+          "leaseTermType": null,
+          "currency": "rur",
+          "agentBonus": null,
+          "bargainAllowed": null,
+          "priceType": "all",
+          "leaseType": null,
+          "vatType": null,
+          "price": 11887164,
+          "utilitiesTerms": null,
+          "priceForWorkplace": null,
+          "paymentPeriod": null,
+          "vatPrice": null,
+          "deposit": null
+        },
+        "formattedAdditionalInfo": "Долевое участие (214-ФЗ), возможна ипотека",
+        "formattedFullPrice": "11 887 164 ₽",
+        "specialty": {
+          "specialties": [],
+          "types": [],
+          "additionalTypes": []
+        },
+        "totalArea": "42.1",
+        "dealRentVersion": null,
+        "officeType": null,
+        "readyBusinessType": null,
+        "isCalltrackingEnabled": true,
+        "building": {
+          "deadline": {
+            "quarter": "first",
+            "quarterEnd": "2029-03-31",
+            "year": 2029,
+            "isComplete": false
+          },
+          "type": null,
+          "parking": null,
+          "buildYear": null,
+          "materialType": "monolith",
+          "floorsCount": 22,
+          "classType": null,
+          "accessType": null,
+          "passengerLiftsCount": 2,
+          "cargoLiftsCount": 1,
+          "heatingType": null
+        },
+        "commercialOwnership": null,
+        "monthlyIncome": null,
+        "isCommercialOwnershipVerified": null,
+        "isRentByParts": false,
+        "isDuplicatedDescription": false,
+        "isFavorite": false,
+        "notes": {
+          "offer": null,
+          "realtor": null
+        },
+        "user": {
+          "cianUserId": "134642318",
+          "isAgent": true,
+          "isBuilder": true,
+          "isCallbackUser": true,
+          "isCianPartner": false,
+          "isHidden": false,
+          "isPassportVerified": false,
+          "isSubAgent": false,
+          "userId": 134642318,
+          "userTrustLevel": "notInvolved",
+          "accountType": "agency",
+          "agencyName": "Абсолют Недвижимость",
+          "agentAvatarUrl": "https://www.cian.ru/api/get-avatar/?i=72650908&t=2&p=2&timestamp=1766554569",
+          "agentModerationInfo": {
+            "isUserIdentified": false,
+            "isUserIdentifiedByDocuments": false,
+            "showUserIdentifiedByDocuments": false
+          },
+          "billingInfo": {
+            "accountType": 1,
+            "packages": [
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Москва и ближнее Подмосковье",
+                "locationId": 1,
+                "packageTypeId": 5,
+                "packageTypeName": "Застройщик"
+              },
+              {
+                "countryId": 138,
+                "depositRequired": false,
+                "geoName": "Дальнее Подмосковье",
+                "locationId": 4593,
+                "packageTypeId": 5,
+                "packageTypeName": "Застройщик"
+              }
+            ],
+            "removeCompetitor": false,
+            "replenishDisabled": true
+          },
+          "canShowOnline": false,
+          "cianProfileStatus": "approved",
+          "companyName": "Абсолют Недвижимость",
+          "isChatsEnabled": false,
+          "isSelfEmployed": false,
+          "phoneNumbers": [
+            {
+              "countryCode": "+7",
+              "number": "9253532887"
+            },
+            {
+              "countryCode": "+7",
+              "number": "9263483889"
+            }
+          ],
+          "userType": "developer",
+          "personalRating": null,
+          "agentAvailability": {
+            "available": true,
+            "availableFrom": null,
+            "availableTo": null,
+            "message": null,
+            "title": null,
+            "userId": 134642318,
+            "vacationTo": null
+          },
+          "agentLists": [],
+          "profileUri": "zastroishchik-absolyut-nedvizhimost-5956/"
+        },
+        "isPro": true,
+        "gaLabel": "/sale/flat/mo_id=0/obl_id=1/city_id=470077/object_type=2/ga_obj_type=1/spec=company/331001739/from_developer=1/repres=0/owner=0/pod_snos=0/nv=0/",
+        "adfoxParams": {
+          "puid1": "deal_type_sale",
+          "puid2": "offer_flat",
+          "puid3": "sale_type_first",
+          "puid4": "offer_type_1",
+          "puid5": "obl_id_1",
+          "puid6": "10001_15000",
+          "puid7": "2323",
+          "puid8": 11887164,
+          "puid9": 377,
+          "puid10": "no_agent",
+          "puid16": "false",
+          "puid17": "false",
+          "puid18": 1448,
+          "puid19": "not_video",
+          "puid36": 1,
+          "puid41": "business"
+        },
+        "chatId": null,
+        "chat": {
+          "chatId": null,
+          "canSendMessage": false
+        },
+        "isUnique": false,
+        "savedSearchLabels": [],
+        "isDealRequestSubstitutionPhone": false,
+        "contextToken": null,
+        "showGalleryThumbnails": true,
+        "isNewbuildingTourAvailable": true,
+        "isExternalTourAvailable": true,
+        "comparisonStatus": {
+          "status": "available",
+          "description": "Добавить к сравнению"
+        },
+        "photoFeatureIcons": [
+          {
+            "type": "has3dTour",
+            "text": "Объявление с 3D-туром",
+            "link": "https://www.cian.ru/sale/flat/331001739/"
+          },
+          {
+            "type": "hasVideo",
+            "text": "Объявление с видео",
+            "link": "https://www.cian.ru/sale/flat/331001739/"
+          }
+        ],
+        "factoids": [
+          {
+            "type": "houseFinishDate",
+            "title": "Сдача корпуса",
+            "text": "1 кв 2029"
+          },
+          {
+            "type": "house",
+            "title": "Корпус",
+            "text": "5 корпус (11 квартал)"
+          }
+        ],
+        "brandingLevel": null,
+        "isRosreestrChecked": false,
+        "bestPlaceAnalyticsAvailable": null,
+        "discount": null,
+        "mortgagePayment": {
+          "title": "В ипотеку от 55 427 ₽/мес",
+          "programTypeWithRate": "Семейная 5,75%",
+          "descriptionDialog": {
+            "title": "Семейная ипотека 5,75%"
+          }
+        },
+        "newbuildingBroker": {
+          "bookingEnabled": true
+        },
+        "offerFeatureLabels": [
+          "ЖК лидер продаж"
+        ],
+        "isNewLabel": false
+      }
+    ]
+  }
+}

--- a/packages/cian-connector/tests/fixtures/search_sale_live.provenance.json
+++ b/packages/cian-connector/tests/fixtures/search_sale_live.provenance.json
@@ -1,0 +1,50 @@
+{
+  "captured": "2026-09-09",
+  "endpoint": "https://api.cian.ru/search-offers/v2/search-offers-desktop/",
+  "transport": "CDP (operator's Chrome), datacenter egress via VPN",
+  "jsonQuery": {
+    "_type": "flatsale",
+    "engine_version": {
+      "type": "term",
+      "value": 2
+    },
+    "region": {
+      "type": "terms",
+      "value": [
+        1
+      ]
+    },
+    "page": {
+      "type": "term",
+      "value": 1
+    },
+    "room": {
+      "type": "terms",
+      "value": [
+        1
+      ]
+    },
+    "price": {
+      "type": "range",
+      "value": {
+        "gte": 10000000,
+        "lte": 12000000
+      }
+    }
+  },
+  "displayed": {
+    "status": 200,
+    "count": 28,
+    "offerCount": 636,
+    "aggregatedCount": 501,
+    "first": {
+      "id": 331002424,
+      "priceRur": 11985439,
+      "price": 11985439,
+      "userInput": "Москва, Московский, микрорайон Первый Московский",
+      "category": "newBuildingFlatSale",
+      "fullUrl": "https://www.cian.ru/sale/flat/331002424/?mlSearchSessionGuid=5de2db838918a063854e163ee9623af6"
+    }
+  },
+  "trimmed": "first 3 offers; description cut to 300 chars; photos cut to 2"
+}

--- a/packages/cian-connector/tests/test_server.py
+++ b/packages/cian-connector/tests/test_server.py
@@ -27,8 +27,10 @@ def _load(name: str) -> dict:
 
 SEARCH_SALE = _load("search_sale_live.json")
 SEARCH_RENT = _load("search_rent_live.json")
+SEARCH_DAILY = _load("search_daily_live.json")
 CARD_SALE = _load("card_sale_live.json")
 CARD_RENT = _load("card_rent_live.json")
+CARD_DAILY = _load("card_daily_live.json")
 
 WAF_BODY = (
     "<!DOCTYPE html><html><head><title>Ошибка - Циан</title></head><body>"
@@ -176,6 +178,7 @@ async def test_search_parses_a_sale_page(monkeypatch):
     first = result.items[0]
     assert first.offer_id == 331002424
     assert first.price_rub == 11985439
+    assert first.price_unit == "total"
     assert first.deal_type == "sale"
     assert first.category == "newBuildingFlatSale"
     assert first.rooms == 1
@@ -205,6 +208,7 @@ async def test_search_parses_a_rent_page_with_period_and_deposit(monkeypatch):
     assert first.offer_id == 317754437
     assert first.deal_type == "rent"
     assert first.price_rub == 60000
+    assert first.price_unit == "month"
     assert first.price_period == "monthly"
     assert first.lease_term == "fewMonths"
     assert first.deposit_rub == 50000
@@ -565,6 +569,135 @@ async def test_selfcheck_reports_drift_when_the_card_lost_its_state(monkeypatch)
     assert result.status == "drift_detected"
     assert result.checks["search"].state == "healthy"
     assert result.checks["card"].state == "drift"
+
+
+# --------------------------------------------------------- daily rent ----
+
+
+def test_daily_queries_flip_the_for_day_flag_and_keep_the_rent_family():
+    """Daily and long-term are the same _type with opposite for_day values;
+    omitting the key would mix two markets that are not comparable."""
+    long_term = server._build_json_query(
+        deal="rent",
+        offer_type="flat",
+        region="1",
+        rooms=None,
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+    daily = server._build_json_query(
+        deal="daily",
+        offer_type="flat",
+        region="1",
+        rooms=[2],
+        price_min=None,
+        price_max=4000,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+
+    assert long_term["for_day"] == {"type": "term", "value": "!1"}
+    assert daily["_type"] == "flatrent"
+    assert daily["for_day"] == {"type": "term", "value": "1"}
+    # Every other filter keeps working on the daily market (verified live).
+    assert daily["room"] == {"type": "terms", "value": [2]}
+    assert daily["price"] == {"type": "range", "value": {"lte": 4000}}
+
+
+def test_daily_rooms_and_houses_keep_their_own_families():
+    room = server._build_json_query(
+        deal="daily",
+        offer_type="room",
+        region="1",
+        rooms=None,
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+    house = server._build_json_query(
+        deal="daily",
+        offer_type="house",
+        region="1",
+        rooms=None,
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+
+    assert room["_type"] == "flatrent" and room["room"] == {"type": "terms", "value": [0]}
+    assert house["_type"] == "suburbanrent"
+    assert room["for_day"] == house["for_day"] == {"type": "term", "value": "1"}
+
+
+async def test_daily_commercial_is_refused_by_name_not_by_an_empty_page():
+    """Cian accepts the query and answers zero offers, which would read as
+    'nothing available today' instead of 'this market does not exist'."""
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("daily", offer_type="commercial")
+
+    assert "bad_request" in str(excinfo.value)
+    assert "daily" in str(excinfo.value).lower()
+
+
+async def test_daily_search_prices_are_per_night_and_say_so(monkeypatch):
+    calls: list = []
+    _patch_search(monkeypatch, _ok(SEARCH_DAILY), calls)
+
+    result = await server.cian_search("daily", region="1")
+
+    assert result.deal == "daily"
+    assert calls[0]["for_day"] == {"type": "term", "value": "1"}
+    first = result.items[0]
+    assert first.category == "dailyFlatRent"
+    assert first.deal_type == "rent"
+    # A daily offer carries no bargainTerms.priceRur at all — only .price.
+    assert first.price_rub is not None and first.price_rub > 0
+    assert first.price_unit == "day"
+    # Cian leaves both of these null on daily offers; price_unit is the only signal.
+    assert first.price_period is None
+    assert first.lease_term is None
+    assert all(item.price_unit == "day" for item in result.items)
+
+
+async def test_daily_card_reads_the_nightly_price(monkeypatch):
+    _patch_card(monkeypatch, (200, _card_body(CARD_DAILY, "https://www.cian.ru/rent/flat/191071633/"), "cdp"))
+
+    result = await server.cian_card("191071633")
+
+    assert result.offer_id == 191071633
+    assert result.category == "dailyFlatRent"
+    assert result.price_rub == 5000
+    assert result.price_unit == "day"
+    assert result.price_period is None and result.lease_term is None
+    assert result.meta.healthy is True
+
+
+@pytest.mark.parametrize(
+    ("category", "deal_type", "period", "expected"),
+    [
+        ("flatSale", "sale", None, "total"),
+        ("newBuildingFlatSale", "sale", None, "total"),
+        ("flatRent", "rent", "monthly", "month"),
+        ("roomRent", "rent", None, "month"),
+        ("dailyFlatRent", "rent", None, "day"),
+        ("dailyRoomRent", "rent", None, "day"),
+        ("dailyHouseRent", "rent", None, "day"),
+        # An unfamiliar period is passed through rather than flattened to a
+        # month the connector never saw.
+        ("flatRent", "rent", "weekly", "weekly"),
+        (None, None, None, None),
+    ],
+)
+def test_price_unit_derivation(category, deal_type, period, expected):
+    assert server._price_unit(category, deal_type, period) == expected
 
 
 # ------------------------------------------------------------ inventory ----

--- a/packages/cian-connector/tests/test_server.py
+++ b/packages/cian-connector/tests/test_server.py
@@ -1,0 +1,576 @@
+"""Offline tests for the Cian connector.
+
+Every upstream call is monkeypatched at the transport dispatch layer
+(``_fetch_search`` / ``_fetch_card``), so the suite runs with no network and no
+browser. Fixtures are real payloads captured over CDP on 2026-09-09 and trimmed
+(provenance sits next to each file): a new-building sale in Moscow whose card
+carries the price only in ``bargainTerms.price``, and a long-term rent in
+St. Petersburg with a deposit and a monthly period.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+from cian_connector import server
+from fastmcp.exceptions import ToolError
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _load(name: str) -> dict:
+    return json.loads((FIXTURES / name).read_text(encoding="utf-8"))
+
+
+SEARCH_SALE = _load("search_sale_live.json")
+SEARCH_RENT = _load("search_rent_live.json")
+CARD_SALE = _load("card_sale_live.json")
+CARD_RENT = _load("card_rent_live.json")
+
+WAF_BODY = (
+    "<!DOCTYPE html><html><head><title>Ошибка - Циан</title></head><body>"
+    "Обнаружен подозрительный трафик. Код страницы: cian_waf_block</body></html>"
+)
+
+
+def _card_body(fixture: dict, url: str = "https://www.cian.ru/sale/flat/331002424/") -> str:
+    return json.dumps({"kind": "ok", "title": "Продажа квартиры", "url": url, "offerData": fixture["offerData"]})
+
+
+@pytest.fixture(autouse=True)
+def _no_cache():
+    """Every test starts with an empty cache: a cached body from a previous
+    case would otherwise shadow its monkeypatched fetch."""
+    server._cache._data.clear()
+
+
+def _patch_search(monkeypatch, result, calls: list | None = None):
+    async def fake(query, ctx):
+        if calls is not None:
+            calls.append(query)
+        return result
+
+    monkeypatch.setattr(server, "_fetch_search", fake)
+
+
+def _patch_card(monkeypatch, result, calls: list | None = None):
+    async def fake(offer_id, ctx):
+        if calls is not None:
+            calls.append(offer_id)
+        return result
+
+    monkeypatch.setattr(server, "_fetch_card", fake)
+
+
+def _ok(payload: dict) -> tuple[int, str, str]:
+    return 200, json.dumps(payload, ensure_ascii=False), "cdp"
+
+
+# ---------------------------------------------------------- jsonQuery ----
+
+
+def test_query_for_a_flat_sale_carries_rooms_and_price_range():
+    query = server._build_json_query(
+        deal="sale",
+        offer_type="flat",
+        region="1",
+        rooms=[2, 1, 1],
+        price_min=10_000_000,
+        price_max=12_000_000,
+        area_min=None,
+        area_max=None,
+        page=3,
+    )
+
+    assert query["_type"] == "flatsale"
+    assert query["engine_version"] == {"type": "term", "value": 2}
+    assert query["region"] == {"type": "terms", "value": [1]}
+    assert query["room"] == {"type": "terms", "value": [1, 2]}
+    assert query["price"] == {"type": "range", "value": {"gte": 10_000_000, "lte": 12_000_000}}
+    assert query["page"] == {"type": "term", "value": 3}
+    assert "for_day" not in query
+    assert "total_area" not in query
+
+
+def test_query_for_rent_adds_the_long_term_flag_and_open_ranges():
+    query = server._build_json_query(
+        deal="rent",
+        offer_type="flat",
+        region="2",
+        rooms=None,
+        price_min=None,
+        price_max=60_000,
+        area_min=30.0,
+        area_max=None,
+        page=1,
+    )
+
+    assert query["_type"] == "flatrent"
+    assert query["for_day"] == {"type": "term", "value": "!1"}
+    assert query["price"] == {"type": "range", "value": {"lte": 60_000}}
+    assert query["total_area"] == {"type": "range", "value": {"gte": 30.0}}
+    assert "room" not in query
+
+
+def test_query_for_rooms_houses_and_commercial_use_their_own_families():
+    room = server._build_json_query(
+        deal="sale",
+        offer_type="room",
+        region="1",
+        rooms=[3],
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+    house = server._build_json_query(
+        deal="rent",
+        offer_type="house",
+        region="4593",
+        rooms=[3],
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+    office = server._build_json_query(
+        deal="sale",
+        offer_type="commercial",
+        region="1",
+        rooms=None,
+        price_min=None,
+        price_max=None,
+        area_min=None,
+        area_max=None,
+        page=1,
+    )
+
+    # Rooms are flats with room=[0]; the caller's room filter is irrelevant there.
+    assert room["_type"] == "flatsale" and room["room"] == {"type": "terms", "value": [0]}
+    assert house["_type"] == "suburbanrent" and "room" not in house
+    assert office["_type"] == "commercialsale" and "room" not in office
+
+
+# ---------------------------------------------------------- cian_search ----
+
+
+async def test_search_parses_a_sale_page(monkeypatch):
+    calls: list = []
+    _patch_search(monkeypatch, _ok(SEARCH_SALE), calls)
+
+    result = await server.cian_search("sale", rooms=[1], price_min=10_000_000, price_max=12_000_000)
+
+    assert result.status == "success"
+    assert result.deal == "sale" and result.offer_type == "flat" and result.region == "1"
+    assert result.count == 3
+    assert result.total_count == 501
+    assert result.tier_used == "cdp"
+    assert result.meta.healthy is True
+    assert calls[0]["_type"] == "flatsale" and calls[0]["room"]["value"] == [1]
+
+    first = result.items[0]
+    assert first.offer_id == 331002424
+    assert first.price_rub == 11985439
+    assert first.deal_type == "sale"
+    assert first.category == "newBuildingFlatSale"
+    assert first.rooms == 1
+    assert first.total_area_m2 == 38.1
+    assert first.kitchen_area_m2 == 16.6
+    assert first.floor == 12 and first.floors_total == 22
+    assert first.address == "Москва, Московский, микрорайон Первый Московский"
+    assert first.metro is not None
+    assert first.metro.name == "Рассказовка" and first.metro.minutes == 6 and first.metro.mode == "transport"
+    assert first.url == "https://www.cian.ru/sale/flat/331002424/"
+    assert first.agency_name == "Абсолют Недвижимость"
+    assert first.seller_type == "developer"
+    assert first.newbuilding_name == "Город-парк Первый Московский"
+    assert first.created_at == "2026-06-11T19:42:24.507"
+    assert first.photos == 2  # trimmed fixture keeps two
+    # Cian sets no title on this offer; the short info line stands in.
+    assert first.title == "1-комн.кв. · 12/22 этаж"
+
+
+async def test_search_parses_a_rent_page_with_period_and_deposit(monkeypatch):
+    _patch_search(monkeypatch, _ok(SEARCH_RENT))
+
+    result = await server.cian_search("rent", region="2", rooms=[2])
+
+    assert result.total_count == 1227
+    first = result.items[0]
+    assert first.offer_id == 317754437
+    assert first.deal_type == "rent"
+    assert first.price_rub == 60000
+    assert first.price_period == "monthly"
+    assert first.lease_term == "fewMonths"
+    assert first.deposit_rub == 50000
+    assert first.is_by_homeowner is False
+    assert first.title == "Сдаются впервые после ремонта"
+    assert first.agency_name == "SVET hotel"
+    # Three stations in the payload; Академическая is 7 min by transport, but
+    # Cian marks Гражданский проспект (10 min on foot) as the tile's station.
+    assert first.metro is not None and first.metro.name == "Гражданский проспект" and first.metro.mode == "walk"
+    assert first.url == "https://spb.cian.ru/rent/flat/317754437/"
+
+
+async def test_search_a_priceless_offer_is_none_never_zero(monkeypatch):
+    """Cian shows 'цена не указана' for some offers; the payload then carries no
+    price keys at all. It must surface as None — a 0 would rank it cheapest."""
+    payload = copy.deepcopy(SEARCH_SALE)
+    offer = payload["data"]["offersSerialized"][0]
+    for key in ("priceRur", "price"):
+        offer["bargainTerms"].pop(key, None)
+    offer.pop("priceTotalRur", None)
+    _patch_search(monkeypatch, _ok(payload))
+
+    result = await server.cian_search("sale")
+
+    assert result.items[0].price_rub is None
+    assert result.items[0].price_rub != 0
+    assert result.items[1].price_rub is not None
+
+
+async def test_search_reads_the_default_region_from_settings(monkeypatch):
+    calls: list = []
+    _patch_search(monkeypatch, _ok(SEARCH_SALE), calls)
+
+    result = await server.cian_search("sale")
+
+    assert result.region == server._settings.region
+    assert calls[0]["region"]["value"] == [int(server._settings.region)]
+
+
+@pytest.mark.parametrize("bad_region", ["", "moscow", "1 2", "1;rm -rf", "spb"])
+async def test_search_rejects_a_malformed_region(bad_region):
+    """Refusal must come from argument parsing, never from a failed fetch."""
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale", region=bad_region)
+    assert "bad_request" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("bad_rooms", [[0], [8], [10], [1, 8]])
+async def test_search_rejects_unknown_room_codes(bad_rooms):
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale", rooms=bad_rooms)
+    assert "bad_request" in str(excinfo.value)
+
+
+async def test_search_rejects_inverted_ranges():
+    with pytest.raises(ToolError):
+        await server.cian_search("sale", price_min=5, price_max=1)
+    with pytest.raises(ToolError):
+        await server.cian_search("sale", area_min=50.0, area_max=20.0)
+
+
+async def test_search_maps_a_waf_block_to_transport_down(monkeypatch):
+    _patch_search(monkeypatch, (403, WAF_BODY, "cdp_blocked"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale")
+
+    text = str(excinfo.value)
+    assert "transport_down" in text
+    assert "cian.ru" in text
+
+
+async def test_search_treats_a_200_block_page_as_a_block_not_drift(monkeypatch):
+    """The WAF page can arrive as a 200 through the in-page fetch; the marker
+    in the body decides, not the status."""
+    _patch_search(monkeypatch, (200, WAF_BODY, "cdp"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale")
+
+    assert "transport_down" in str(excinfo.value)
+
+
+async def test_search_maps_non_json_to_parser_drift(monkeypatch):
+    _patch_search(monkeypatch, (200, "<html><body>Циан</body></html>", "cdp"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale")
+
+    assert "parser_drift" in str(excinfo.value)
+
+
+async def test_search_maps_a_changed_envelope_to_parser_drift(monkeypatch):
+    _patch_search(monkeypatch, _ok({"status": "ok", "data": {"offers": []}}))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_search("sale")
+
+    assert "parser_drift" in str(excinfo.value)
+    assert "offersSerialized" in str(excinfo.value)
+
+
+async def test_search_warns_on_empty_items_with_nonzero_total(monkeypatch):
+    _patch_search(monkeypatch, _ok({"status": "ok", "data": {"offersSerialized": [], "aggregatedCount": 41}}))
+
+    result = await server.cian_search("sale")
+
+    assert result.count == 0
+    assert result.total_count == 41
+    assert result.meta.healthy is False
+    assert "empty_items_with_nonzero_total" in result.meta.warnings
+
+
+async def test_search_an_empty_result_with_zero_total_is_healthy(monkeypatch):
+    _patch_search(monkeypatch, _ok({"status": "ok", "data": {"offersSerialized": [], "aggregatedCount": 0}}))
+
+    result = await server.cian_search("sale")
+
+    assert result.count == 0
+    assert result.meta.healthy is True
+
+
+# ------------------------------------------------------------ cian_card ----
+
+
+async def test_card_parses_a_new_building_sale(monkeypatch):
+    _patch_card(monkeypatch, (200, _card_body(CARD_SALE), "cdp"))
+
+    result = await server.cian_card("331002424")
+
+    assert result.offer_id == 331002424
+    # The card carries no priceRur — the price comes from bargainTerms.price.
+    assert result.price_rub == 11985439
+    assert result.deal_type == "sale"
+    assert result.category == "newBuildingFlatSale"
+    assert result.rooms == 1
+    assert result.total_area_m2 == 38.1
+    assert result.floor == 12 and result.floors_total == 22
+    assert result.building_material == "monolith"
+    assert result.ceiling_height_m == 2.73
+    assert result.description is not None and result.description.startswith("Продается однокомнатная квартира")
+    assert result.views == 12907
+    assert result.updated_at == "2026-09-08T22:25:42.932744Z"
+    # Four changes on this offer, newest first; the two most recent are pinned.
+    assert len(result.price_history) == 4
+    assert [change.price_rub for change in result.price_history[:2]] == [11985439, 11866772]
+    assert result.price_history[0].changed_at == "2026-09-01T19:14:33.257248Z"
+    assert result.agency_name == "Абсолют Недвижимость"
+    assert result.seller_type == "developer"
+    assert result.agent is not None
+    assert result.agent.name == "Абсолют Недвижимость"
+    assert result.agent.account_type == "agency"
+    assert result.agent.user_type == "developer"
+    assert result.agent.agent_id == 134642318
+    assert result.metro and result.metro[0].name == "Рассказовка"
+    assert result.url == "https://www.cian.ru/sale/flat/331002424/"
+    assert result.meta.healthy is True
+
+
+async def test_card_parses_a_rent_offer(monkeypatch):
+    _patch_card(monkeypatch, (200, _card_body(CARD_RENT, "https://spb.cian.ru/rent/flat/317754437/"), "cdp"))
+
+    result = await server.cian_card("https://spb.cian.ru/rent/flat/317754437/")
+
+    assert result.offer_id == 317754437
+    assert result.deal_type == "rent"
+    assert result.price_rub == 60000
+    assert result.price_period == "monthly"
+    assert result.lease_term == "fewMonths"
+    assert result.deposit_rub == 50000
+    assert result.is_by_homeowner is False
+    assert result.views == 3841
+    assert result.agent is not None and result.agent.name == "SVET hotel"
+    assert result.url == "https://spb.cian.ru/rent/flat/317754437/"
+
+
+async def test_card_without_a_price_warns_instead_of_inventing_one(monkeypatch):
+    fixture = copy.deepcopy(CARD_SALE)
+    offer = fixture["offerData"]["offer"]
+    offer["bargainTerms"].pop("price", None)
+    offer.pop("priceTotalRur", None)
+    offer.pop("priceTotal", None)
+    _patch_card(monkeypatch, (200, _card_body(fixture), "cdp"))
+
+    result = await server.cian_card("331002424")
+
+    assert result.price_rub is None
+    assert result.meta.healthy is False
+    assert "price_missing" in result.meta.warnings
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("331002424", 331002424),
+        ("  331002424 ", 331002424),
+        ("https://www.cian.ru/sale/flat/331002424/", 331002424),
+        ("https://spb.cian.ru/rent/flat/317754437/?mlSearchSessionGuid=abc", 317754437),
+        ("https://dedovsk.cian.ru/sale/suburban/332770439/", 332770439),
+        ("https://www.cian.ru/sale/commercial/332617039", 332617039),
+        ("123", None),
+        ("flat 331002424", None),
+        ("https://www.avito.ru/moskva/kvartiry/331002424", None),
+        ("https://www.cian.ru/agents/134642318/", None),
+    ],
+)
+def test_extract_offer_id(raw, expected):
+    assert server._extract_offer_id(raw) == expected
+
+
+async def test_card_rejects_input_without_an_id():
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_card("https://www.cian.ru/agents/134642318/")
+    assert "bad_request" in str(excinfo.value)
+
+
+async def test_card_maps_a_waf_block_to_transport_down(monkeypatch):
+    _patch_card(monkeypatch, (403, "navigation blocked: HTTP 403", "cdp_blocked"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_card("331002424")
+
+    assert "transport_down" in str(excinfo.value)
+
+
+async def test_card_maps_a_removed_offer_to_not_found(monkeypatch):
+    body = json.dumps(
+        {"kind": "not_found", "title": "Объявление не найдено", "url": "https://www.cian.ru/sale/flat/1/"}
+    )
+    _patch_card(monkeypatch, (200, body, "cdp"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_card("100000001")
+
+    assert "not_found" in str(excinfo.value)
+
+
+async def test_card_without_embedded_state_is_parser_drift(monkeypatch):
+    body = json.dumps(
+        {"kind": "no_offer", "title": "Продажа квартиры", "url": "https://www.cian.ru/sale/flat/1/", "keys": ["x"]}
+    )
+    _patch_card(monkeypatch, (200, body, "cdp"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_card("331002424")
+
+    assert "parser_drift" in str(excinfo.value)
+
+
+async def test_card_with_an_error_title_and_no_state_is_a_block(monkeypatch):
+    body = json.dumps({"kind": "no_config", "title": "Ошибка - Циан", "url": "https://www.cian.ru/sale/flat/1/"})
+    _patch_card(monkeypatch, (200, body, "cdp"))
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.cian_card("331002424")
+
+    assert "transport_down" in str(excinfo.value)
+
+
+# ---------------------------------------------------------------- cache ----
+
+
+async def test_search_serves_a_repeat_query_from_cache(monkeypatch):
+    calls: list = []
+
+    async def fake_post(query, ctx):
+        calls.append(query)
+        return 200, json.dumps(SEARCH_SALE, ensure_ascii=False)
+
+    monkeypatch.setattr(server, "_cdp_post_json", fake_post)
+
+    async def no_wait():
+        return None
+
+    monkeypatch.setattr(server, "_polite_wait", no_wait)
+
+    first = await server.cian_search("sale", rooms=[1])
+    second = await server.cian_search("sale", rooms=[1])
+
+    assert len(calls) == 1
+    assert first.tier_used == "cdp"
+    assert second.tier_used == "cache"
+    assert second.items[0].offer_id == first.items[0].offer_id
+
+
+async def test_a_block_page_is_never_cached(monkeypatch):
+    calls: list = []
+
+    async def fake_post(query, ctx):
+        calls.append(query)
+        return 403, WAF_BODY
+
+    monkeypatch.setattr(server, "_cdp_post_json", fake_post)
+
+    async def no_wait():
+        return None
+
+    monkeypatch.setattr(server, "_polite_wait", no_wait)
+
+    for _ in range(2):
+        with pytest.raises(ToolError):
+            await server.cian_search("sale")
+
+    assert len(calls) == 2
+
+
+# ------------------------------------------------------------ selfcheck ----
+
+
+async def test_selfcheck_is_success_when_search_and_card_parse(monkeypatch):
+    card_calls: list = []
+    _patch_search(monkeypatch, _ok(SEARCH_SALE))
+    _patch_card(monkeypatch, (200, _card_body(CARD_SALE), "cdp"), card_calls)
+
+    result = await server.cian_selfcheck()
+
+    assert result.status == "success"
+    assert result.healthy is True
+    assert result.checks["search"].state == "healthy"
+    assert result.checks["card"].state == "healthy"
+    # The card probe used the id the search probe supplied, not a hardcoded one.
+    assert card_calls == [331002424]
+
+
+async def test_selfcheck_is_inconclusive_on_a_block_never_drift(monkeypatch):
+    _patch_search(monkeypatch, (403, WAF_BODY, "cdp_blocked"))
+    _patch_card(monkeypatch, (403, WAF_BODY, "cdp_blocked"))
+
+    result = await server.cian_selfcheck()
+
+    assert result.status == "inconclusive"
+    assert result.healthy is None
+    assert result.checks["search"].state == "inconclusive"
+    assert result.checks["search"].reason == "blocked"
+    assert result.checks["card"].state == "inconclusive"
+
+
+async def test_selfcheck_reports_drift_when_the_envelope_changed(monkeypatch):
+    _patch_search(monkeypatch, _ok({"status": "ok", "data": {"offers": []}}))
+
+    result = await server.cian_selfcheck()
+
+    assert result.status == "drift_detected"
+    assert result.healthy is False
+    assert result.checks["search"].state == "drift"
+    assert result.checks["card"].state == "inconclusive"
+
+
+async def test_selfcheck_reports_drift_when_the_card_lost_its_state(monkeypatch):
+    _patch_search(monkeypatch, _ok(SEARCH_SALE))
+    body = json.dumps(
+        {"kind": "no_offer", "title": "Продажа квартиры", "url": "https://www.cian.ru/sale/flat/1/", "keys": []}
+    )
+    _patch_card(monkeypatch, (200, body, "cdp"))
+
+    result = await server.cian_selfcheck()
+
+    assert result.status == "drift_detected"
+    assert result.checks["search"].state == "healthy"
+    assert result.checks["card"].state == "drift"
+
+
+# ------------------------------------------------------------ inventory ----
+
+
+async def test_the_server_exposes_exactly_the_two_read_tools():
+    tools = sorted(t.name for t in await server.mcp.list_tools())
+
+    assert tools == ["cian_card", "cian_search"]

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -992,7 +992,7 @@ async def compare_verify_offer(
     """Verify one compared offer through its marketplace card tool.
 
     This is the cheap compare-server follow-up: it lets an agent confirm the
-    raw search price, stock and seller without enabling the 36-tool unified
+    raw search price, stock and seller without enabling the 39-tool unified
     mount. The returned card is source-native and therefore keeps fields the
     comparison intentionally normalises away.
 

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -168,7 +168,9 @@ SOURCES = _available_sources()
 
 # Marketplaces that support a text query. Detsky Mir is absent on purpose: its
 # API has no working text search (see the detmir connector's module docstring),
-# so including it would mean returning products unrelated to the query.
+# so including it would mean returning products unrelated to the query. Cian is
+# absent too: it is real estate searched by filters, and a flat has no price to
+# compare against a kettle.
 SEARCHABLE = (
     "wildberries",
     "yandex_market",

--- a/packages/marketplace-connector/pyproject.toml
+++ b/packages/marketplace-connector/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "lamoda-connector",
     "dns-connector",
     "citilink-connector",
+    "cian-connector",
     "compare-connector",
     "mpstats-connector",
 ]
@@ -52,5 +53,6 @@ megamarket-connector = { workspace = true }
 lamoda-connector = { workspace = true }
 dns-connector = { workspace = true }
 citilink-connector = { workspace = true }
+cian-connector = { workspace = true }
 compare-connector = { workspace = true }
 mpstats-connector = { workspace = true }

--- a/packages/marketplace-connector/src/marketplace_connector/cli.py
+++ b/packages/marketplace-connector/src/marketplace_connector/cli.py
@@ -47,6 +47,7 @@ SERVERS: list[tuple[str, str, str]] = [
     ("lamoda", "lamoda-mcp", "cards anonymous; search needs your Chrome"),
     ("dns", "dns-mcp", "needs your Chrome — Qrator proof-of-work"),
     ("citilink", "citilink-mcp", "needs your Chrome — Qrator"),
+    ("cian", "cian-mcp", "real estate; needs your Chrome — WAF by IP"),
     ("compare-prices", "compare-mcp", "fans out across all of the above"),
 ]
 
@@ -61,6 +62,7 @@ _SELFCHECKS: list[tuple[str, str, str]] = [
     ("lamoda", "lamoda_connector.server", "lamoda_selfcheck"),
     ("dns", "dns_connector.server", "dns_selfcheck"),
     ("citilink", "citilink_connector.server", "citilink_selfcheck"),
+    ("cian", "cian_connector.server", "cian_selfcheck"),
     ("mpstats", "mpstats_connector.server", "mpstats_selfcheck"),
 ]
 

--- a/packages/marketplace-connector/src/marketplace_connector/cli.py
+++ b/packages/marketplace-connector/src/marketplace_connector/cli.py
@@ -350,7 +350,7 @@ def cmd_doctor(argv: list[str]) -> int:
                 f"Chrome CDP: reachable on {probe['host']}:{probe['port']} ({probe.get('contexts', '?')} context(s))."
             )
         else:
-            cdp_note = f"Chrome CDP: NOT reachable — {probe.get('reason')}. Avito/Taobao/Megamarket/Lamoda-search/DNS/Citilink need it."
+            cdp_note = f"Chrome CDP: NOT reachable — {probe.get('reason')}. Avito/Taobao/Megamarket/Lamoda-search/DNS/Citilink/Cian need it."
     except Exception as exc:
         cdp_note = f"Chrome CDP: probe failed ({type(exc).__name__})."
     print(f"\n  {cdp_note}")

--- a/packages/marketplace-connector/src/marketplace_connector/server.py
+++ b/packages/marketplace-connector/src/marketplace_connector/server.py
@@ -50,8 +50,9 @@ mcp = FastMCP(
         "All marketplace connectors in one server. Tools keep their per-source "
         "names: wb_*, ozon_*, yandex_*, detmir_*, avito_*, taobao_*, "
         "megamarket_*, lamoda_*, dns_*, citilink_*, aliexpress_*, mpstats_* plus compare_prices and "
-        "compare_sources. Sources whose optional dependencies are missing are "
-        "simply absent from the set."
+        "compare_sources. cian_* is real estate (flats, houses, commercial "
+        "property for sale or rent), not goods. Sources whose optional "
+        "dependencies are missing are simply absent from the set."
     ),
     version=SERVER_VERSION,
 )
@@ -130,6 +131,9 @@ _CAPABILITIES: dict[str, dict[str, object]] = {
         "currency": "rub",
         "text_search": False,
     },
+    # Real estate, not goods: search is by filters (deal, type, region, rooms,
+    # price, area), never by text, and it takes no part in compare_prices.
+    "cian": {"access": "cdp", "requires_cdp": True, "requires_login": False, "currency": "rub", "text_search": False},
 }
 
 
@@ -157,6 +161,7 @@ def _mount_all() -> None:
         ("dns", "dns_connector.server"),
         ("citilink", "citilink_connector.server"),
         ("aliexpress", "aliexpress_connector.server"),
+        ("cian", "cian_connector.server"),
         ("compare", "compare_connector.server"),
         ("mpstats", "mpstats_connector.server"),
     )

--- a/packages/marketplace-connector/tests/fixtures/public_contract.json
+++ b/packages/marketplace-connector/tests/fixtures/public_contract.json
@@ -205,6 +205,7 @@
         "price_history": {},
         "price_period": {},
         "price_rub": {},
+        "price_unit": {},
         "rooms": {},
         "seller_type": {},
         "status": {},
@@ -278,7 +279,8 @@
         "deal": {
           "enum": [
             "sale",
-            "rent"
+            "rent",
+            "daily"
           ],
           "type": "string"
         },

--- a/packages/marketplace-connector/tests/fixtures/public_contract.json
+++ b/packages/marketplace-connector/tests/fixtures/public_contract.json
@@ -175,6 +175,185 @@
       "type": "object"
     }
   },
+  "cian_card": {
+    "output": {
+      "properties": {
+        "_meta": {},
+        "address": {},
+        "agency_name": {},
+        "agent": {},
+        "build_year": {},
+        "building_material": {},
+        "category": {},
+        "ceiling_height_m": {},
+        "created_at": {},
+        "deal_type": {},
+        "deposit_rub": {},
+        "description": {},
+        "flat_type": {},
+        "floor": {},
+        "floors_total": {},
+        "is_apartments": {},
+        "is_by_homeowner": {},
+        "kitchen_area_m2": {},
+        "lease_term": {},
+        "living_area_m2": {},
+        "metro": {},
+        "newbuilding_name": {},
+        "offer_id": {},
+        "photos": {},
+        "price_history": {},
+        "price_period": {},
+        "price_rub": {},
+        "rooms": {},
+        "seller_type": {},
+        "status": {},
+        "tier_used": {},
+        "title": {},
+        "total_area_m2": {},
+        "updated_at": {},
+        "url": {},
+        "views": {}
+      },
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "offer_id_or_url": {
+          "maxLength": 300,
+          "minLength": 1,
+          "type": "string"
+        }
+      },
+      "required": [
+        "offer_id_or_url"
+      ],
+      "type": "object"
+    }
+  },
+  "cian_search": {
+    "output": {
+      "properties": {
+        "_meta": {},
+        "count": {},
+        "deal": {},
+        "items": {},
+        "offer_type": {},
+        "page": {},
+        "region": {},
+        "status": {},
+        "tier_used": {},
+        "total_count": {}
+      },
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "area_max": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "area_min": {
+          "anyOf": [
+            {
+              "exclusiveMinimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "deal": {
+          "enum": [
+            "sale",
+            "rent"
+          ],
+          "type": "string"
+        },
+        "offer_type": {
+          "default": "flat",
+          "enum": [
+            "flat",
+            "room",
+            "house",
+            "commercial"
+          ],
+          "type": "string"
+        },
+        "page": {
+          "default": 1,
+          "maximum": 100,
+          "minimum": 1,
+          "type": "integer"
+        },
+        "price_max": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "price_min": {
+          "anyOf": [
+            {
+              "minimum": 1,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "region": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
+        "rooms": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "integer"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "deal"
+      ],
+      "type": "object"
+    }
+  },
   "citilink_card": {
     "output": {
       "properties": {

--- a/packages/marketplace-connector/tests/test_server.py
+++ b/packages/marketplace-connector/tests/test_server.py
@@ -51,7 +51,7 @@ def test_tool_names_keep_their_source_prefixes():
 def test_the_mounted_count_matches_the_imported_sources():
     tools = asyncio.run(server.mcp.list_tools())
     names = {t.name for t in tools}
-    # 8 + 3 + 2 + 3 + 3 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 35 mounted tools across
+    # 8 + 3 + 2 + 3 + 3 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 3 + 2 = 38 mounted tools across
     # 14 servers, plus marketplace_sources, which this server owns rather than
     # mounts. Operator-only *_selfcheck diagnostics are not MCP tools.
     own = {"marketplace_sources"}

--- a/packages/marketplace-connector/tests/test_server.py
+++ b/packages/marketplace-connector/tests/test_server.py
@@ -52,24 +52,27 @@ def test_the_mounted_count_matches_the_imported_sources():
     tools = asyncio.run(server.mcp.list_tools())
     names = {t.name for t in tools}
     # 8 + 3 + 2 + 3 + 3 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 2 = 35 mounted tools across
-    # 13 servers, plus marketplace_sources, which this server owns rather than
+    # 14 servers, plus marketplace_sources, which this server owns rather than
     # mounts. Operator-only *_selfcheck diagnostics are not MCP tools.
     own = {"marketplace_sources"}
     assert own <= names
-    assert len(tools) == 37, f"expected 36 mounted tools + 1 own, got {len(tools)}"
-    assert len(names - own) == 36
+    assert len(tools) == 39, f"expected 38 mounted tools + 1 own, got {len(tools)}"
+    assert len(names - own) == 38
 
 
 def test_marketplace_sources_reports_what_mounted():
     """A skipped source must be visible to the client, not just to stderr."""
     result = asyncio.run(server.marketplace_sources())
 
-    assert result.mounted_count == 13
+    assert result.mounted_count == 14
     assert result.skipped_count == 0
     assert result.skipped == {}
     assert "wildberries" in result.mounted
     assert "citilink" in result.mounted
     assert "aliexpress" in result.mounted
+    assert "cian" in result.mounted
+    assert result.capabilities["cian"]["requires_cdp"] is True
+    assert result.capabilities["cian"]["text_search"] is False
     assert "mpstats" in result.mounted
     assert result.server_version == server.SERVER_VERSION
     assert result.capabilities["taobao"]["currency"] == "cny"

--- a/packages/marketplace-connector/tests/test_wire_frugality.py
+++ b/packages/marketplace-connector/tests/test_wire_frugality.py
@@ -22,9 +22,10 @@ def test_no_operator_selfcheck_is_registered_as_a_tool():
 
     leaked = sorted(name for name in names if name.endswith("_selfcheck"))
     assert not leaked, f"operator-only selfchecks leaked into the MCP surface: {leaked}"
-    # The count changed from 45 to 34 on purpose (11 selfchecks left) and from
-    # 34 to 36 when the aliexpress connector (2 tools) joined the mount.
-    assert len(tools) == 37
+    # The count changed from 45 to 34 on purpose (11 selfchecks left), from
+    # 34 to 36 when the aliexpress connector (2 tools) joined the mount, and
+    # from 37 to 39 when the cian connector (2 tools) joined.
+    assert len(tools) == 39
 
 
 def test_every_output_schema_is_wire_frugal():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "citilink-connector",
     "mpstats-connector",
     "aliexpress-connector",
+    "cian-connector",
     "marketplace-connector",
 ]
 
@@ -58,6 +59,7 @@ dns-connector = { workspace = true }
 citilink-connector = { workspace = true }
 mpstats-connector = { workspace = true }
 aliexpress-connector = { workspace = true }
+cian-connector = { workspace = true }
 marketplace-connector = { workspace = true }
 
 [dependency-groups]
@@ -135,6 +137,7 @@ testpaths = [
     "packages/citilink-connector/tests",
     "packages/mpstats-connector/tests",
     "packages/aliexpress-connector/tests",
+    "packages/cian-connector/tests",
     "packages/marketplace-connector/tests",
 ]
 asyncio_mode = "auto"
@@ -166,6 +169,7 @@ source = [
     "packages/citilink-connector/src/citilink_connector",
     "packages/mpstats-connector/src/mpstats_connector",
     "packages/aliexpress-connector/src/aliexpress_connector",
+    "packages/cian-connector/src/cian_connector",
     "packages/marketplace-connector/src/marketplace_connector",
 ]
 omit = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ markers = [
 filterwarnings = ["ignore::DeprecationWarning"]
 
 [tool.coverage.run]
-# Measure the fifteen workspace packages' source, not their tests. This is what the
+# Measure the sixteen workspace packages' source, not their tests. This is what the
 # `--cov` invocation in the CI coverage job reports against; the enforcing
 # --cov-fail-under floor is passed on that job's command line, not baked in here,
 # so the rest of the test matrix runs exactly as before.

--- a/scripts/e2e_stdio_check.py
+++ b/scripts/e2e_stdio_check.py
@@ -40,8 +40,9 @@ EXPECTED_TOOLS = {
     "dns-mcp": 2,
     "citilink-mcp": 2,
     "aliexpress-mcp": 2,
+    "cian-mcp": 2,
     "mpstats-mcp": 2,
-    "marketplace-mcp": 37,  # 36 mounted + marketplace_sources
+    "marketplace-mcp": 39,  # 38 mounted + marketplace_sources
 }
 
 TIMEOUT_S = 60.0

--- a/scripts/e2e_stdio_check.py
+++ b/scripts/e2e_stdio_check.py
@@ -25,7 +25,7 @@ from mcp.client.stdio import stdio_client
 # script name -> how many model-facing tools it must expose. Operator-only
 # *_selfcheck canaries are no longer MCP tools (they run via
 # `marketplace-mcp doctor`), which is why every figure is one lower than the
-# pre-dsh contract and the marketplace server is 36, not 47.
+# pre-dsh contract and the marketplace server is 39, not 47.
 EXPECTED_TOOLS = {
     "wb-mcp": 8,
     "ozon-mcp": 3,

--- a/scripts/e2e_stdio_check_docker.py
+++ b/scripts/e2e_stdio_check_docker.py
@@ -17,7 +17,7 @@ import subprocess
 import sys
 import time
 
-EXPECTED_TOOLS = 37
+EXPECTED_TOOLS = 39
 TIMEOUT_S = 120.0
 
 

--- a/scripts/e2e_stdio_check_docker.py
+++ b/scripts/e2e_stdio_check_docker.py
@@ -102,8 +102,8 @@ def probe(image: str) -> int:
         if result.get("isError"):
             raise RuntimeError(f"marketplace_sources returned an error: {result}")
         mounted = (result.get("structuredContent") or {}).get("mounted_count") or 0
-        if mounted != 13:
-            raise RuntimeError(f"expected 13 mounted sources, got {mounted}")
+        if mounted != 14:
+            raise RuntimeError(f"expected 14 mounted sources, got {mounted}")
         print(f"PASS: docker stdio MCP session, {len(tools)} tools, {mounted} sources mounted")
         return 0
     finally:

--- a/skills/cian-connector/SKILL.md
+++ b/skills/cian-connector/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: cian-connector
+description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale or long-term rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
+---
+
+# Cian Connector
+
+Reads Cian through the site's own JSON API, called from inside the operator's
+Chrome over CDP: the search endpoint answers an in-page POST, and the offer
+card embeds its whole state in `window._cianConfig`. No HTML is parsed. Plain
+HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен подозрительный
+трафик» page, no captcha), so there is no anonymous tier.
+
+## When to use
+- Find offers by filters: deal (sale / rent), property type, region, rooms,
+  price range, total area
+- One offer's price, its price history, layout, building, address, metro,
+  description and publisher
+- Real estate only. For goods use the marketplace connectors; for price
+  comparison across shops use `compare_prices` — Cian takes no part in it
+
+## Tools available
+- `cian_search(deal, offer_type="flat", region=None, rooms=None, price_min=None, price_max=None, area_min=None, area_max=None, page=1)`
+  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale` or
+  `rent` (long-term); `offer_type` is `flat`, `room`, `house` or `commercial`.
+  `price_rub` is None for an offer without a stated price — never 0.
+- `cian_card(offer_id_or_url)` — one offer: price, `price_history`, rooms,
+  areas, floor, building, address, `metro[]`, description, views, `agent`.
+
+**Not an MCP tool:** `cian_selfcheck()` is a tri-state drift canary. It is
+CLI-only — `marketplace-mcp doctor` runs every connector's canary at once.
+
+## Region is an id, not a name
+
+Cian addresses regions by its own numeric ids and the connector has no
+lookup table. Known and verified live:
+
+| id   | region                |
+|------|-----------------------|
+| 1    | Москва                |
+| 2    | Санкт-Петербург       |
+| 4593 | Московская область    |
+| 4588 | Ленинградская область |
+
+Anything else needs the Cian id (visible as `region=` in a cian.ru search
+URL). Do not guess an id: a wrong one returns another region's offers with
+correct-looking prices. Default is `CIAN_REGION` (1, Moscow).
+
+## Filters: what the search does and does not do
+
+- **No text search.** There is no query string; "двушка у метро Сокол" has to
+  become `rooms=[2]` plus a region and a price range. Metro and street filters
+  are not exposed; filter the returned rows by `address` / `metro` yourself.
+- **`rooms`** applies to flats only: any of 1–6, plus Cian's codes 7 (свободная
+  планировка) and 9 (студия) — verified live, and easy to get backwards.
+  Rooms (`offer_type="room"`) are searched as flats with Cian's room code 0 —
+  the caller's `rooms` is ignored there.
+- **Rent is long-term** (`for_day: "!1"`); daily rent is not exposed.
+- **`price_min` / `price_max`** are rubles: total for sale, per month for rent.
+- **`total_count`** is Cian's `aggregatedCount` — the de-duplicated figure the
+  site shows, usually below the raw `offerCount`.
+
+## What a row carries and how to read it
+
+Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
+
+- **Price** comes from `bargainTerms.priceRur`, then `bargainTerms.price`, then
+  `priceTotalRur`. A new-building card has only the latter two — the parser
+  reads all three, so a `null` price means Cian shows none, not a missed key.
+- **`title` is Cian's own only on some offers**; otherwise the short info line
+  ("1-комн.кв. · 12/22 этаж") or a composed "rooms, area, floor" stands in.
+  Do not treat the title as a marketing name.
+- **`metro`** on a search row is the station Cian marks as the tile's own
+  (`isDefault`), not the shortest travel time — a 7-minute bus ride does not
+  outrank a 10-minute walk. The card returns every station in that order, with
+  `mode` `walk` or `transport`.
+- **`category`** tells the market: `newBuildingFlatSale` is a developer's
+  primary offer (`agent.user_type = developer`, `saleType fz214`), `flatSale`
+  is resale, `roomSale`, `houseSale`, `officeSale` and friends for the rest.
+- **Rent rows** add `price_period` (`monthly`), `lease_term` (`longTerm` /
+  `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only when the
+  owner publishes without an agent; None means Cian did not say.
+- **`created_at`** is Cian's local ISO time without a zone; `updated_at` on the
+  card is UTC. Do not compare them as if they were in one zone.
+- **`views`** on the card is parsed from Cian's own text
+  («12907 просмотров, 98 за сегодня»): the first number, total views.
+
+## What the source cannot do (and the connector does not pretend)
+
+- No agent/agency tool: `/agents/<id>/` renders profile facts only as page
+  text, with no structured state, so no tool reads it. The publisher's name,
+  type, id, offer count and account age ship inside the card's `agent` field.
+- No reviews — real estate has no per-offer review pool.
+- No geo-suggest: regions and metro are ids, not names (see above).
+- No phone numbers: the card knows how many phones the offer has, not their
+  values.
+
+## Gotchas
+- **403 inside the browser session** (`transport_down` with "WAF block") means
+  Cian challenged the scraping profile: open cian.ru in that Chrome, pass the
+  check if one is shown, retry. From a datacenter IP a cold session can start
+  blocked; a warmed-up session answered 8 requests in a row with no 429.
+- **Pace is deliberate**: 1.5 s between requests, one tab at a time. Do not
+  hammer pages 1–10 in a loop; ask for what is needed.
+- **`parser_drift`** means the envelope or `_cianConfig` shape changed — the
+  connector will not hand back a half-parsed card as if it were data. Run the
+  canary, then fix the parser.
+- **A removed offer** may render as "объявление не найдено" → `not_found`.
+- **Verification story:** a green selfcheck proves the transport answered and
+  the parser found ids, prices and addresses. It does not prove a particular
+  price is current — Cian's `price_history` on the card is the evidence to
+  quote when it matters.
+
+## DSH activation
+
+In DeepSeek Harness, the default profile exposes only `compare_prices` and
+`compare_sources` through the cheap compare mount. Per-marketplace tools and
+`marketplace_sources` require `RU_MARKETPLACE_MCP_FULL=1` and a profile restart;
+do not call them in the default mode. Cian is never part of the compare mount,
+so it is only reachable in the full profile.

--- a/skills/cian-connector/SKILL.md
+++ b/skills/cian-connector/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: cian-connector
-description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale or long-term rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
+description: Use this skill when the operator needs Russian real-estate data from Cian (cian.ru) — flats, rooms, houses or commercial property for sale, long-term rent or daily rent, or one offer's card with price history and publisher. Trigger on Russian queries like "найди на циане", "квартира на циан", "снять квартиру", "снять посуточно", "квартира на сутки", "купить однушку в Москве", "сколько стоит квартира на", "объявление циан", or English mentions of Cian. Needs the operator's Chrome over CDP (Cian's WAF blocks plain HTTP by IP). Skip for goods, marketplaces, and non-Cian real estate.
 ---
 
 # Cian Connector
@@ -12,8 +12,8 @@ HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен по�
 трафик» page, no captcha), so there is no anonymous tier.
 
 ## When to use
-- Find offers by filters: deal (sale / rent), property type, region, rooms,
-  price range, total area
+- Find offers by filters: deal (sale / long-term rent / daily rent), property
+  type, region, rooms, price range, total area
 - One offer's price, its price history, layout, building, address, metro,
   description and publisher
 - Real estate only. For goods use the marketplace connectors; for price
@@ -21,9 +21,10 @@ HTTP is blocked by Cian's WAF on IP reputation (a 403 «Обнаружен по�
 
 ## Tools available
 - `cian_search(deal, offer_type="flat", region=None, rooms=None, price_min=None, price_max=None, area_min=None, area_max=None, page=1)`
-  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale` or
-  `rent` (long-term); `offer_type` is `flat`, `room`, `house` or `commercial`.
-  `price_rub` is None for an offer without a stated price — never 0.
+  — offers via `search-offers-desktop`, 28 per page. `deal` is `sale`, `rent`
+  (long-term) or `daily` (посуточно); `offer_type` is `flat`, `room`, `house`
+  or `commercial`. `price_rub` is None for an offer without a stated price —
+  never 0, and `price_unit` says what it buys.
 - `cian_card(offer_id_or_url)` — one offer: price, `price_history`, rooms,
   areas, floor, building, address, `metro[]`, description, views, `agent`.
 
@@ -55,18 +56,41 @@ correct-looking prices. Default is `CIAN_REGION` (1, Moscow).
   планировка) and 9 (студия) — verified live, and easy to get backwards.
   Rooms (`offer_type="room"`) are searched as flats with Cian's room code 0 —
   the caller's `rooms` is ignored there.
-- **Rent is long-term** (`for_day: "!1"`); daily rent is not exposed.
-- **`price_min` / `price_max`** are rubles: total for sale, per month for rent.
+- **`price_min` / `price_max`** are rubles, in whatever unit the deal implies:
+  total for sale, per month for `rent`, **per night** for `daily`.
 - **`total_count`** is Cian's `aggregatedCount` — the de-duplicated figure the
   site shows, usually below the raw `offerCount`.
+
+## Long-term and daily are two markets, never one page
+
+`deal="rent"` and `deal="daily"` are separate on Cian and the connector keeps
+them separate (`for_day` `"!1"` vs `"1"`). Measured live in Moscow on
+2026-09-10: 25 411 long-term flats, 53 441 daily ones, and dropping the flag
+entirely returns a mixture, which is why the connector never does.
+
+- **A daily price is per night.** `price_unit` is `"day"`, and the category
+  comes back as `dailyFlatRent` / `dailyRoomRent` / `dailyHouseRent`. Cian
+  leaves `price_period` and `lease_term` null there, so `price_unit` is the
+  only honest signal — do not rank a 5 000 ₽ night against a 90 000 ₽ month.
+- **Daily covers flat, room and house only.** `offer_type="commercial"` with
+  `deal="daily"` is refused as a bad request: Cian accepts that query upstream
+  and answers zero, which would read as "nothing free today" rather than "this
+  market does not exist".
+- **For a stay of about a month**, both markets are worth a look: long-term
+  with `lease_term == "fewMonths"` (снять на несколько месяцев), and daily
+  where a monthly discount is usually negotiated in the description rather
+  than published as a field.
 
 ## What a row carries and how to read it
 
 Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
 
 - **Price** comes from `bargainTerms.priceRur`, then `bargainTerms.price`, then
-  `priceTotalRur`. A new-building card has only the latter two — the parser
-  reads all three, so a `null` price means Cian shows none, not a missed key.
+  `priceTotalRur`. A new-building card has only the latter two, and a daily
+  offer has no `priceRur` at all — the parser reads all three, so a `null`
+  price means Cian shows none, not a missed key.
+- **`price_unit`** is computed by the connector, not Cian: `total`, `month` or
+  `day`. Quote it whenever you show a price, and never average across units.
 - **`title` is Cian's own only on some offers**; otherwise the short info line
   ("1-комн.кв. · 12/22 этаж") or a composed "rooms, area, floor" stands in.
   Do not treat the title as a marketing name.
@@ -77,9 +101,9 @@ Confirmed against live payloads captured 2026-09-09 (fixtures in the package):
 - **`category`** tells the market: `newBuildingFlatSale` is a developer's
   primary offer (`agent.user_type = developer`, `saleType fz214`), `flatSale`
   is resale, `roomSale`, `houseSale`, `officeSale` and friends for the rest.
-- **Rent rows** add `price_period` (`monthly`), `lease_term` (`longTerm` /
-  `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only when the
-  owner publishes without an agent; None means Cian did not say.
+- **Long-term rent rows** add `price_period` (`monthly`), `lease_term`
+  (`longTerm` / `fewMonths`) and `deposit_rub`. `is_by_homeowner` is True only
+  when the owner publishes without an agent; None means Cian did not say.
 - **`created_at`** is Cian's local ISO time without a zone; `updated_at` on the
   card is UTC. Do not compare them as if they were in one zone.
 - **`views`** on the card is parsed from Cian's own text

--- a/skills/marketplace/SKILL.md
+++ b/skills/marketplace/SKILL.md
@@ -7,17 +7,17 @@ description: Use this skill when the operator wants the full marketplace mount, 
 
 One server mounting every installed connector as a namespaced toolset:
 `wb_*`, `ozon_*`, `yandex_*`, `detmir_*`, `avito_*`, `taobao_*`, `megamarket_*`,
-`lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `mpstats_*` plus
+`lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `cian_*`, `mpstats_*` plus
 `compare_prices` / `compare_sources` and its own `marketplace_sources`. Tool
 names keep their prefixes, so habits and configs carry over — but the operator
-wires a single `marketplace` entry instead of thirteen. The server exposes 36
-tools: 35 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
+wires a single `marketplace` entry instead of fourteen. The server exposes 39
+tools: 38 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
 source: without `MPSTATS_MP_AUTH` its tools answer `auth_missing` while
 everything else is unaffected.
 
 ## When to use
 - "Where is X cheapest" — compare_prices fans out across all searchable sources
-- Client setup: one config entry, not twelve
+- Client setup: one config entry, not fourteen
 - Health overview: the CLI's `doctor` runs every selfcheck at once
 - A source came back empty and you can't tell installed-but-quiet from never-loaded
   → `marketplace_sources`

--- a/uv.lock
+++ b/uv.lock
@@ -317,7 +317,7 @@ wheels = [
 
 [[package]]
 name = "cian-connector"
-version = "2.0.2"
+version = "2.1.0"
 source = { editable = "packages/cian-connector" }
 dependencies = [
     { name = "fastmcp" },

--- a/uv.lock
+++ b/uv.lock
@@ -1229,6 +1229,7 @@ version = "2.1.0"
 source = { editable = "packages/marketplace-connector" }
 dependencies = [
     { name = "avito-connector" },
+    { name = "cian-connector" },
     { name = "citilink-connector" },
     { name = "compare-connector" },
     { name = "detmir-connector" },
@@ -1248,6 +1249,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "avito-connector", editable = "packages/avito-connector" },
+    { name = "cian-connector", editable = "packages/cian-connector" },
     { name = "citilink-connector", editable = "packages/citilink-connector" },
     { name = "compare-connector", editable = "packages/compare-connector" },
     { name = "detmir-connector", editable = "packages/detmir-connector" },

--- a/uv.lock
+++ b/uv.lock
@@ -13,6 +13,7 @@ resolution-markers = [
 members = [
     "aliexpress-connector",
     "avito-connector",
+    "cian-connector",
     "citilink-connector",
     "compare-connector",
     "detmir-connector",
@@ -312,6 +313,27 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/4e/b5/721b8799b04bf9afe054a3899c6cf4e880fcf8563cc71c15610242490a0c/cfgv-3.5.0.tar.gz", hash = "sha256:d5b1034354820651caa73ede66a6294d6e95c1b00acc5e9b098e917404669132", size = 7334, upload-time = "2025-11-19T20:55:51.612Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/db/3c/33bac158f8ab7f89b2e59426d5fe2e4f63f7ed25df84c036890172b412b5/cfgv-3.5.0-py2.py3-none-any.whl", hash = "sha256:a8dc6b26ad22ff227d2634a65cb388215ce6cc96bbcc5cfde7641ae87e8dacc0", size = 7445, upload-time = "2025-11-19T20:55:50.744Z" },
+]
+
+[[package]]
+name = "cian-connector"
+version = "2.0.2"
+source = { editable = "packages/cian-connector" }
+dependencies = [
+    { name = "fastmcp" },
+    { name = "mcp-core" },
+    { name = "playwright" },
+    { name = "pydantic" },
+    { name = "pydantic-settings" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "fastmcp", specifier = ">=3.4.6,<4" },
+    { name = "mcp-core", editable = "packages/mcp-core" },
+    { name = "playwright", specifier = ">=1.40" },
+    { name = "pydantic", specifier = ">=2.6" },
+    { name = "pydantic-settings", specifier = ">=2.2" },
 ]
 
 [[package]]
@@ -2038,6 +2060,7 @@ source = { virtual = "." }
 dependencies = [
     { name = "aliexpress-connector" },
     { name = "avito-connector" },
+    { name = "cian-connector" },
     { name = "citilink-connector" },
     { name = "compare-connector" },
     { name = "detmir-connector" },
@@ -2069,6 +2092,7 @@ dev = [
 requires-dist = [
     { name = "aliexpress-connector", editable = "packages/aliexpress-connector" },
     { name = "avito-connector", editable = "packages/avito-connector" },
+    { name = "cian-connector", editable = "packages/cian-connector" },
     { name = "citilink-connector", editable = "packages/citilink-connector" },
     { name = "compare-connector", editable = "packages/compare-connector" },
     { name = "detmir-connector", editable = "packages/detmir-connector" },


### PR DESCRIPTION
## What and why

A Cian (cian.ru) connector: `cian_search` and `cian_card`, mounted into the unified server as a tier-2 source.

**Scope question first, since it is the obvious one.** Cian is real estate, not goods, and this repository is called ru-marketplace-mcp. My argument for it fitting anyway: Avito is already here and is classifieds rather than a catalog, the same way Cian is; the connector follows `docs/ADDING_A_SOURCE.md` step by step; and it deliberately stays out of `compare_prices` (a flat has no price comparable to a kettle), with `text_search: False` in `_CAPABILITIES` so nothing routes a product query to it. If you would rather keep the project to goods, say so and I will keep this in my fork — no hard feelings, and the anti-bot findings below may still be worth having.

**Probe (question 1 of the doctrine), datacenter egress, 2026-09-09.** Plain HTTP is a dead end: the search page, the offer card and the internal JSON API all answer 403 with Cian's own WAF page (`cian_waf_block`, «Обнаружен подозрительный трафик»), no captcha and no redirect loop — an IP-reputation firewall, so TLS impersonation has nothing to clear. Inside the operator's Chrome the site's own API answers an in-page `fetch` POST with structured offers, and the card embeds its whole state in `window._cianConfig`. So: tier 2 only, JSON both ways, no HTML parsing anywhere. Eight back-to-back API calls inside the session returned 200 in ~1.2 s each with no 429; the connector still paces itself at 1.5 s behind a single-tab lock. Written up as a new `docs/ANTI_BOT.md` section in the format of the existing ones.

**The in-page JavaScript is transport, not parsing.** It POSTs a `jsonQuery` or serialises one `_cianConfig` subtree; every field decision is Python, covered by offline tests over trimmed live fixtures with provenance files next to them.

**Search is by filters, not text** — Cian has no free-text search worth exposing, and the tool says so rather than pretending. Deal is `sale`, `rent` (long-term) or `daily`; property type is flat, room, house or commercial. Verified live rather than assumed: region ids 1 / 2 / 4593 / 4588 by the addresses that came back, `room=[0]` for rooms, room codes 7 (свободная планировка) and 9 (студия) — which are the reverse of what the open-source parsers suggest — the `total_area` range key, and Cian's redirect from `/sale/flat/<id>/` to an offer's real deal/type URL, which is what lets one URL shape serve every category.

**Long-term and daily rent are kept apart**, `for_day` `"!1"` vs `"1"`. In Moscow that is 25 411 long-term flats against 53 441 daily ones, and omitting the flag returns a mixture. A daily price is per night, and Cian leaves `paymentPeriod` and `leaseTermType` null there while omitting `priceRur` entirely — nothing in the payload marks the unit. Hence `price_unit` (`total` / `month` / `day`) on every row and card: without it a 5 000 ₽ night ranks above a 90 000 ₽ month in any "cheapest" reading. Daily commercial is refused as `bad_request`, because upstream accepts that query and answers zero, which would read as "nothing free today" rather than "this market does not exist".

**What the source cannot do, and what therefore is not shipped:** no agent tool — `/agents/<id>/` renders profile facts only as page text, `_cianConfig` there holds application telemetry, so the publisher ships inside the card instead; no reviews (real estate has no per-offer pool); no geo-suggest, so regions and metro stay ids; no phone numbers.

Registered in the usual places: workspace lists, `_CAPABILITIES` / `_mount_all` / doctor, CI smoke, both e2e tool counts (37 → 39), Dockerfiles, compose, skill plus its `dsh/` copy, README in both languages, CHANGELOG, and the public-contract snapshot regenerated.

Rebased onto v2.1.0 after #45/#46 landed: the connector carries the release version, and the README server tables gain a Cian row. The stated totals move to 38 tools across 14 servers (39 on the unified mount) — which also corrects a pre-existing off-by-one, since compare has exposed three tools since `compare_verify_offer` landed and the README still said 35/13.

The connector is deliberately absent from the new `decision-mcp` profile: that mount is about verifying a winning product offer, which a flat does not have. The dsh bundle vendors its skill like every other connector, so the CI guard there now expects fifteen vendored skills rather than fourteen; the three MCP rows in `cordis.patch.yml` are untouched and still disabled by default, since Cian is reachable through the existing full mount.

## Checks

- [x] `uv run pytest -q -m "not live"` — 1253 passed, 58 skipped
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy`
- [x] `uv run python scripts/check_no_print.py`
- [x] `uv run python scripts/check_versions.py` — 2.1.0 in 84 places
- [x] `uv run mypy --platform win32`
- [x] `uv run python scripts/e2e_stdio_check.py` — 16/16 servers, `cian-mcp` 2 tools, `marketplace-mcp` 39
- [x] `uv run python scripts/test_ops_gates.py`
- [x] `uv run python scripts/check_test_count.py` — 1311 collected, documented in 7 places

Live, through the connector against a real session: filter searches for sale, long-term rent, daily flats, daily houses and rooms; cards for a new-building sale, a rent and a daily offer; the daily-commercial refusal.

## Project gates

- [x] No `print()` in server code — diagnostics go through `log_event`
- [x] Tool names and signatures are additive; nothing existing renamed or reordered

## If this reads a new field or endpoint

- [x] Missing values are `None`, never `0` — price reads `bargainTerms.priceRur`, then `.price`, then `priceTotalRur` (a new-building card carries only the last two, a daily card has no `priceRur` at all), and `None` means Cian states no price
- [x] Format drift raises `parser_drift`; a WAF block raises `transport_down` with the fix inline; a removed offer raises `not_found` — the three are not conflated, including the case where the block page arrives as a 200 through the in-page fetch
- [x] Tests monkeypatch the fetch layer and assert the contract an agent sees; fixtures are real trimmed payloads with provenance recording what the page displayed. `cian_selfcheck` is a tri-state canary wired into `doctor`, and it chains: the search probe supplies the live id the card probe uses


