### PR TITLE
fix: give test_ops_gates.py a __main__ runner so the documented gate can fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,12 @@
   пакета или в `[tool.uv.sources]` — и в обратную сторону тоже. Класс ошибки
   «зарегистрирован в _mount_all, забыт в pyproject» теперь закрыт гейтом, а не
   памятью ревьюера.
+- `scripts/test_ops_gates.py` получил `__main__`-раннер: задокументированная
+  команда `uv run python scripts/test_ops_gates.py` раньше выходила с кодом 0,
+  не выполнив ни одного из своих трёх тестов, — гейт, который не может упасть,
+  ничего не проверяет. Теперь команда прогоняет тесты через pytest и
+  пробрасывает настоящий код возврата; `uv run pytest scripts/test_ops_gates.py`
+  работает как прежде.
 
 ### Fixed
 
@@ -91,6 +97,11 @@
   dependencies or from `[tool.uv.sources]` — and in the reverse direction too.
   The "registered in _mount_all, forgotten in pyproject" bug class is now a
   gate, not a reviewer's memory.
+- `scripts/test_ops_gates.py` gained a `__main__` runner: the documented
+  invocation `uv run python scripts/test_ops_gates.py` used to exit 0 without
+  executing any of its three tests — a gate that cannot fail checks nothing.
+  It now runs them through pytest and propagates the real exit code;
+  `uv run pytest scripts/test_ops_gates.py` keeps working unchanged.
 
 ### Изменено
 

--- a/scripts/test_ops_gates.py
+++ b/scripts/test_ops_gates.py
@@ -31,3 +31,15 @@ def test_wire_snapshot_is_machine_readable() -> None:
     assert snapshot["tool_count"] == 2
     assert snapshot["tools"][0]["name"] == "a"
     json.dumps(snapshot, ensure_ascii=False)
+
+
+if __name__ == "__main__":
+    # The documented invocation is `uv run python scripts/test_ops_gates.py`
+    # (README, Development section). Without this runner that command exits 0
+    # having collected nothing — a vacuous gate, the same bug class as a check
+    # that cannot fail. pytest.main runs the three tests above and propagates
+    # the real exit code; `uv run pytest scripts/test_ops_gates.py` keeps
+    # working unchanged.
+    import pytest
+
+    raise SystemExit(pytest.main([__file__, "-q"]))


### PR DESCRIPTION
## What and why

README documents `uv run python scripts/test_ops_gates.py` as a development gate, but the script only defines three pytest-style test functions with **no runner**: the command exited 0 having executed zero assertions — a vacuous gate, the same bug class as a check that cannot fail. Found by the independent gate runner reviewing #49; the repo's own doctrine ("no check beats a lying one") applies to checks that silently check nothing.

## What changed

- `scripts/test_ops_gates.py`: `__main__` block runs `pytest.main([__file__, "-q"])` and propagates the real exit code via `SystemExit`. The pytest invocation (`uv run pytest scripts/test_ops_gates.py`) keeps working unchanged; `scripts/` stays out of `testpaths`, so the documented offline count (1315) is untouched.
- `CHANGELOG.md`: RU+EN entries under Unreleased → Исправлено/Fixed.

## Verification

- `uv run python scripts/test_ops_gates.py` → prints `3 passed in 0.19s`, exit **0** (was: no output, exit 0, zero tests)
- Mutation evidence that the gate can now fail: a non-matching `-k` selection exits **5** (`3 deselected`), proving non-zero propagation through `SystemExit`
- `uv run pytest -q scripts/test_ops_gates.py` → 3 passed (unchanged path)
- Gates: ruff check/format clean (277 files), `check_no_print` clean (83 files), `check_test_count` 1315 × 7, full offline suite **1314 passed, 1 pre-existing skip** in 67 s