### PR TITLE
fix(megamarket): profile address read becomes opt-in; disclose source, guard the raw id (S4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,57 @@
   mistaken for a login wall: on card payloads the title marker reads the
   document title (`page_title`), never the product name.
 
+### Изменено
+
+- Мегамаркет: чтение адресов профиля (`/profileService/address/list` —
+  аккаунтная зона, запрос с `credentials: include` в вашем залогиненном
+  Chrome) стало **opt-in**: `MEGAMARKET_USE_PROFILE_ADDRESS=1`. По умолчанию
+  выключено — адрес резолвится через публичный suggest-эндпоинт из
+  `MEGAMARKET_ADDRESS` (Москва), поиск работает как прежде, но без
+  персонализации профиля. Использование профиля раскрывается в
+  `_meta.warnings` (`address_source:profile` + `profile_address_read`);
+  сырой `addressId` не покидает процесс ни в успешных ответах, ни в ошибках
+  (отказ при нуле офферов называет `address_source`, а не идентификатор).
+  Раньше профильный эндпоинт читался безусловно при каждом старте.
+- Офлайн-счётчик тестов в документации обновлён до 1356: семь тестов
+  приватности Мегамаркета добавились к 1349.
+
+### Исправлено
+
+- `SECURITY.md` (RU+EN) и trust-boundary абзац README (обе половины) больше
+  не утверждают, что MPStats — единственная точка входа в аккаунтную зону:
+  список адресов профиля Мегамаркета документирован как вторая такая
+  поверхность, доступная только через явный opt-in. Раньше пользователь мог
+  включить Мегамаркет, полагая, что читаются лишь публичные каталожные
+  эндпоинты, а сервер читал локационные данные профиля и персонализировал
+  ими выдачу (находка S4 исследования `work/v2-research/security.md`).
+
+### Changed
+
+- Megamarket: reading the profile addresses (`/profileService/address/list` —
+  an account-gated zone, fetched with `credentials: include` inside your
+  logged-in Chrome) is now **opt-in**: `MEGAMARKET_USE_PROFILE_ADDRESS=1`.
+  The default is off — the address resolves through the public suggest
+  endpoint from `MEGAMARKET_ADDRESS` (Moscow), so search keeps working
+  without profile personalization. Profile use is disclosed in
+  `_meta.warnings` (`address_source:profile` + `profile_address_read`); the
+  raw `addressId` never leaves the process, in successful responses or in
+  errors alike (the zero-offers refusal names the `address_source`, not the
+  identifier). Previously the profile endpoint was read unconditionally at
+  startup.
+- Documented offline test count is 1356: seven Megamarket privacy tests on
+  top of 1349.
+
+### Fixed
+
+- `SECURITY.md` (RU+EN) and the README trust-boundary paragraph (both
+  halves) no longer claim MPStats is the only account-gated surface: the
+  Megamarket profile address list is now documented as a second such
+  surface, reachable only through explicit opt-in. Previously a user could
+  enable Megamarket believing only public catalog endpoints were read,
+  while the server read profile location data and personalized results with
+  it (finding S4 of `work/v2-research/security.md`).
+
 ## [2.1.0] — 2026-09-09
 
 ### Добавлено

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1349 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1356 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -522,7 +522,7 @@ compare_prices("кроссовки мужские")
 | `AVITO_`             | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID`                                                         |
 | `TAOBAO_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`,                                                                                               |
 | `ALI_`               | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                                |
-| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                                |
+| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `USE_PROFILE_ADDRESS` (0/1, по умолчанию 0 — приватный список адресов профиля не читается; 1 = адрес по умолчанию из залогиненного профиля, цены «как видит оператор») |
 | `LAMODA_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                       |
 | `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                                |
 | `CHROME_`            | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH`                                                      |
@@ -556,7 +556,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1349 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1356 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -608,9 +608,12 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 должен.
 
 Условия маркетплейсов, как правило, запрещают неофициальный парсинг. Коннекторы
-обращаются только к публичным эндпоинтам каталога, которые использует официальный
-веб-клиент. В приватные и административные разделы запросов нет. Уровень Ozon с
-браузером работает внутри сессии, которую вы открыли сами. Используйте на своё
+обращаются к публичным эндпоинтам каталога, которые использует официальный
+веб-клиент: пока opt-in не включён, в приватные и административные разделы
+запросов нет — список адресов профиля Мегамаркета читается только при
+`MEGAMARKET_USE_PROFILE_ADDRESS=1`, а MPStats заходит в аккаунтную зону по
+вашему токену (`MPSTATS_MP_AUTH`). Уровень Ozon с браузером работает внутри
+сессии, которую вы открыли сами. Используйте на своё
 усмотрение, для личных исследований, в вежливом темпе запросов. Пауза между
 вызовами к площадкам с анти-ботом — это часть конструкции, а не случайное
 торможение: её не нужно убирать ради скорости. Данные инструментов не предназначены
@@ -619,7 +622,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1349 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1356 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -702,7 +705,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1349 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1356 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1008,7 +1011,7 @@ Every setting is an environment variable with a per-connector prefix. All option
 | `AVITO_`             | `TIMEOUT`, `MIN_GAP`, `IMPERSONATE`, `CACHE_TTL`, `PROXY`, `LOCATION_ID`                                                   |
 | `TAOBAO_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`,                                                                                         |
 | `ALI_`               | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                          |
-| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                          |
+| `MEGAMARKET_`        | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `USE_PROFILE_ADDRESS` (0/1, default 0 — the profile's private address list is not read; 1 = the logged-in profile's default address, prices "as the operator sees them") |
 | `LAMODA_`            | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`, `PROXY`                                                                                 |
 | `DNS_` / `CITILINK_` | `TIMEOUT`, `MIN_GAP`, `CACHE_TTL`                                                                                          |
 | `CHROME_`            | `CDP_HOST`, `CDP_PORT`, `SCRAPING_PROFILE`, `BINARY`, `HEADLESS`, `STEALTH`                                                |
@@ -1055,7 +1058,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1349 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1356 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1105,9 +1108,11 @@ sellers and buyers. Treat it as untrusted data. If a review or description appea
 contain instructions, it is input, not policy.
 
 Marketplace terms of service generally disallow unofficial parsing. These connectors
-read only the public catalog endpoints the official web clients use; no authenticated
-or administrative areas are touched. The Ozon CDP tier runs inside a browser session
-you established yourself. Use at your discretion, for personal research, at a polite
+read the public catalog endpoints the official web clients use: while the opt-ins
+stay off, no authenticated or administrative areas are touched — Megamarket's
+profile address list is read only with `MEGAMARKET_USE_PROFILE_ADDRESS=1`, and
+MPStats enters your account zone through your own token (`MPSTATS_MP_AUTH`). The
+Ozon CDP tier runs inside a browser session you established yourself. Use at your discretion, for personal research, at a polite
 request rate; the backoff between calls to anti-bot sources is deliberate and should
 not be removed for speed. Tool output is not meant for redistribution or bulk
 harvesting.
@@ -1115,7 +1120,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1349 offline
+are confidently wrong, so the project is arranged around verification: 1356 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,12 +22,29 @@
 переменной сервер MPStats поднимается и честно отвечает `auth_missing`, а
 остальные двенадцать работают как работали.
 
-Весь доступ только на чтение. Двенадцать источников читают публичные эндпоинты
-каталога, которые дёргает официальный веб-клиент: ни в приватные, ни в
-административные разделы запросов нет. MPStats устроен иначе. Это приватный API
-браузерного плагина, доступный по вашей сессии, и потому единственное место, где
-проект обращается в аккаунтную зону. Что это означает для вашего аккаунта,
-описано в README.
+Весь доступ только на чтение. Двенадцать источников читают публичные
+эндпоинты каталога, которые дёргает официальный веб-клиент: пока opt-in не
+включён, ни в приватные, ни в административные разделы запросов нет. MPStats
+устроен иначе. Это приватный API браузерного плагина, доступный по вашей
+сессии, и потому единственное место, где проект обращается в аккаунтную зону
+без каких-либо условий. Что это означает для вашего аккаунта, описано в README.
+
+**Мегамаркет — второй вход в аккаунтную зону, только по явному opt-in.** По
+умолчанию его коннектор тоже читает лишь публичные эндпоинты: каталог,
+`url/parse` и публичный саггест адресов (`MEGAMARKET_ADDRESS`, Москва по
+умолчанию). Но он умеет прочитать и приватный `/profileService/address/list`
+из залогиненного Chrome-профиля оператора. Что при этом читается: список
+адресов профиля, флаг «адрес по умолчанию» и регион — этого достаточно, чтобы
+выбрать адрес, под который персонализуются цены и наличие. Делается это только
+при `MEGAMARKET_USE_PROFILE_ADDRESS=1`; по умолчанию флаг выключен, и
+включённый Мегамаркет публичных эндпоинтов не покидает. Смысл включения: цены
+и наличие совпадают с тем, что видит сам оператор, а не с городскими.
+Сырой `addressId` не покидает процесс. Раскрытие источника адреса в
+`_meta.warnings` (`address_source:profile|suggest|none`) имеет смысл только
+для состояний, меняющих цену: предупреждение о прочитанном профиле
+(и `_meta.healthy=false`) появляется, когда opt-in сработал, а
+`address_source:none` — когда адрес не разрешился вовсе. Обычный путь через
+саггест предупреждением не помечается и отвечает `_meta.healthy=true`.
 
 ## Единственная часть с реальным риском: уровень CDP
 
@@ -112,7 +129,9 @@ MPStats требует отдельной оговорки: там вы риск
 есть и официальный API: если аналитика нужна постоянно, он безопаснее.
 
 За своё использование, включая соблюдение местного законодательства и условий
-сервисов, отвечаете вы.
+сервисов, отвечаете вы. Чтение приватных эндпоинтов (MPStats по умолчанию,
+профильные адреса Мегамаркета при явном opt-in) — ваша ответственность в той
+же мере: это использование вашей сессии для чтения ваших же данных.
 
 ## Поддерживаемые версии
 
@@ -141,10 +160,26 @@ you supply yourself via env. It is never written into code or stored by the proj
 — there is still nothing to leak.
 
 All access is read-only. Twelve sources read the public catalog endpoints the official
-web clients use, touching no authenticated or administrative area. MPStats is the
-exception: a private browser-plugin API reached with your own session, and so the one
-place this project enters an account-gated zone. The README explains what that means
-for your account.
+web clients use, touching no authenticated or administrative area — unless you opt in.
+MPStats is the one place this project enters an account-gated zone by default: a
+private browser-plugin API reached with your own session. The README explains what
+that means for your account.
+
+**Megamarket is a second account-gated surface, and only on explicit opt-in.**
+By default its connector also stays on public endpoints: catalog reads,
+`url/parse`, and the public address suggest driven by `MEGAMARKET_ADDRESS`
+(Moscow by default). It *can* read the private `/profileService/address/list`
+endpoint from the operator's logged-in Chrome profile. What that touches: the
+profile's address list, the default-address flag, and the region — enough to
+pick the address prices and availability are personalized to. It happens only
+with `MEGAMARKET_USE_PROFILE_ADDRESS=1`; the flag defaults to off, so an
+enabled Megamarket never leaves public endpoints. The point of opting in:
+prices and availability match what the operator themself sees, not city-level
+ones. The raw `addressId` never leaves the process. Source disclosure in
+`_meta.warnings` (`address_source:profile|suggest|none`) is reserved for the
+states that change the prices: a profile-read notice (and `_meta.healthy=false`)
+when the opt-in fired, and `address_source:none` when nothing resolved. The
+ordinary suggest path adds no address warning and answers `_meta.healthy=true`.
 
 ## The one part that carries real risk: the CDP tier
 
@@ -228,7 +263,9 @@ moves you toward a block, and a blocked account is not refunded (clause 5.2). Th
 service also has an official API, which is the safer route for sustained use.
 
 You are responsible for your own use, including compliance with local law and the
-relevant terms.
+relevant terms. Reading private endpoints — MPStats by default, Megamarket's profile
+address list when explicitly opted in — is your responsibility in the same measure:
+it is your session being used to read your own data.
 
 ## Supported versions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1349 offline tests, no network required. Three flavours:
+1356 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/dsh/skills/megamarket-connector/SKILL.md
+++ b/dsh/skills/megamarket-connector/SKILL.md
@@ -31,6 +31,32 @@ code-7 refusal is inconclusive (transport), never drift. It is CLI-only —
   anonymously, and only a challenge-passed session confirms the in-browser shape.
 - A missing price is `null`, never `0`: `price_rub: null` means Megamarket had
   no usable price — treat it as no data, never as a free item.
+- Prices are address-dependent. `_meta.warnings` carries the address source
+  only when it changes what the prices mean: `address_source:profile` (the
+  operator's personal default address — personalized prices) or
+  `address_source:none` (no delivery address resolved, so no offers are
+  deliverable — expect the empty-items symptom). Both mark the response
+  `_meta.healthy=false`. The default public city-level source
+  (`address_source:suggest` from `MEGAMARKET_ADDRESS`) is the normal healthy
+  case: no address warning.
+
+## Privacy: the profile address is opt-in
+
+`MEGAMARKET_USE_PROFILE_ADDRESS` (default `0`) decides whether the connector may
+read the private, account-gated `/profileService/address/list` endpoint from the
+operator's logged-in Chrome profile, to use the profile's default delivery
+address. Off — the default — it is never called: the address comes from the
+public suggest endpoint for `MEGAMARKET_ADDRESS` (Москва by default), and prices
+are city-level, not personalized. On, the profile's address list, its
+default flag and the region are read once per process, prices and availability
+match exactly what the operator sees on the site, and the search response
+carries `address_source:profile` plus a `profile_address_read` warning in
+`_meta.warnings` so the reader knows before quoting a price. The raw addressId
+never leaves the process.
+
+Opt in when the operator asks for Megamarket prices "as I see them"; leave it
+off for neutral, city-level price research.
+
 ## DSH activation
 
 In DeepSeek Harness, the default profile exposes only `compare_prices` and

--- a/packages/megamarket-connector/src/megamarket_connector/server.py
+++ b/packages/megamarket-connector/src/megamarket_connector/server.py
@@ -84,6 +84,16 @@ _PAGE_SIZE = 44
 _ADDRESS = _settings.address
 _address_id: str | None = None
 _address_resolved = False
+# Which of the three sources produced the address: "profile" | "suggest" |
+# "none". _address_warnings() turns it into _meta warnings only for the states
+# that change what the prices mean (the opted-in profile read, or nothing
+# resolved); the default suggest path stays warning-free and healthy. The raw
+# addressId itself never leaves the process.
+_address_source: str | None = None
+# Bound at import from settings and consulted at call time through this module
+# global — the same seam _min_gap uses — so a test can flip the privacy posture
+# without rebuilding the settings object.
+_USE_PROFILE_ADDRESS = _settings.use_profile_address
 
 mcp = FastMCP(
     name="megamarket-connector",
@@ -238,33 +248,50 @@ async def _resolve_address_id(ctx: Context | None) -> str | None:
     Two sources, in order of trust:
 
     1. the logged-in profile's default address — exactly what the operator sees
-       on the site, so prices and availability match their own experience;
+       on the site, so prices and availability match their own experience. This
+       reads a PRIVATE, account-gated endpoint (/profileService/address/list),
+       so it happens only when the operator explicitly opted in via
+       MEGAMARKET_USE_PROFILE_ADDRESS (default off). Off, the connector never
+       touches the profile;
     2. the configured city (MEGAMARKET_ADDRESS, Moscow by default) through the
        public suggest endpoint, which works without a session.
+
+    The winning source is recorded in the module-level ``_address_source``
+    ("profile" | "suggest" | "none") and logged through ``megamarket.address``.
+    _address_warnings() discloses it in _meta warnings only for the states that
+    deserve attention (the opted-in profile read, or nothing resolved). The raw
+    addressId itself never leaves the process.
 
     A failure here is not fatal: the caller still gets a search, and the empty
     result is reported honestly rather than as a mysterious zero.
     """
-    global _address_id, _address_resolved
+    global _address_id, _address_resolved, _address_source
     if _address_resolved:
         return _address_id
 
     _address_resolved = True
-    try:
-        profile = await _post("/profileService/address/list", {}, ctx, "address list")
-        addresses = profile.get("profileAddresses")
-        if isinstance(addresses, list) and addresses:
-            preferred = next(
-                (a for a in addresses if isinstance(a, dict) and a.get("isDefault") is True),
-                next((a for a in addresses if isinstance(a, dict)), None),
-            )
-            if preferred and preferred.get("addressId"):
-                _address_id = str(preferred["addressId"])
-                log_event("megamarket.address", source="profile", region=str(preferred.get("region") or "")[:40])
-                return _address_id
-    except Exception as exc:
-        # Not logged in, or the profile endpoint refused. Fall through.
-        log_event("megamarket.address_profile_failed", error=_redact(str(exc))[:120])
+    if _USE_PROFILE_ADDRESS:
+        try:
+            profile = await _post("/profileService/address/list", {}, ctx, "address list")
+            addresses = profile.get("profileAddresses")
+            if isinstance(addresses, list) and addresses:
+                preferred = next(
+                    (a for a in addresses if isinstance(a, dict) and a.get("isDefault") is True),
+                    next((a for a in addresses if isinstance(a, dict)), None),
+                )
+                if preferred and preferred.get("addressId"):
+                    _address_id = str(preferred["addressId"])
+                    _address_source = "profile"
+                    log_event("megamarket.address", source="profile", region=str(preferred.get("region") or "")[:40])
+                    return _address_id
+        except Exception as exc:
+            # Not logged in, or the profile endpoint refused. Fall through.
+            log_event("megamarket.address_profile_failed", error=_redact(str(exc))[:120])
+    else:
+        log_event(
+            "megamarket.address_profile_skipped",
+            reason="MEGAMARKET_USE_PROFILE_ADDRESS is off; the profile endpoint is not read",
+        )
 
     try:
         suggested = await _post(
@@ -278,17 +305,46 @@ async def _resolve_address_id(ctx: Context | None) -> str | None:
             candidate = items[0].get("addressId")
             if candidate:
                 _address_id = str(candidate)
+                _address_source = "suggest"
                 log_event("megamarket.address", source="suggest", query=_ADDRESS[:40])
                 return _address_id
     except Exception as exc:
         log_event("megamarket.address_suggest_failed", error=_redact(str(exc))[:120])
 
+    _address_source = "none"
     log_event("megamarket.address_unresolved", configured=_ADDRESS[:40])
     return None
 
 
 # url/parse returns filter bounds as words; the search endpoint wants the codes.
 _FILTER_TYPE_CODES = {"EXACT_VALUE": 0, "LEFT_BOUND": 1, "RIGHT_BOUND": 2}
+
+
+def _address_warnings() -> list[str]:
+    """Disclose the address provenance only when it changes what the prices mean.
+
+    A warning flips ``_meta.healthy`` to false (attach_meta: an empty warnings
+    list is the healthy case), so this list is reserved for the two states an
+    agent should act on before quoting a price: the opted-in profile read —
+    a private account endpoint was used and the prices are personalized — and
+    ``none``, where offers are priced for no address at all. The default
+    suggest path is the normal healthy case: no warning, ``_meta.healthy``
+    stays true, and the source remains observable through the
+    ``megamarket.address`` log event and the documented behavior.
+    """
+    source = _address_source
+    if source == "profile":
+        return [
+            "address_source:profile — prices and availability are personalized to the "
+            "operator's default profile address",
+            "profile_address_read: opted in via MEGAMARKET_USE_PROFILE_ADDRESS; the private "
+            "account endpoint /profileService/address/list was read to resolve the default address",
+        ]
+    if source == "none":
+        return [
+            "address_source:none — no delivery address could be resolved, so offers are priced for no address at all"
+        ]
+    return []
 
 
 # Resolved search params are cached per query for the process lifetime. Each
@@ -410,9 +466,12 @@ def _search_body(
     paging is ``limit``/``offset`` rather than a page number, and
     ``requestVersion`` selects the response shape.
 
-    ``addressId`` stays None: this connector has no address concept, so
-    Megamarket answers for a default region. The prices are therefore
-    default-region prices, which is worth knowing before quoting them.
+    ``addressId`` carries the resolved delivery address when one was resolved
+    (profile default when opted in, otherwise the public suggest result for
+    MEGAMARKET_ADDRESS). Without any address Megamarket answers listingSize>0
+    with an empty items array — see _resolve_address_id — so _address_warnings
+    flags in the response's _meta warnings the states that change what the
+    prices mean (the profile read, or nothing resolved at all).
     """
     page = max(1, int(page))
     body: dict[str, Any] = {
@@ -522,10 +581,19 @@ async def megamarket_search(
 ) -> MegamarketSearchResponse:
     """Search the Megamarket catalog via the mobile API, inside the operator's Chrome.
 
+    Prices and availability depend on the delivery address: by default a public
+    city-level one (MEGAMARKET_ADDRESS); only with MEGAMARKET_USE_PROFILE_ADDRESS=1
+    does the logged-in profile's default address win — that reads a private
+    account endpoint, and the response says so in _meta.warnings
+    ("address_source:profile" plus a "profile_address_read" notice).
+    _meta.healthy is false only for that profile read and for
+    "address_source:none" (no delivery address resolved); the default suggest
+    path answers healthy with no address warning.
+
     ## Return Format
 
     MegamarketSearchResponse: {status, query, tier_used, count, total_count,
-    items[], meta}. price_rub is None when absent — never 0.
+    items[], _meta}. price_rub is None when absent — never 0.
 
     ## Error Format
 
@@ -545,7 +613,7 @@ async def megamarket_search(
         items_raw, total, container_found = _parse_items(payload)
         listing_size = R.coerce_int(payload.get("listingSize"))
         items = [MegamarketSearchItemOut(**it) for it in items_raw]
-        warnings: list[str] = []
+        warnings: list[str] = _address_warnings()
         # A 200 that parses to nothing is the dangerous case: without these two
         # guards the tool reports success with zero offers, and compare_prices
         # then calls the comparison complete while Megamarket has silently
@@ -569,15 +637,20 @@ async def megamarket_search(
             # exist and no *offer* came back. That happens when the request
             # carries no delivery address: every offer has its own
             # deliveryPossibilities, and none can be delivered to nowhere.
+            # The message names the address *source*, never the raw addressId —
+            # the same privacy boundary the success-path serialization keeps.
             raise_tool_error(
                 TransportDownError(
                     f"Megamarket matched {listing_size} products but returned no offers"
                     + (f" (collection {resolved.get('collectionId')})" if resolved.get("collectionId") else "")
                     + (
                         " and no delivery address could be resolved. Set MEGAMARKET_ADDRESS to a city, "
-                        "or log the scraping-profile Chrome into Megamarket so its default address is used."
+                        "or set MEGAMARKET_USE_PROFILE_ADDRESS=1 so the logged-in profile's default "
+                        "address is used."
                         if not address_id
-                        else f" for address {address_id}. The address may not be deliverable for this query; "
+                        else " for the resolved delivery address (address_source:"
+                        + (_address_source or "unknown")
+                        + "). The address may not be deliverable for this query; "
                         "try another city via MEGAMARKET_ADDRESS."
                     )
                 )
@@ -626,7 +699,7 @@ async def megamarket_card(
     ## Return Format
 
     MegamarketCardResponse: {status, item_id, title, price_rub, old_price_rub,
-    is_available, rating, rating_count, url, tier_used, meta}.
+    is_available, rating, rating_count, url, tier_used, _meta}.
 
     ## Error Format
 

--- a/packages/megamarket-connector/src/megamarket_connector/settings.py
+++ b/packages/megamarket-connector/src/megamarket_connector/settings.py
@@ -28,7 +28,18 @@ class MegamarketSettings(BaseSettings):
         description=(
             "Delivery address used to resolve an addressId. Megamarket answers a search without one "
             "with listingSize>0 and an empty items array: it finds the products but no deliverable "
-            "offer. A logged-in profile's default address wins over this value."
+            "offer. A logged-in profile's default address wins over this value only when "
+            "use_profile_address is enabled; by default this city is what search uses."
+        ),
+    )
+    use_profile_address: bool = Field(
+        default=False,
+        description=(
+            "Opt-in: resolve the delivery address from the logged-in profile's default address by "
+            "reading the private account endpoint /profileService/address/list in the operator's "
+            "Chrome. On = prices and availability exactly as the operator's own profile sees them, "
+            "but a private account endpoint is read. Off (default) = only the public city-level "
+            "suggest endpoint is used, driven by MEGAMARKET_ADDRESS."
         ),
     )
 

--- a/packages/megamarket-connector/tests/test_server.py
+++ b/packages/megamarket-connector/tests/test_server.py
@@ -7,6 +7,8 @@ the code-7 ServicePipe refusal that must never be read as data.
 
 from __future__ import annotations
 
+import json
+
 import pytest
 from fastmcp.exceptions import ToolError
 from megamarket_connector import server
@@ -60,6 +62,11 @@ def _no_cache(monkeypatch):
     # has to be forgotten between tests or they become order-dependent.
     monkeypatch.setattr(server, "_address_id", None)
     monkeypatch.setattr(server, "_address_resolved", False)
+    monkeypatch.setattr(server, "_address_source", None)
+    # The privacy posture is pinned to the shipped default: a test asserting
+    # "profile is not read" must not flip just because the machine running the
+    # suite happens to export MEGAMARKET_USE_PROFILE_ADDRESS=1.
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", False)
     monkeypatch.setattr(server, "_search_params_cache", {})
     # The pacer is real and its gap is seconds; an offline suite must not sleep it.
     monkeypatch.setattr(server, "_min_gap", 0.0)
@@ -400,6 +407,11 @@ def test_stock_is_none_when_the_payload_omits_it():
 # address there is no deliverable offer and the array comes back empty while
 # listingSize still counts what the catalog matched. The maintained
 # xob0t/mmparser resolves an address three ways before it ever searches.
+#
+# Privacy (S4, work/v2-research/security.md): source 1, the profile default
+# address, lives behind a private account-gated endpoint. Reading it is
+# opt-in via MEGAMARKET_USE_PROFILE_ADDRESS (default off); off, only the
+# public suggest endpoint is consulted and search stays city-wide.
 
 PROFILE_ADDRESSES = {
     "profileAddresses": [
@@ -425,15 +437,62 @@ def _patch_routes(monkeypatch, routes: dict[str, object]):
     monkeypatch.setattr(server, "_post", fake_post)
 
 
-async def test_the_profile_default_address_wins(monkeypatch):
-    """The operator's own default address makes prices match what they see."""
+async def test_the_profile_default_address_wins_when_opted_in(monkeypatch):
+    """The operator's own default address makes prices match what they see.
+
+    The profile lookup is opt-in now, so this behaviour — previously the
+    unconditional default — must be enabled explicitly.
+    """
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", True)
     _patch_routes(monkeypatch, {"/profileService/address/list": PROFILE_ADDRESSES})
 
     assert await server._resolve_address_id(None) == "a-222"
+    assert server._address_source == "profile"
+
+
+async def test_the_profile_endpoint_is_never_read_by_default(monkeypatch):
+    """The privacy boundary itself: opt-in off means /profileService/address/list
+    is not called even when a logged-in profile would answer it successfully."""
+    calls: list[str] = []
+
+    async def tracking_post(api_path, body, ctx, what):
+        calls.append(api_path)
+        if "profileService" in api_path:
+            return PROFILE_ADDRESSES
+        if "addressSuggest" in api_path:
+            return SUGGESTED_ADDRESSES
+        raise AssertionError(f"unexpected endpoint {api_path}")
+
+    monkeypatch.setattr(server, "_post", tracking_post)
+
+    assert await server._resolve_address_id(None) == "s-999"
+    assert server._address_source == "suggest"
+    assert not any("profileService" in c for c in calls), (
+        "the private profile endpoint must not be read unless MEGAMARKET_USE_PROFILE_ADDRESS is set"
+    )
 
 
 async def test_the_suggest_endpoint_is_the_fallback(monkeypatch):
-    """Without a session the public suggest endpoint still yields an address."""
+    """Default mode: the public suggest endpoint resolves the configured city.
+
+    When the profile branch is skipped (or opted in but refused), suggest still
+    yields an address without any session.
+    """
+    _patch_routes(
+        monkeypatch,
+        {
+            "/profileService/address/list": PROFILE_ADDRESSES,
+            "/addressSuggestService/address/suggest": SUGGESTED_ADDRESSES,
+        },
+    )
+
+    assert await server._resolve_address_id(None) == "s-999"
+    assert server._address_source == "suggest"
+
+
+async def test_opted_in_but_logged_out_falls_back_to_suggest(monkeypatch):
+    """Opt-in requests the profile address; it does not require it to exist."""
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", True)
     _patch_routes(
         monkeypatch,
         {
@@ -443,6 +502,7 @@ async def test_the_suggest_endpoint_is_the_fallback(monkeypatch):
     )
 
     assert await server._resolve_address_id(None) == "s-999"
+    assert server._address_source == "suggest"
 
 
 async def test_the_address_is_resolved_once_per_process(monkeypatch):
@@ -453,6 +513,7 @@ async def test_the_address_is_resolved_once_per_process(monkeypatch):
         return PROFILE_ADDRESSES
 
     monkeypatch.setattr(server, "_post", counting_post)
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", True)
 
     first = await server._resolve_address_id(None)
     second = await server._resolve_address_id(None)
@@ -471,6 +532,7 @@ async def test_an_unresolvable_address_is_not_fatal(monkeypatch):
     )
 
     assert await server._resolve_address_id(None) is None
+    assert server._address_source == "none"
 
 
 def test_the_address_reaches_the_search_body():
@@ -506,7 +568,7 @@ async def test_a_genuine_zero_result_stays_a_success(monkeypatch):
     _patch_routes(
         monkeypatch,
         {
-            "/profileService/address/list": PROFILE_ADDRESSES,
+            "/addressSuggestService/address/suggest": SUGGESTED_ADDRESSES,
             "/catalogService/catalog/search": {"success": True, "listingSize": 0, "items": []},
         },
     )
@@ -515,6 +577,141 @@ async def test_a_genuine_zero_result_stays_a_success(monkeypatch):
 
     assert result.count == 0
     assert any("empty_result" in w for w in result.meta.warnings)
+
+
+# --------------------------------------------- address-source disclosure ----
+#
+# A warning flips _meta.healthy to false (attach_meta), so the address source
+# is disclosed in _meta warnings only when it changes what the prices mean:
+# profile (a private endpoint was read — personalized prices) and none
+# (nothing deliverable resolved). The default suggest path is the normal
+# healthy case — no address warning, _meta.healthy true — with the source
+# still visible in the megamarket.address log event. The raw addressId itself
+# never leaves the process, on the success path or the error path.
+
+ONE_ITEM_SEARCH = {
+    "success": True,
+    "listingSize": 1,
+    "items": [
+        {
+            "goods": {"goodsId": "1_2", "title": "Ноутбук", "webUrl": "u"},
+            "favoriteOffer": {"finalPrice": 50000},
+            "isAvailable": True,
+        }
+    ],
+}
+
+
+async def test_the_default_suggest_path_is_healthy_and_warning_free(monkeypatch):
+    """A clean default search must self-report _meta.healthy=true.
+
+    _address_warnings used to emit an address_source:suggest warning on every
+    resolution path, so every successful megamarket_search answered
+    healthy=false — contradicting the envelope semantics in mcp-core
+    ("healthy=False ... something about it was off"). The default city-level
+    address is the normal case, not a degraded one.
+    """
+    _patch_routes(
+        monkeypatch,
+        {
+            "/addressSuggestService/address/suggest": SUGGESTED_ADDRESSES,
+            "/urlService/url/parse": URL_PARSE_SEARCH,
+            "/catalogService/catalog/search": ONE_ITEM_SEARCH,
+        },
+    )
+
+    result = await server.megamarket_search("ноутбук")
+
+    assert result.count == 1
+    assert result.meta.healthy is True, result.meta.warnings
+    assert not any(w.startswith("address_source:") for w in result.meta.warnings), result.meta.warnings
+    assert not any("profile_address_read" in w for w in result.meta.warnings), (
+        "default mode never read the profile, so it must not claim it did"
+    )
+
+
+async def test_search_discloses_the_profile_read_when_opted_in(monkeypatch):
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", True)
+    _patch_routes(
+        monkeypatch,
+        {
+            "/profileService/address/list": PROFILE_ADDRESSES,
+            "/urlService/url/parse": URL_PARSE_SEARCH,
+            "/catalogService/catalog/search": ONE_ITEM_SEARCH,
+        },
+    )
+
+    result = await server.megamarket_search("ноутбук")
+
+    warnings = result.meta.warnings
+    assert result.meta.healthy is False, "the profile read is the one state that must mark the response"
+    assert any(w.startswith("address_source:profile") for w in warnings), warnings
+    assert any(w.startswith("profile_address_read") for w in warnings), warnings
+    # Only the source is disclosed; the raw addressId never leaves the process.
+    dumped = json.dumps(result.model_dump(by_alias=True), ensure_ascii=False)
+    assert "a-222" not in dumped
+
+
+async def test_search_discloses_when_no_address_resolved(monkeypatch):
+    _patch_routes(
+        monkeypatch,
+        {
+            "/addressSuggestService/address/suggest": ToolError("nope"),
+            "/urlService/url/parse": URL_PARSE_SEARCH,
+            "/catalogService/catalog/search": ONE_ITEM_SEARCH,
+        },
+    )
+
+    result = await server.megamarket_search("ноутбук")
+
+    assert result.meta.healthy is False
+    assert any(w.startswith("address_source:none") for w in result.meta.warnings), result.meta.warnings
+
+
+async def test_the_zero_offers_error_hides_the_raw_address_id(monkeypatch):
+    """The error path keeps the privacy promise the success path makes.
+
+    The refusal used to embed the resolved addressId verbatim ("...no offers
+    for address a-222"), crossing the process boundary in the one place the
+    guard never looked — only the success-path serialization was tested. The
+    message must say how the address was resolved (source), never what it
+    resolved to (the id).
+    """
+    _patch_routes(
+        monkeypatch,
+        {
+            "/addressSuggestService/address/suggest": SUGGESTED_ADDRESSES,
+            "/urlService/url/parse": URL_PARSE_SEARCH,
+            "/catalogService/catalog/search": {"success": True, "listingSize": 44, "items": []},
+        },
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.megamarket_search("ноутбук")
+
+    message = str(excinfo.value)
+    assert "44" in message
+    assert "s-999" not in message, "the raw addressId must not cross into the agent-facing error"
+    assert "address_source:suggest" in message, "the source stands in for the id"
+
+
+async def test_the_disclosure_survives_the_process_address_cache(monkeypatch):
+    """The source is remembered with the address, not re-derived per search."""
+    monkeypatch.setattr(server, "_USE_PROFILE_ADDRESS", True)
+    _patch_routes(
+        monkeypatch,
+        {
+            "/profileService/address/list": PROFILE_ADDRESSES,
+            "/urlService/url/parse": URL_PARSE_SEARCH,
+            "/catalogService/catalog/search": ONE_ITEM_SEARCH,
+        },
+    )
+
+    first = await server.megamarket_search("ноутбук")
+    second = await server.megamarket_search("ноутбук")
+
+    assert any(w.startswith("address_source:profile") for w in second.meta.warnings)
+    assert second.count == first.count
 
 
 # ---------------------------------------------- url/parse before the search ----
@@ -622,6 +819,8 @@ async def test_search_calls_url_parse_before_searching(monkeypatch):
         calls.append(api_path)
         if "url/parse" in api_path:
             return URL_PARSE_SEARCH
+        if "addressSuggest" in api_path:
+            return SUGGESTED_ADDRESSES
         if "address" in api_path:
             return PROFILE_ADDRESSES
         return {

--- a/skills/megamarket-connector/SKILL.md
+++ b/skills/megamarket-connector/SKILL.md
@@ -31,6 +31,32 @@ code-7 refusal is inconclusive (transport), never drift. It is CLI-only —
   anonymously, and only a challenge-passed session confirms the in-browser shape.
 - A missing price is `null`, never `0`: `price_rub: null` means Megamarket had
   no usable price — treat it as no data, never as a free item.
+- Prices are address-dependent. `_meta.warnings` carries the address source
+  only when it changes what the prices mean: `address_source:profile` (the
+  operator's personal default address — personalized prices) or
+  `address_source:none` (no delivery address resolved, so no offers are
+  deliverable — expect the empty-items symptom). Both mark the response
+  `_meta.healthy=false`. The default public city-level source
+  (`address_source:suggest` from `MEGAMARKET_ADDRESS`) is the normal healthy
+  case: no address warning.
+
+## Privacy: the profile address is opt-in
+
+`MEGAMARKET_USE_PROFILE_ADDRESS` (default `0`) decides whether the connector may
+read the private, account-gated `/profileService/address/list` endpoint from the
+operator's logged-in Chrome profile, to use the profile's default delivery
+address. Off — the default — it is never called: the address comes from the
+public suggest endpoint for `MEGAMARKET_ADDRESS` (Москва by default), and prices
+are city-level, not personalized. On, the profile's address list, its
+default flag and the region are read once per process, prices and availability
+match exactly what the operator sees on the site, and the search response
+carries `address_source:profile` plus a `profile_address_read` warning in
+`_meta.warnings` so the reader knows before quoting a price. The raw addressId
+never leaves the process.
+
+Opt in when the operator asks for Megamarket prices "as I see them"; leave it
+off for neutral, city-level price research.
+
 ## DSH activation
 
 In DeepSeek Harness, the default profile exposes only `compare_prices` and


### PR DESCRIPTION
## Что и зачем

Находка **S4** исследования `work/v2-research/security.md`, подтверждённая на текущем main: `_resolve_address_id` безусловно дёргал аккаунтный эндпоинт `/profileService/address/list` (с `credentials: include` в залогиненном Chrome оператора), тогда как `SECURITY.md` утверждал, что MPStats — единственная точка входа в аккаунтную зону. Пользователь получал персонализированную профиль-адресом выдачу, не будучи об этом уведомлённым.

## Что изменено

- **`MEGAMARKET_USE_PROFILE_ADDRESS=1`** — чтение профиля теперь явный opt-in, **по умолчанию выключено**. Публичный suggest-фолбэк (`MEGAMARKET_ADDRESS`, Москва) сохраняет работу поиска без персонализации.
- **Раскрытие `address_source`** (profile|suggest|none) без изменения схемы: предупреждения в `_meta` только для состояний, меняющих смысл цен — opt-in профиль (privacy-уведомление) и нерезолвленный адрес. Чистый дефолтный поиск сохраняет `_meta.healthy=true` (attach_meta считает `healthy = not warnings`; всегда-включённое раскрытие перевернуло бы каждый успешный ответ в «подозрительный» — поймано на ревью и исправлено).
- **Сырой `addressId` не покидает процесс** — включая error-путь: отказ при нуле офферов раньше печатал `"no offers for address a-222"` (утечка идентификатора, поймана ревью), теперь называет `address_source`.
- **`SECURITY.md` RU+EN исправлен**: MPStats остаётся безусловной аккаунтной поверхностью, список адресов Мегамаркета документирован как вторая, opt-in. Trust-boundary абзацы README (обе половины) приведены в соответствие.
- **SKILL.md + dsh-копия** (байт-идентичны, parity-тест зелёный) документируют env-переменную, дефолт и `_meta.warnings` (сериализованный ключ, а не `meta.warnings`); env-таблицы README RU+EN дополнены.

## Проверки

- **+7 тестов** → документированный счётчик согласован в 7 местах: профиль не читается по умолчанию (даже когда чтение удалось бы), opt-in возвращает profile-first резолв, раскрытие по всем путям, сырой id отсутствует в сериализованных ответах И в поднятых ошибках, healthy-семантика, once-per-process сохранён
- Офлайн-набор полностью зелёный + 1 pre-existing skip; ruff/format; mypy host+win32; no-print; versions 2.1.0×84; skills-parity + dsh-bundle 105 passed
- Независимое ревью (код/безопасность + документация) поймало две major-находки (утечка id в ошибке, инверсия `_meta.healthy`) — обе исправлены и перепроверены финальной верификацией: merge_ready

## Остаток (вне scope)

Вторая стадия S4 из исследования: кэш адреса остаётся per-process, а не per-profile.

**Порядок мержа**: после #51 (taobao) — эта ветка будет перебазирована (пересчёт тестов, CHANGELOG-блоки соседствуют).
