### PR TITLE
fix: harden Lamoda challenges and CDP tab ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@
 Русский текст первый, английский — ниже в каждом разделе. Аудитория проекта
 русскоязычная, и переводить для неё собственные заметки о релизе странно.
 
+## [Unreleased]
+
+### Исправлено
+
+- Lamoda больше не принимает слова `captcha` и «не робот» внутри скриптов,
+  скрытых виджетов или названий товаров за блокировку; challenge определяется
+  только по видимому тексту пустой выдачи.
+- Параллельные CDP-коннекторы теперь сопоставляют созданную вкладку с её
+  `targetId`, чтобы один вызов не получил вкладку другого.
+
+### Fixed
+
+- Lamoda no longer treats `captcha` or bot wording in scripts, hidden widgets,
+  or product names as a block; a challenge is classified only from visible text
+  on an empty result.
+- Concurrent CDP connectors now correlate a created page with its `targetId`,
+  preventing one call from claiming another call's tab.
+
 ## [2.2.0] — 2026-09-11
 
 ### Добавлено

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1360 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1368 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -562,7 +562,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1360 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1368 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -628,7 +628,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1360 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1368 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -711,7 +711,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1360 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1368 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1069,7 +1069,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1360 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1368 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1131,7 +1131,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1360 offline
+are confidently wrong, so the project is arranged around verification: 1368 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1360 offline tests, no network required. Three flavours:
+1368 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -188,15 +188,50 @@ _SEARCH_EXTRACT_TEMPLATE = """
         });
         if (out.length >= 48) break;
     }
-    const bodyText = (document.body && document.body.textContent || '').toLowerCase();
-    const blocked = /проверку|не робот|бота|captcha|are you human|access denied/.test(bodyText);
-    return JSON.stringify({items: out, title: blocked ? '__BLOCKED__' : (document.title || '')});
+    // Challenge words also occur in scripts, hidden anti-bot widgets and even
+    // product copy. Keep this as raw transport data; the Python classifier
+    // decides whether an empty page is a challenge. In particular, never let
+    // a hidden/script marker override a healthy product grid.
+    const bodyCopy = document.body ? document.body.cloneNode(true) : null;
+    if (bodyCopy) {
+        for (const node of bodyCopy.querySelectorAll('script, style, noscript, [hidden]')) node.remove();
+        for (const node of bodyCopy.querySelectorAll('[style]')) {
+            const style = node.getAttribute('style') || '';
+            if (/display\\s*:\\s*none|visibility\\s*:\\s*hidden/i.test(style)) node.remove();
+        }
+    }
+    const bodyText = (bodyCopy && bodyCopy.textContent || '').replace(/\\s+/g, ' ').trim();
+    return JSON.stringify({items: out, title: document.title || '', body_snippet: bodyText.slice(0, 2000)});
 }
 """
 
 # Spliced rather than duplicated: one fix to tile resolution or price selection
 # lands on every CDP source at once.
 _SEARCH_EXTRACT_JS = _SEARCH_EXTRACT_TEMPLATE.replace("//__SHARED_HELPERS__", JS_HELPERS)
+
+
+# The extractor only transports a bounded visible-text sample. Keep challenge
+# wording in one Python classifier so product copy and hidden widgets cannot
+# change the verdict while a healthy grid is present. ``бота`` on its own is
+# deliberately absent: it occurs in ordinary product copy and is not evidence
+# of a challenge.
+_CHALLENGE_TEXT_RE = re.compile(r"провер|не\s+робот|captcha|are\s+you\s+human|access\s+denied", re.IGNORECASE)
+
+
+def _anti_bot_challenge(data: dict[str, Any]) -> bool:
+    """Return whether an empty rendered page is an anti-bot challenge.
+
+    ``__BLOCKED__`` is retained only for the legacy cached payload shape and
+    only when it carried no items. Current extractor payloads carry a raw
+    ``body_snippet`` and the wording is classified here in Python.
+    """
+    items = data.get("items")
+    if isinstance(items, list) and items:
+        return False
+    if str(data.get("title") or "") == "__BLOCKED__":
+        return True
+    snippet = data.get("body_snippet")
+    return isinstance(snippet, str) and bool(_CHALLENGE_TEXT_RE.search(snippet))
 
 
 def _search_item_from_tile(tile: dict[str, Any]) -> LamodaSearchItemOut:
@@ -348,7 +383,7 @@ async def lamoda_search(
             payload = await _cdp_render_search(query.strip(), ctx)
         except NavBlocked as exc:
             raise_tool_error(TransportDownError(f"Lamoda navigation blocked (HTTP {exc.status})."))
-        if payload.get("title") == "__BLOCKED__":
+        if _anti_bot_challenge(payload):
             raise_tool_error(
                 TransportDownError("Lamoda search is behind an anti-bot challenge in the connected Chrome.")
             )
@@ -495,44 +530,43 @@ async def _lamoda_selfcheck_impl(ctx: Context | None) -> LamodaSelfcheckResponse
     try:
         async with asyncio.timeout(90):
             payload = await _cdp_render_search("кроссовки", ctx)
-        if payload.get("title") == "__BLOCKED__":
+        if _anti_bot_challenge(payload):
             checks["search"] = R.selfcheck_entry(
                 "inconclusive", baseline=baseline, reason="blocked", notes=["anti-bot challenge in rendered page"]
             )
-            items_raw = []
         else:
             items_raw = [*payload.get("items", [])] if isinstance(payload.get("items"), list) else []
-        if items_raw:
-            # Tiles extract — now ask the second question: did the SHAPE move?
-            # The registry was measured on the captured page (2026-08-07); a
-            # live payload that loses a parser-critical key family is
-            # structural drift even while tiles still come back.
-            live_signature = R.shape_signature(payload)
-            drift = R.diff_keys(SEARCH_SHAPE_REFERENCE, live_signature)
-            missing = missing_required_families(live_signature)
-            if missing:
-                checks["search"] = R.selfcheck_entry(
-                    "drift",
-                    baseline=baseline,
-                    reason="shape_drift",
-                    notes=[
-                        f"{len(items_raw)} tiles extracted",
-                        "required key families missing: " + "; ".join(", ".join(family) for family in missing),
-                    ],
-                    shape_missing=drift["missing"],
-                    shape_added=drift["added"],
-                )
+            if items_raw:
+                # Tiles extract — now ask the second question: did the SHAPE move?
+                # The registry was measured on the captured page (2026-08-07); a
+                # live payload that loses a parser-critical key family is
+                # structural drift even while tiles still come back.
+                live_signature = R.shape_signature(payload)
+                drift = R.diff_keys(SEARCH_SHAPE_REFERENCE, live_signature)
+                missing = missing_required_families(live_signature)
+                if missing:
+                    checks["search"] = R.selfcheck_entry(
+                        "drift",
+                        baseline=baseline,
+                        reason="shape_drift",
+                        notes=[
+                            f"{len(items_raw)} tiles extracted",
+                            "required key families missing: " + "; ".join(", ".join(family) for family in missing),
+                        ],
+                        shape_missing=drift["missing"],
+                        shape_added=drift["added"],
+                    )
+                else:
+                    notes = [f"{len(items_raw)} tiles extracted", "shape matches the captured reference"]
+                    if drift["added"]:
+                        notes.append(f"{len(drift['added'])} new paths vs baseline (informational)")
+                    checks["search"] = R.selfcheck_entry(
+                        "healthy", baseline=baseline, notes=notes, shape_added=drift["added"]
+                    )
             else:
-                notes = [f"{len(items_raw)} tiles extracted", "shape matches the captured reference"]
-                if drift["added"]:
-                    notes.append(f"{len(drift['added'])} new paths vs baseline (informational)")
                 checks["search"] = R.selfcheck_entry(
-                    "healthy", baseline=baseline, notes=notes, shape_added=drift["added"]
+                    "drift", baseline=baseline, reason="parse_smoke_failed", notes=["zero SKUs"]
                 )
-        elif payload.get("title") != "__BLOCKED__":
-            checks["search"] = R.selfcheck_entry(
-                "drift", baseline=baseline, reason="parse_smoke_failed", notes=["zero SKUs"]
-            )
     except ToolError as exc:
         checks["search"] = R.selfcheck_entry(
             "inconclusive", baseline=baseline, reason="transport_down", notes=[str(exc)[:160]]

--- a/packages/lamoda-connector/src/lamoda_connector/shape_reference.py
+++ b/packages/lamoda-connector/src/lamoda_connector/shape_reference.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 
 SEARCH_SHAPE_REFERENCE: tuple[str, ...] = (
+    "body_snippet:str",
     "items[].brand:null",
     "items[].price_texts.attached[]:str",
     "items[].price_texts.other[]:str",

--- a/packages/lamoda-connector/tests/test_search_extractor_dom.py
+++ b/packages/lamoda-connector/tests/test_search_extractor_dom.py
@@ -47,11 +47,16 @@ def _items() -> list[dict]:
     return payload["items"]
 
 
-def _extract(js_source: str) -> dict:
+def _extract(js_source: str, html: str | None = None, tmp_path: Path | None = None) -> dict:
     try:
+        fixture = FIXTURE
+        if html is not None:
+            assert tmp_path is not None
+            fixture = tmp_path / "challenge.html"
+            fixture.write_text(html, encoding="utf-8")
         return run_extractor(
             js_source,
-            FIXTURE,
+            fixture,
             page_url="https://www.lamoda.ru/catalogsearch/result/?q=%D0%BA%D1%80%D0%BE%D1%81%D1%81%D0%BE%D0%B2%D0%BA%D0%B8",
         )
     except JsdomUnavailable as exc:
@@ -103,3 +108,63 @@ def test_the_extractor_uses_shared_helpers_not_legacy_heuristics() -> None:
     assert "Math.min" not in code, "price picking went back to Math.min"
     assert "tileRootFor" in code, "shared tileRootFor vanished from the extractor"
     assert "priceTextsIn" in code, "shared priceTextsIn vanished from the extractor"
+
+
+def test_challenge_words_in_scripts_or_hidden_widgets_do_not_block_products(tmp_path: Path) -> None:
+    html = FIXTURE.read_text(encoding="utf-8").replace(
+        "</body>",
+        '<script>captcha; "не робот"</script><div hidden>access denied</div>'
+        '<div style="display:none">пройти проверку</div></body>',
+    )
+    payload = _extract(server._SEARCH_EXTRACT_JS, html, tmp_path)
+
+    assert len(payload["items"]) == 2
+    assert payload["title"] != "__BLOCKED__"
+    assert server._anti_bot_challenge(payload) is False
+
+
+def test_visible_challenge_blocks_only_an_empty_result(tmp_path: Path) -> None:
+    html = "<html><body><div>Подтвердите, что вы не робот</div></body></html>"
+    payload = _extract(server._SEARCH_EXTRACT_JS, html, tmp_path)
+
+    assert payload["items"] == []
+    assert payload["title"] == ""
+    assert server._anti_bot_challenge(payload) is True
+
+
+def test_script_only_challenge_is_not_a_blocked_page(tmp_path: Path) -> None:
+    html = "<html><body><script>captcha</script></body></html>"
+    payload = _extract(server._SEARCH_EXTRACT_JS, html, tmp_path)
+
+    assert payload["items"] == []
+    assert payload["title"] != "__BLOCKED__"
+    assert server._anti_bot_challenge(payload) is False
+
+
+def test_hidden_and_css_hidden_widgets_on_an_empty_page_are_not_a_challenge(tmp_path: Path) -> None:
+    html = """<html><body>
+      <script>captcha are you human</script>
+      <div hidden>Подтвердите, что вы не робот</div>
+      <div style="display:none">пройти проверку</div>
+      <div style="visibility: hidden">access denied</div>
+    </body></html>"""
+    payload = _extract(server._SEARCH_EXTRACT_JS, html, tmp_path)
+
+    assert payload["items"] == []
+    assert payload["body_snippet"] == ""
+    assert server._anti_bot_challenge(payload) is False
+
+
+async def test_extractor_payload_flows_through_lamoda_search(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exercise the real extractor payload through the public tool mapping."""
+    payload = _extract(server._SEARCH_EXTRACT_JS)
+
+    async def fake_render(query: str, ctx: object) -> dict:
+        return payload
+
+    monkeypatch.setattr(server, "_cdp_render_search", fake_render)
+    result = await server.lamoda_search("кроссовки")
+
+    assert result.count == len(payload["items"])
+    assert result.items[0].title == payload["items"][0]["title"]
+    assert result.items[0].price_rub == 5990.0

--- a/packages/lamoda-connector/tests/test_server.py
+++ b/packages/lamoda-connector/tests/test_server.py
@@ -151,6 +151,21 @@ async def test_search_maps_zero_skus_to_parser_drift(monkeypatch):
         await server.lamoda_search("кроссовки")
 
 
+async def test_search_empty_visible_challenge_is_transport_down(monkeypatch):
+    _patch_render(
+        monkeypatch,
+        {
+            "title": "Lamoda",
+            "items": [],
+            "body_snippet": "Подтвердите, что вы не робот и пройдите проверку",
+        },
+    )
+
+    with pytest.raises(ToolError) as excinfo:
+        await server.lamoda_search("кроссовки")
+    assert "challenge" in str(excinfo.value).lower()
+
+
 # ---------------------------------------------------------- lamoda_selfcheck ----
 
 
@@ -220,6 +235,31 @@ async def test_selfcheck_cries_shape_drift_when_the_price_family_vanishes(monkey
     assert search.state == "drift"
     assert search.reason == "shape_drift"
     assert any("price" in note for note in search.notes)
+
+
+async def test_selfcheck_price_shape_drift_survives_challenge_copy(monkeypatch):
+    """Visible challenge wording in product copy cannot suppress shape drift."""
+    _patch_graphql(monkeypatch, GRAPHQL_PRODUCT)
+    _patch_render(
+        monkeypatch,
+        {
+            "title": "Кроссовки — Lamoda",
+            "body_snippet": "Кроссовки с защитой от робота; пройти проверку размера",
+            "items": [
+                {
+                    "sku": "MP002XM1RMM3",
+                    "title": "Кроссовки без цены",
+                    "url": "https://www.lamoda.ru/p/mp002xm1rmm3/",
+                }
+            ],
+        },
+    )
+
+    result = await server.lamoda_selfcheck()
+
+    assert result.status == "drift_detected"
+    assert result.checks["search"].state == "drift"
+    assert result.checks["search"].reason == "shape_drift"
 
 
 # ------------------------------------------------------------------- helpers ----

--- a/packages/lamoda-connector/tests/test_shape_reference.py
+++ b/packages/lamoda-connector/tests/test_shape_reference.py
@@ -23,6 +23,7 @@ FIXTURE = Path(__file__).parent / "fixtures" / "search_grid.html"
 LIVE_FIXTURE = Path(__file__).parent / "fixtures" / "search_grid_live.html"
 
 SEARCH_GOLDEN = [
+    "body_snippet:str",
     "items[].brand:null",
     "items[].price_texts.attached[]:str",
     "items[].price_texts.other:empty_array",

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -750,7 +750,9 @@ async def _new_tab(ctx: BrowserContext) -> Page:
     activates the Chrome window on every call (and drags macOS along to the
     Space that window lives on). With stealth on, create the target over a
     browser-level CDP session with ``background: true`` and pick up the Page
-    Playwright attaches for it. If the CDP session itself cannot be opened,
+    Playwright attaches for that exact target id. Page events are broadcast
+    to every CDP client, so accepting the first event can claim another
+    connector's tab. If the CDP session itself cannot be opened,
     fall back to the plain call: a visible tab beats no tab.
     """
     browser = ctx.browser
@@ -760,13 +762,45 @@ async def _new_tab(ctx: BrowserContext) -> Page:
         cdp = await browser.new_browser_cdp_session()
     except Exception:
         return await ctx.new_page()
+    target_id: str | None = None
+    claimed = False
     try:
-        async with ctx.expect_page(timeout=_TAB_OP_TIMEOUT_S * 1000) as new_page:
-            await cdp.send("Target.createTarget", {"url": "about:blank", "background": True})
-        return await new_page.value
+        async with asyncio.timeout(_TAB_OP_TIMEOUT_S):
+            created = await cdp.send("Target.createTarget", {"url": "about:blank", "background": True})
+            created_id = created.get("targetId")
+            if not isinstance(created_id, str) or not created_id:
+                raise RuntimeError("CDP Target.createTarget returned no targetId")
+            target_id = created_id
+            while True:
+                # BrowserContext emits pages to every connected Playwright
+                # client. Correlate against the CDP target id returned above
+                # instead of accepting the first broadcast event.
+                for page in tuple(ctx.pages):
+                    try:
+                        page_cdp = await ctx.new_cdp_session(page)
+                        try:
+                            info = await page_cdp.send("Target.getTargetInfo")
+                        finally:
+                            try:
+                                await asyncio.wait_for(page_cdp.detach(), timeout=_RAW_CONNECT_TIMEOUT_S)
+                            except Exception:
+                                pass
+                    except Exception:
+                        continue
+                    if info.get("targetInfo", {}).get("targetId") == target_id:
+                        claimed = True
+                        return page
+                await asyncio.sleep(0.01)
     finally:
+        if target_id is not None and not claimed:
+            try:
+                await asyncio.wait_for(
+                    cdp.send("Target.closeTarget", {"targetId": target_id}), timeout=_RAW_CONNECT_TIMEOUT_S
+                )
+            except Exception:
+                pass
         try:
-            await cdp.detach()
+            await asyncio.wait_for(cdp.detach(), timeout=_RAW_CONNECT_TIMEOUT_S)
         except Exception:
             pass
 

--- a/packages/mcp-core/tests/test_chrome_cdp_stealth.py
+++ b/packages/mcp-core/tests/test_chrome_cdp_stealth.py
@@ -9,7 +9,6 @@ back", never a real browser.
 from __future__ import annotations
 
 import subprocess
-from contextlib import asynccontextmanager
 
 import pytest
 from mcp_core.transport import chrome_cdp
@@ -143,6 +142,18 @@ class _FakeCdp:
         self.detached = True
 
 
+class _FakePageCdp:
+    def __init__(self, target_id: str) -> None:
+        self.target_id = target_id
+
+    async def send(self, method: str, params=None):
+        assert method == "Target.getTargetInfo"
+        return {"targetInfo": {"targetId": self.target_id}}
+
+    async def detach(self) -> None:
+        pass
+
+
 class _FakeBrowser:
     def __init__(self, cdp: _FakeCdp | None) -> None:
         self._cdp = cdp
@@ -170,15 +181,14 @@ class _FakeContext:
         self.browser = browser
         self.plain_pages = 0
         self.expect_timeouts: list[float | None] = []
+        self.pages = ["background-page"]
+
+    async def new_cdp_session(self, page: str) -> _FakePageCdp:
+        return _FakePageCdp("T1")
 
     async def new_page(self) -> str:
         self.plain_pages += 1
         return "foreground-page"
-
-    @asynccontextmanager
-    async def expect_page(self, timeout: float | None = None):
-        self.expect_timeouts.append(timeout)
-        yield _FakeEventInfo("background-page")
 
 
 async def test_new_tab_creates_the_target_in_the_background_when_stealth_is_on(monkeypatch):
@@ -192,7 +202,7 @@ async def test_new_tab_creates_the_target_in_the_background_when_stealth_is_on(m
     assert cdp.sent == [("Target.createTarget", {"url": "about:blank", "background": True})]
     assert cdp.detached is True
     assert ctx.plain_pages == 0
-    assert ctx.expect_timeouts == [chrome_cdp._TAB_OP_TIMEOUT_S * 1000]
+    assert ctx.expect_timeouts == []
 
 
 async def test_new_tab_uses_plain_new_page_when_stealth_is_off(monkeypatch):
@@ -225,10 +235,9 @@ async def test_new_tab_falls_back_to_new_page_when_the_cdp_session_fails(monkeyp
 
 async def test_new_tab_detaches_the_session_even_when_no_page_arrives(monkeypatch):
     class _NoPageContext(_FakeContext):
-        @asynccontextmanager
-        async def expect_page(self, timeout: float | None = None):
-            raise TimeoutError("no page event")
-            yield  # pragma: no cover
+        def __init__(self, browser):
+            super().__init__(browser)
+            self.pages = []
 
     monkeypatch.setattr(chrome_cdp, "STEALTH", True)
     cdp = _FakeCdp()
@@ -238,3 +247,17 @@ async def test_new_tab_detaches_the_session_even_when_no_page_arrives(monkeypatc
         await chrome_cdp._new_tab(ctx)  # type: ignore[arg-type]
 
     assert cdp.detached is True
+
+
+async def test_new_tab_serializes_target_ownership_for_concurrent_callers(monkeypatch):
+    """Each waiter must own the page event it caused, even under fan-out."""
+
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    ctx = _FakeContext(_FakeBrowser(_FakeCdp()))
+
+    import asyncio
+
+    pages = await asyncio.gather(*(chrome_cdp._new_tab(ctx) for _ in range(6)))  # type: ignore[arg-type]
+
+    assert len(pages) == 6
+    assert all(page == "background-page" for page in pages)


### PR DESCRIPTION
## What changed

- classify Lamoda anti-bot challenges from bounded visible text only, gated on an empty result;
- preserve shape drift detection when product tiles exist alongside challenge wording;
- correlate Playwright CDP pages with the exact `Target.createTarget` id, preventing concurrent callers from claiming another connector's tab;
- add regression coverage and update the documented offline test count to 1368.

## Verification

- `uv run pytest -q -m "not live and not cdp"` — 1367 passed, 1 skipped, 5 deselected;
- targeted Lamoda/CDP suite — 55 passed;
- `ruff check`, format check, mypy (host and win32), no-print, version, test-count, ops gates, and `e2e_stdio_check.py` — passed.

Credits: Lamoda hardening follows the v2.2 backlog finding; contributor attribution remains in `CONTRIBUTORS.md`.
