### PR TITLE
feat: выбор монтируемых источников через MARKETPLACE_SOURCES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,9 @@
   Детского мира всегда был `false`, даже когда они смонтированы, — таблица
   монтирования называет их `yandex`/`detmir`, а метаданные —
   `yandex_market`/`detsky_mir`.
+- `MARKETPLACE_SOURCES` теперь отклоняет неизвестные имена при запуске и
+  перечисляет поддерживаемые источники: опечатка больше не создаёт частичный
+  сервер молча.
 
 ### Added
 
@@ -85,6 +88,8 @@
 - `marketplace_sources`: the `mounted` flag in `capabilities` always read
   `false` for Yandex Market and Detsky Mir, even when mounted — the mount table
   names them `yandex`/`detmir`, the metadata `yandex_market`/`detsky_mir`.
+- `MARKETPLACE_SOURCES` now rejects unknown names at startup and lists the
+  supported sources, so a typo cannot silently create a partial server.
 
 ### Исправлено
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,20 @@
   публикатора. Цена без указания — `None`, не 0. В `compare_prices` источник не
   участвует. Страница агента структурированных данных не отдаёт, поэтому тула
   `cian_agent` нет — агент приходит внутри карточки (`docs/ANTI_BOT.md` § Cian).
+- Переменная `MARKETPLACE_SOURCES` выбирает, какие источники монтирует
+  `marketplace-mcp`: схемы всех тулов уходят клиенту в каждом запросе, и
+  оператор, которому нужны три площадки, не платит за остальные. Имена
+  канонические, псевдонимы `wb`, `ym`/`yandex`, `detmir`, `ali` тоже
+  принимаются. Не задана или пуста — монтируется всё, как раньше. Снятые
+  источники видны в `marketplace_sources` → `skipped` с пометкой
+  `deselected`, а `compare_prices` опрашивает тот же набор.
+
+### Исправлено
+
+- `marketplace_sources`: флаг `mounted` в `capabilities` у Яндекс Маркета и
+  Детского мира всегда был `false`, даже когда они смонтированы, — таблица
+  монтирования называет их `yandex`/`detmir`, а метаданные —
+  `yandex_market`/`detsky_mir`.
 
 ### Added
 
@@ -59,6 +73,18 @@
   takes no part in `compare_prices`. The agent page exposes no structured data,
   so there is no `cian_agent` tool — the agent ships inside the card
   (`docs/ANTI_BOT.md` § Cian).
+- `MARKETPLACE_SOURCES` selects which sources `marketplace-mcp` mounts: every
+  tool schema is sent to the client on every request, so an operator who needs
+  three marketplaces does not pay for the rest. Canonical names, plus the
+  aliases `wb`, `ym`/`yandex`, `detmir` and `ali`. Unset or blank mounts
+  everything, as before. Deselected sources appear in `marketplace_sources` →
+  `skipped` marked `deselected`, and `compare_prices` queries the same subset.
+
+### Fixed
+
+- `marketplace_sources`: the `mounted` flag in `capabilities` always read
+  `false` for Yandex Market and Detsky Mir, even when mounted — the mount table
+  names them `yandex`/`detmir`, the metadata `yandex_market`/`detsky_mir`.
 
 ### Исправлено
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,33 @@
+# Contributors / Участники
+
+This project keeps a durable thank-you record for people whose merged pull
+requests improved it. The PR links are the source of detail; this file is a
+human-readable index, so future maintainers do not have to reconstruct credit
+from chat history.
+
+Проект сохраняет здесь список авторов влитых pull request. Ссылки на PR —
+первоисточник деталей; этот файл нужен, чтобы благодарности не терялись в
+истории обсуждений.
+
+## People / Люди
+
+| Contributor | Merged PRs | Contribution |
+|---|---|---|
+| [@Vladimir-Human](https://github.com/Vladimir-Human) | maintainer | Project architecture, releases, reviews, and core maintenance. |
+| [@Xpos587](https://github.com/Xpos587) | [#5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5) | MPStats connector: plugin API analysis, parser structure, and the first working version. |
+| [@avxone](https://github.com/avxone) | [#37](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/37) | Avito selfcheck fix for the `catalog.items[]` response envelope. |
+| [@Khalmatov](https://github.com/Khalmatov) | [#38](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/38) | Ozon review provenance: mark the SKU the review is about. |
+| [@fosteev](https://github.com/fosteev) | [#42](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/42), [#47](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/47) | macOS CDP stealth portability and the Cian real-estate connector. |
+| [@ilodezis](https://github.com/ilodezis) | [#48](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/48) | Selective unified-server mounting through `MARKETPLACE_SOURCES`, reducing tool-schema wire cost. |
+
+## Automation / Автоматизация
+
+| Contributor | Merged PRs | Contribution |
+|---|---|---|
+| [dependabot[bot]](https://github.com/apps/dependabot) | [#2](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/2), [#3](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/3), [#4](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/4), [#17](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/17), [#23](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/23), [#24](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/24), [#41](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/41) | Dependency updates and supply-chain maintenance. |
+
+If a merged contribution is missing or the description needs correction, please
+open an issue or pull request so the record stays accurate.
+
+Если вклад пропущен или описание нужно исправить, откройте issue или pull request,
+чтобы список оставался точным.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1315 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1325 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -138,6 +138,34 @@ macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 команд — `wb-mcp`, `ozon-mcp`, `yandex-mcp`, `detmir-mcp`, `avito-mcp`,
 `taobao-mcp`, `megamarket-mcp`, `lamoda-mcp`, `dns-mcp`, `citilink-mcp`,
 `compare-mcp`, `marketplace-mcp`.
+
+### Только нужные площадки: `MARKETPLACE_SOURCES`
+
+Объединённый сервер монтирует все источники, а описания их инструментов уходят
+в контекст **в каждом запросе**. Переменная `MARKETPLACE_SOURCES` оставляет
+только перечисленные:
+
+```jsonc
+{
+  "mcpServers": {
+    "marketplace": {
+      "command": "uv",
+      "args": ["run", "--directory", "C:/путь/к/ru-marketplace-mcp", "marketplace-mcp"],
+      "env": {
+        "MARKETPLACE_SOURCES": "wildberries,ozon,yandex_market,avito,aliexpress,dns,compare",
+      },
+    },
+  },
+}
+```
+
+Имена — канонические (`wildberries`, `ozon`, `yandex_market`, `detsky_mir`,
+`avito`, `taobao`, `megamarket`, `lamoda`, `dns`, `citilink`, `aliexpress`,
+`cian`, `compare`, `mpstats`); короткие псевдонимы `wb`, `ym`/`yandex`, `detmir`, `ali`
+тоже принимаются. Переменная не задана или пуста — монтируется всё, как раньше.
+Отключённые источники видно в `marketplace_sources`: они попадают в `skipped`
+с пометкой, что их сняли, а не что они не импортировались. `compare_prices`
+опрашивает ровно тот же набор.
 
 </details>
 
@@ -526,7 +554,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1315 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1325 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -589,7 +617,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1315 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1325 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -670,7 +698,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1315 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1325 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1006,11 +1034,22 @@ nothing to configure, nothing to leak. MPStats alone has `MPSTATS_MP_AUTH`, the 
 of a paid account — it belongs only in the client entry's env, never in code or
 commits.
 
+**Only the sources you use: `MARKETPLACE_SOURCES`.** The unified server mounts every
+source, and their tool schemas are sent to the client on every request. Set
+`MARKETPLACE_SOURCES` in the `marketplace-mcp` entry's env to a comma-separated list
+to mount only those, e.g. `wildberries,ozon,yandex_market,avito,aliexpress,dns,compare`.
+Names are canonical (`wildberries`, `ozon`, `yandex_market`, `detsky_mir`, `avito`,
+`taobao`, `megamarket`, `lamoda`, `dns`, `citilink`, `aliexpress`, `cian`, `compare`,
+`mpstats`); the aliases `wb`, `ym`/`yandex`, `detmir` and `ali` work too. Unset or
+blank mounts everything, as before. Deselected sources show up in
+`marketplace_sources` under `skipped`, marked as deselected rather than failed to
+import, and `compare_prices` queries the same subset.
+
 ## Development
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1315 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1325 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1070,7 +1109,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1315 offline
+are confidently wrong, so the project is arranged around verification: 1325 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/README.md
+++ b/README.md
@@ -162,7 +162,9 @@ macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
 Имена — канонические (`wildberries`, `ozon`, `yandex_market`, `detsky_mir`,
 `avito`, `taobao`, `megamarket`, `lamoda`, `dns`, `citilink`, `aliexpress`,
 `cian`, `compare`, `mpstats`); короткие псевдонимы `wb`, `ym`/`yandex`, `detmir`, `ali`
-тоже принимаются. Переменная не задана или пуста — монтируется всё, как раньше.
+тоже принимаются. Неизвестное имя отклоняется при запуске с перечнем
+поддерживаемых источников, чтобы опечатка не превратилась в частичный сервер.
+Переменная не задана или пуста — монтируется всё, как раньше.
 Отключённые источники видно в `marketplace_sources`: они попадают в `skipped`
 с пометкой, что их сняли, а не что они не импортировались. `compare_prices`
 опрашивает ровно тот же набор.
@@ -1040,8 +1042,10 @@ source, and their tool schemas are sent to the client on every request. Set
 to mount only those, e.g. `wildberries,ozon,yandex_market,avito,aliexpress,dns,compare`.
 Names are canonical (`wildberries`, `ozon`, `yandex_market`, `detsky_mir`, `avito`,
 `taobao`, `megamarket`, `lamoda`, `dns`, `citilink`, `aliexpress`, `cian`, `compare`,
-`mpstats`); the aliases `wb`, `ym`/`yandex`, `detmir` and `ali` work too. Unset or
-blank mounts everything, as before. Deselected sources show up in
+`mpstats`); the aliases `wb`, `ym`/`yandex`, `detmir` and `ali` work too. An unknown
+name is rejected at startup with the supported-source list, so a typo cannot
+silently produce a partial server. Unset or blank mounts everything, as before.
+Deselected sources show up in
 `marketplace_sources` under `skipped`, marked as deselected rather than failed to
 import, and `compare_prices` queries the same subset.
 

--- a/README.md
+++ b/README.md
@@ -624,14 +624,16 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
 
-Вопрос «кто набрал текст» кажется мне менее интересным, чем вопрос «чем это
-проверено». Второй здесь задокументирован, и проверить его может любой.
+Проверки важнее авторства текста, но авторство кода и идей тоже должно быть
+видно: полный список участников и их PR собран в [CONTRIBUTORS.md](CONTRIBUTORS.md).
 
 ## Спасибо
 
-[@Xpos587](https://github.com/Xpos587) — коннектор MPStats
-([PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5)):
-разбор API плагина, структура парсеров и первая рабочая версия.
+- [@Xpos587](https://github.com/Xpos587) — коннектор MPStats, [PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5).
+- [@avxone](https://github.com/avxone) — исправление Avito selfcheck, [PR #37](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/37).
+- [@Khalmatov](https://github.com/Khalmatov) — provenance отзывов Ozon, [PR #38](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/38).
+- [@fosteev](https://github.com/fosteev) — macOS CDP stealth и коннектор Циана, [PR #42](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/42), [PR #47](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/47).
+- [@ilodezis](https://github.com/ilodezis) — выбор источников unified-сервера через `MARKETPLACE_SOURCES`, [PR #48](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/48).
 
 ## Лицензия
 
@@ -1118,14 +1120,17 @@ tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.
 
-Who typed the text seems a less interesting question than what checks it survived.
-The second one is documented here, and anyone can re-run it.
+Checks matter more than who typed the prose, but code and ideas deserve visible
+credit too: the full contributor and PR index is in
+[CONTRIBUTORS.md](CONTRIBUTORS.md).
 
 ## Thanks
 
-[@Xpos587](https://github.com/Xpos587) for the MPStats connector
-([PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5)): the
-plugin API work, the parser structure and the first working version.
+- [@Xpos587](https://github.com/Xpos587) — MPStats connector, [PR #5](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/5).
+- [@avxone](https://github.com/avxone) — Avito selfcheck fix, [PR #37](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/37).
+- [@Khalmatov](https://github.com/Khalmatov) — Ozon review provenance, [PR #38](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/38).
+- [@fosteev](https://github.com/fosteev) — macOS CDP stealth and the Cian connector, [PR #42](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/42), [PR #47](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/47).
+- [@ilodezis](https://github.com/ilodezis) — unified-server source selection, [PR #48](https://github.com/Vladimir-Human/ru-marketplace-mcp/pull/48).
 
 ## License
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1315 offline tests, no network required. Three flavours:
+1325 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -41,6 +41,18 @@ Diagnostics go to **stderr only**. Under stdio, stdout is the JSON-RPC stream an
 a single stray byte there corrupts the protocol; `scripts/check_no_print.py`
 enforces this across the connector source, `mcp_core.runtime` included.
 
+## Unified source selection
+
+The unified `marketplace-mcp` server mounts every source by default. Set
+`MARKETPLACE_SOURCES` to a comma-separated list of canonical names to reduce the
+tool surface and wire cost, for example
+`wildberries,ozon,yandex_market,compare`. The aliases `wb`, `ym`/`yandex`,
+`detmir`, and `ali` are accepted. Unset or blank means all sources; unknown
+names fail at startup with the supported-source list instead of silently
+starting a partial server. Deselected sources remain visible in
+`marketplace_sources.skipped` with a `deselected` reason, and `compare_prices`
+uses the same selected subset.
+
 ### stdio (default, unchanged)
 
 Nothing to configure. The README's client configs already do this:

--- a/dsh/skills/marketplace/SKILL.md
+++ b/dsh/skills/marketplace/SKILL.md
@@ -49,6 +49,11 @@ everything else is unaffected.
 ## Gotchas
 - A source whose optional deps are missing is simply absent from the set —
   `marketplace_sources` says which and why.
+- Set `MARKETPLACE_SOURCES` on the unified server to mount only a comma-separated
+  subset (`wildberries,ozon,compare`); unset or blank keeps every source. The
+  aliases `wb`, `ym`/`yandex`, `detmir`, and `ali` work too. Unknown names fail
+  at startup instead of silently producing a partial server, and deselected
+  sources are reported with a `deselected` reason.
 - compare_prices ranks on everyday ruble prices; Taobao (CNY) is reported in
   `price_native` but never ranked against rubles.
 ## DSH activation

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -44,6 +44,7 @@ from mcp_core.errors import BadRequestError, raise_tool_error
 from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.redact import redact_error_text as _redact
+from mcp_core.source_selection import selected
 from pydantic import Field
 
 from compare_connector.models_output import (
@@ -160,6 +161,10 @@ def _available_sources() -> dict[str, Any]:
         sources["aliexpress"] = aliexpress_server
     except Exception as exc:
         log_event("compare.source_unavailable", source="aliexpress", error=_redact(str(exc))[:120])
+
+    chosen = selected()
+    if chosen is not None:
+        sources = {name: module for name, module in sources.items() if name in chosen}
 
     return sources
 

--- a/packages/marketplace-connector/src/marketplace_connector/server.py
+++ b/packages/marketplace-connector/src/marketplace_connector/server.py
@@ -30,7 +30,10 @@ class MarketplaceSourcesResponse(BaseModel):
     mounted: list[str] = Field(default_factory=list, description="Sources whose tools are available in this server.")
     skipped: dict[str, str] = Field(
         default_factory=dict,
-        description="Source name mapped to the import error that removed it — usually a missing dependency.",
+        description=(
+            "Source name mapped to the reason it is unavailable: an import error or an explicit "
+            "MARKETPLACE_SOURCES deselection."
+        ),
     )
     mounted_count: int = Field(default=0, description="How many sources mounted.")
     skipped_count: int = Field(default=0, description="How many sources were skipped.")
@@ -212,8 +215,9 @@ async def marketplace_sources() -> MarketplaceSourcesResponse:
     ## Return Format
 
     MarketplaceSourcesResponse: {mounted, skipped, mounted_count, skipped_count,
-    capabilities, server_version}. ``skipped`` maps source name to the import error that
-    removed it, which is usually a missing optional dependency.
+    capabilities, server_version}. ``skipped`` maps source name to the reason
+    it is unavailable: an import error (usually a missing optional dependency)
+    or an explicit ``MARKETPLACE_SOURCES`` deselection.
 
     ## Error Format
 

--- a/packages/marketplace-connector/src/marketplace_connector/server.py
+++ b/packages/marketplace-connector/src/marketplace_connector/server.py
@@ -20,6 +20,7 @@ from fastmcp import FastMCP
 from mcp.types import ToolAnnotations
 from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
+from mcp_core.source_selection import ENV_VAR, canonical, selected, wanted
 from pydantic import BaseModel, Field
 
 
@@ -165,7 +166,14 @@ def _mount_all() -> None:
         ("compare", "compare_connector.server"),
         ("mpstats", "mpstats_connector.server"),
     )
+    chosen = selected()
     for name, module_path in mounts:
+        if not wanted(name, chosen):
+            # Deselected, not broken. Recorded rather than dropped silently so
+            # marketplace_sources can tell "you turned this off" apart from
+            # "this failed to import".
+            _SKIPPED[name] = f"deselected: not listed in {ENV_VAR}"
+            continue
         try:
             module = __import__(module_path, fromlist=["mcp"])
             mcp.mount(module.mcp)
@@ -217,7 +225,10 @@ async def marketplace_sources() -> MarketplaceSourcesResponse:
         skipped=dict(sorted(_SKIPPED.items())),
         mounted_count=len(_MOUNTED),
         skipped_count=len(_SKIPPED),
-        capabilities={name: {**metadata, "mounted": name in _MOUNTED} for name, metadata in _CAPABILITIES.items()},
+        capabilities={
+            name: {**metadata, "mounted": name in {canonical(m) for m in _MOUNTED}}
+            for name, metadata in _CAPABILITIES.items()
+        },
         server_version=SERVER_VERSION,
     )
 

--- a/packages/marketplace-connector/tests/test_source_selection.py
+++ b/packages/marketplace-connector/tests/test_source_selection.py
@@ -1,0 +1,96 @@
+"""MARKETPLACE_SOURCES mounts the operator's subset and nothing else."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+
+import pytest
+from mcp_core.source_selection import ENV_VAR, canonical, selected, wanted
+
+
+def _reload_unified():
+    """Re-import the unified server so _mount_all runs under the current env."""
+    import marketplace_connector.server as unified
+
+    return importlib.reload(unified)
+
+
+@pytest.fixture
+def unified_env(monkeypatch):
+    def _set(value: str | None):
+        if value is None:
+            monkeypatch.delenv(ENV_VAR, raising=False)
+        else:
+            monkeypatch.setenv(ENV_VAR, value)
+        return _reload_unified()
+
+    yield _set
+    monkeypatch.delenv(ENV_VAR, raising=False)
+    _reload_unified()
+
+
+def test_unset_env_mounts_everything(unified_env):
+    # No pinned tool count here: test_server.py already pins it, and a new
+    # connector would break this test for reasons unrelated to selection.
+    server = unified_env(None)
+    assert not any(reason.startswith("deselected") for reason in server._SKIPPED.values())
+
+
+def test_blank_env_is_treated_as_unset(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "   ")
+    assert selected() is None
+
+
+def test_subset_drops_unlisted_sources(unified_env):
+    server = unified_env("wildberries,avito")
+    names = {tool.name for tool in asyncio.run(server.mcp.list_tools())}
+
+    assert any(name.startswith("wb_") for name in names)
+    assert any(name.startswith("avito_") for name in names)
+    assert not any(name.startswith("taobao_") for name in names)
+    assert not any(name.startswith("mpstats_") for name in names)
+    # marketplace_sources belongs to the unified server itself, never to a source.
+    assert "marketplace_sources" in names
+
+
+def test_deselected_sources_are_reported_not_hidden(unified_env):
+    server = unified_env("wildberries")
+    response = asyncio.run(server.marketplace_sources())
+
+    assert "wildberries" in response.mounted
+    assert ENV_VAR in response.skipped["taobao"]
+    assert response.capabilities["wildberries"]["mounted"] is True
+    assert response.capabilities["taobao"]["mounted"] is False
+
+
+def test_capabilities_flag_survives_the_naming_mismatch(unified_env):
+    """_MOUNTED says "yandex"/"detmir"; _CAPABILITIES is keyed canonically."""
+    server = unified_env("yandex,detmir")
+    response = asyncio.run(server.marketplace_sources())
+
+    assert response.capabilities["yandex_market"]["mounted"] is True
+    assert response.capabilities["detsky_mir"]["mounted"] is True
+
+
+def test_aliases_and_spacing_are_accepted(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, " WB , Yandex-Market ,ali")
+    assert selected() == {"wildberries", "yandex_market", "aliexpress"}
+
+
+def test_wanted_defaults_to_keeping_everything():
+    assert wanted("taobao", None) is True
+    assert wanted("taobao", {"wildberries"}) is False
+    assert canonical("Detmir") == "detsky_mir"
+
+
+def test_compare_queries_only_the_selected_sources(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "wildberries,ozon")
+    import compare_connector.server as compare
+
+    compare = importlib.reload(compare)
+    try:
+        assert set(compare.SOURCES) == {"wildberries", "ozon"}
+    finally:
+        monkeypatch.delenv(ENV_VAR, raising=False)
+        importlib.reload(compare)

--- a/packages/marketplace-connector/tests/test_source_selection.py
+++ b/packages/marketplace-connector/tests/test_source_selection.py
@@ -6,7 +6,7 @@ import asyncio
 import importlib
 
 import pytest
-from mcp_core.source_selection import ENV_VAR, canonical, selected, wanted
+from mcp_core.source_selection import ENV_VAR, SourceSelectionError, canonical, selected, wanted
 
 
 def _reload_unified():
@@ -76,6 +76,20 @@ def test_capabilities_flag_survives_the_naming_mismatch(unified_env):
 def test_aliases_and_spacing_are_accepted(monkeypatch):
     monkeypatch.setenv(ENV_VAR, " WB , Yandex-Market ,ali")
     assert selected() == {"wildberries", "yandex_market", "aliexpress"}
+
+
+def test_unknown_source_is_rejected_instead_of_silently_dropped(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "wildberries,typo_source")
+
+    with pytest.raises(SourceSelectionError, match=r"unknown source.*typo_source"):
+        selected()
+
+
+def test_unified_server_rejects_invalid_selection(monkeypatch):
+    monkeypatch.setenv(ENV_VAR, "wildberries,typo_source")
+
+    with pytest.raises(SourceSelectionError, match=r"unknown source.*typo_source"):
+        _reload_unified()
 
 
 def test_wanted_defaults_to_keeping_everything():

--- a/packages/marketplace-connector/tests/test_source_selection.py
+++ b/packages/marketplace-connector/tests/test_source_selection.py
@@ -85,11 +85,9 @@ def test_unknown_source_is_rejected_instead_of_silently_dropped(monkeypatch):
         selected()
 
 
-def test_unified_server_rejects_invalid_selection(monkeypatch):
-    monkeypatch.setenv(ENV_VAR, "wildberries,typo_source")
-
+def test_unified_server_rejects_invalid_selection(unified_env):
     with pytest.raises(SourceSelectionError, match=r"unknown source.*typo_source"):
-        _reload_unified()
+        unified_env("wildberries,typo_source")
 
 
 def test_wanted_defaults_to_keeping_everything():

--- a/packages/mcp-core/src/mcp_core/source_selection.py
+++ b/packages/mcp-core/src/mcp_core/source_selection.py
@@ -65,7 +65,8 @@ def selected() -> set[str] | None:
 
     An empty or whitespace-only value is treated as unset: a client config that
     passes the variable through with nothing in it must not silently mount an
-    empty server.
+    empty server. Unknown names raise ``SourceSelectionError`` so a typo cannot
+    silently produce a partial server.
     """
     raw = os.environ.get(ENV_VAR, "").strip()
     if not raw:

--- a/packages/mcp-core/src/mcp_core/source_selection.py
+++ b/packages/mcp-core/src/mcp_core/source_selection.py
@@ -1,0 +1,52 @@
+"""Operator-chosen subset of marketplace sources.
+
+Every advertised tool costs its schema on EVERY client request, so an operator
+who only reads three marketplaces should not pay for eleven.
+``MARKETPLACE_SOURCES`` names the ones to keep.
+
+Unset means "all", the behaviour before this variable existed — the pinned tool
+counts in the test suite stay valid, and an operator who never sets the
+variable sees no change at all.
+
+The two mount points name sources differently (``yandex`` in the unified
+server's mount table, ``yandex_market`` in compare's source map), so names are
+canonicalised here rather than in either caller.
+"""
+
+from __future__ import annotations
+
+import os
+
+ENV_VAR = "MARKETPLACE_SOURCES"
+
+_ALIASES = {
+    "wb": "wildberries",
+    "yandex": "yandex_market",
+    "ym": "yandex_market",
+    "detmir": "detsky_mir",
+    "ali": "aliexpress",
+}
+
+
+def canonical(name: str) -> str:
+    """One spelling per source, whichever alias a caller or operator used."""
+    cleaned = name.strip().lower().replace("-", "_")
+    return _ALIASES.get(cleaned, cleaned)
+
+
+def selected() -> set[str] | None:
+    """Canonical names the operator asked for, or ``None`` meaning all of them.
+
+    An empty or whitespace-only value is treated as unset: a client config that
+    passes the variable through with nothing in it must not silently mount an
+    empty server.
+    """
+    raw = os.environ.get(ENV_VAR, "").strip()
+    if not raw:
+        return None
+    return {canonical(part) for part in raw.split(",") if part.strip()}
+
+
+def wanted(name: str, chosen: set[str] | None) -> bool:
+    """Whether this source survives the operator's selection."""
+    return chosen is None or canonical(name) in chosen

--- a/packages/mcp-core/src/mcp_core/source_selection.py
+++ b/packages/mcp-core/src/mcp_core/source_selection.py
@@ -19,6 +19,28 @@ import os
 
 ENV_VAR = "MARKETPLACE_SOURCES"
 
+# Keep this list in the same canonical vocabulary as the unified mount table
+# and compare's source map.  A typo must fail at startup instead of producing a
+# plausible-looking server with one or zero marketplaces mounted.
+KNOWN_SOURCES = frozenset(
+    {
+        "wildberries",
+        "ozon",
+        "yandex_market",
+        "detsky_mir",
+        "avito",
+        "taobao",
+        "megamarket",
+        "lamoda",
+        "dns",
+        "citilink",
+        "aliexpress",
+        "cian",
+        "compare",
+        "mpstats",
+    }
+)
+
 _ALIASES = {
     "wb": "wildberries",
     "yandex": "yandex_market",
@@ -26,6 +48,10 @@ _ALIASES = {
     "detmir": "detsky_mir",
     "ali": "aliexpress",
 }
+
+
+class SourceSelectionError(ValueError):
+    """The selection names a source that this release does not provide."""
 
 
 def canonical(name: str) -> str:
@@ -44,7 +70,13 @@ def selected() -> set[str] | None:
     raw = os.environ.get(ENV_VAR, "").strip()
     if not raw:
         return None
-    return {canonical(part) for part in raw.split(",") if part.strip()}
+    chosen = {canonical(part) for part in raw.split(",") if part.strip()}
+    unknown = sorted(chosen - KNOWN_SOURCES)
+    if unknown:
+        names = ", ".join(unknown)
+        supported = ", ".join(sorted(KNOWN_SOURCES))
+        raise SourceSelectionError(f"{ENV_VAR} contains unknown source(s): {names}. Supported: {supported}")
+    return chosen
 
 
 def wanted(name: str, chosen: set[str] | None) -> bool:

--- a/skills/marketplace/SKILL.md
+++ b/skills/marketplace/SKILL.md
@@ -49,6 +49,11 @@ everything else is unaffected.
 ## Gotchas
 - A source whose optional deps are missing is simply absent from the set —
   `marketplace_sources` says which and why.
+- Set `MARKETPLACE_SOURCES` on the unified server to mount only a comma-separated
+  subset (`wildberries,ozon,compare`); unset or blank keeps every source. The
+  aliases `wb`, `ym`/`yandex`, `detmir`, and `ali` work too. Unknown names fail
+  at startup instead of silently producing a partial server, and deselected
+  sources are reported with a `deselected` reason.
 - compare_prices ranks on everyday ruble prices; Taobao (CNY) is reported in
   `price_native` but never ranked against rubles.
 ## DSH activation


### PR DESCRIPTION
## Что и зачем

`marketplace-mcp` монтирует все источники разом, а схемы их тулов уходят клиенту в каждом запросе. Мне из тринадцати источников (замер до Циана) нужны семь, и остальные шесть съедали около трети контекста на каждый запрос: 17 086 → 11 851 токенов, 37 тулов → 24.

Добавил переменную `MARKETPLACE_SOURCES`: список источников через запятую, монтируются только они.

- Не задана или пустая — монтируется всё, как сейчас. Для тех, кто её не трогает, ничего не меняется, зашитые числа тулов в тестах те же.
- Имена канонические (`wildberries`, `yandex_market`, `detsky_mir`, …), короткие `wb`, `ym`/`yandex`, `detmir`, `ali` тоже принимаются, регистр и пробелы не важны.
- Снятые источники видны в `marketplace_sources` → `skipped` с причиной `deselected`, чтобы «сам выключил» не путалось с «не импортировался».
- `compare_prices` опрашивает тот же набор, а не все источники.

Попутно исправил баг: флаг `mounted` в `capabilities` у Яндекс Маркета и Детского мира всегда был `false`, даже когда они смонтированы. Таблица монтирования называет их `yandex`/`detmir`, а метаданные — `yandex_market`/`detsky_mir`.

Документация: раздел в README (обе половины), записи в CHANGELOG (Unreleased), счётчик офлайн-тестов 1311 → 1319 в README и `docs/ARCHITECTURE.md`.

## Проверки

Прогнал локально на Windows:

- [x] `uv run pytest -q -m "not live and not cdp"` — 1261 passed, 58 skipped
- [x] `uv run ruff check .`
- [x] `uv run ruff format --check .`
- [x] `uv run mypy` и `uv run mypy --platform win32`
- [x] `uv run python scripts/check_no_print.py`
- [x] `uv run python scripts/check_versions.py`

## Требования проекта

- [x] Никаких `print()` — диагностика только через `log_event`.
- [x] Имена и сигнатуры тулов не менялись: переменная только решает, какие источники смонтировать.

Новых полей и эндпоинтов нет. Восемь новых тестов в `packages/marketplace-connector/tests/test_source_selection.py`, все офлайн.
