### PR TITLE
fix: refresh challenged reads and close owned CDP targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@
 
 ### Browser recovery
 
+- Raw CDP now attempts bounded cleanup of its exact owned target even when
+  target discovery or page-websocket attachment fails. Cancellation and cleanup
+  errors preserve the original failure. Concurrent ownership tests now use six
+  distinct targets and a foreign tab rather than a single shared fake target.
+- Taobao search/card failures no longer enter the successful-result cache, and
+  Lamoda search does not cache detected challenge pages. After browser action,
+  a new call reads fresh evidence instead of replaying a cached block for up to
+  the default 120-second TTL. Successful payloads still use the normal cache.
+- Taobao search now uses its existing CAPTCHA detector in the public tool, not
+  only in selfcheck. Empty cards with challenge evidence return the same
+  structured error; ordinary product cards mentioning CAPTCHA remain data.
 - Taobao login/CAPTCHA walls and Lamoda search challenges return
   `challenge_required`. Comparison outcomes now retain `error_code`, `retryable`,
   `requires_user_action`, and `challenge_type`, even when error detail is truncated.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1416 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1438 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -562,7 +562,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1416 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1438 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -628,7 +628,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1416 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1438 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -711,7 +711,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1416 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1438 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1069,7 +1069,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1416 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1438 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1131,7 +1131,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1416 offline
+are confidently wrong, so the project is arranged around verification: 1438 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1416 offline tests, no network required. Three flavours:
+1438 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/dsh/skills/lamoda-connector/SKILL.md
+++ b/dsh/skills/lamoda-connector/SKILL.md
@@ -26,7 +26,10 @@ Chrome over CDP.
 ## Gotchas
 - Lamoda exposes NO ratings anywhere — `rating` is not in the GraphQL schema.
   No review tools exist here by design.
-- A search page yielding zero SKUs is drift, not "no results" — verify manually.
+- An empty search with a detected visible challenge returns `challenge_required`;
+  it is not cached. Complete the interaction in the connected Chrome profile,
+  then retry. Empty extraction without challenge evidence remains parser drift,
+  not proof of "no results".
 - A missing price is `null`, never `0`: `price_rub: null` means Lamoda had no
   usable price — treat it as no data, never as a free item.
 ## DSH activation

--- a/dsh/skills/taobao-connector/SKILL.md
+++ b/dsh/skills/taobao-connector/SKILL.md
@@ -28,8 +28,10 @@ connector's canary at once.
 ## Gotchas
 - Prices stay in yuan. Comparing against ruble sources needs an explicit rate;
   a baked-in one would go silently stale.
-- A login wall (title 登录) means the scraping profile is logged out of
-  taobao.com — log in there, then retry.
+- A detected login/CAPTCHA wall returns `challenge_required` and
+  `requires_user_action=true`. Complete it in the scraping profile before retrying
+  the same operation. Failed payloads are not cached; a retry reads the browser
+  again. Successful results still use the normal TTL cache.
 - The operator's Chrome must be running with CDP (scripts/start_chrome_cdp.sh).
 ## DSH activation
 

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -352,7 +352,8 @@ async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
         payload = await asyncio.wait_for(_attempt(), timeout=max(0.01, float(TIMEOUT)))
     except TimeoutError:
         raise_tool_error(TransportDownError(f"CDP timeout after {TIMEOUT}s"))
-    _cache.set(cache_key, payload)
+    if not _anti_bot_challenge(payload):
+        _cache.set(cache_key, payload)
     return payload
 
 
@@ -375,8 +376,9 @@ async def lamoda_search(
 
     ## Error Format
 
-    ToolError: TransportDownError on CDP/nav failures; ParserDriftError when a
-    rendered page yields zero SKUs, which means the tile shape moved.
+    ToolError: challenge_required on a visible challenge (not cached);
+    TransportDownError on CDP/nav failures; ParserDriftError when a rendered
+    page yields zero SKUs without challenge evidence.
     """
     log_event("lamoda_search.start", query=query[:60])
     try:

--- a/packages/lamoda-connector/tests/test_server.py
+++ b/packages/lamoda-connector/tests/test_server.py
@@ -7,6 +7,9 @@ GraphQL product JSON, and the search-tile extraction from a rendered page.
 
 from __future__ import annotations
 
+import json
+from contextlib import asynccontextmanager
+
 import pytest
 from fastmcp.exceptions import ToolError
 from lamoda_connector import server
@@ -164,6 +167,35 @@ async def test_search_empty_visible_challenge_is_transport_down(monkeypatch):
     with pytest.raises(ToolError) as excinfo:
         await server.lamoda_search("кроссовки")
     assert "challenge" in str(excinfo.value).lower()
+
+
+async def test_challenge_recovery_bypasses_failed_payload_cache(monkeypatch):
+    from mcp_core.cache import TTLCache
+
+    monkeypatch.setattr(server, "_cache", TTLCache(ttl_s=300))
+    reads = []
+
+    class Page:
+        async def evaluate(self, expression):
+            reads.append(expression)
+            payload = (
+                {"items": [], "body_snippet": "Подтвердите, что вы не робот"} if len(reads) == 1 else SEARCH_EXTRACTED
+            )
+            return json.dumps(payload)
+
+    @asynccontextmanager
+    async def open_page(url, wait_ms):
+        yield Page()
+
+    monkeypatch.setattr(server, "open_page", open_page)
+    with pytest.raises(ToolError) as excinfo:
+        await server.lamoda_search("кроссовки")
+    assert json.loads(str(excinfo.value))["error"] == "challenge_required"
+    assert len(server._cache) == 0
+    recovered = await server.lamoda_search("кроссовки")
+    assert recovered.count > 0
+    await server.lamoda_search("кроссовки")
+    assert len(reads) == 2  # the successful payload still uses the normal cache
 
 
 # ---------------------------------------------------------- lamoda_selfcheck ----

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -698,44 +698,53 @@ async def _raw_cdp_page(url: str, wait_ms: int) -> AsyncIterator[_RawCdpPage]:
         create_params: dict[str, Any] = {"url": "about:blank"}
         if STEALTH:
             create_params["background"] = True
-        created = await _RawCdpPage(bws, "")._send("Target.createTarget", create_params, timeout=_RAW_CONNECT_TIMEOUT_S)
+        browser = _RawCdpPage(bws, "")
+        created = await browser._send("Target.createTarget", create_params, timeout=_RAW_CONNECT_TIMEOUT_S)
         target_id = created.get("targetId")
         if not isinstance(target_id, str) or not target_id:
             raise RuntimeError("CDP Target.createTarget returned no targetId")
 
-    import urllib.request
-
-    try:
-        with urllib.request.urlopen(f"{CDP_URL}/json", timeout=3) as resp:
-            targets = json.loads(resp.read())
-    except Exception as exc:
-        raise RuntimeError(f"CDP target list unavailable: {exc}") from exc
-    page_ws = next(
-        (t.get("webSocketDebuggerUrl") for t in targets if isinstance(t, dict) and t.get("id") == target_id),
-        None,
-    )
-    if not isinstance(page_ws, str) or not page_ws.startswith("ws"):
-        raise RuntimeError("CDP target has no websocket URL")
-    parts = urlsplit(page_ws)
-    page_ws = urlunsplit(parts._replace(netloc=f"{CDP_HOST}:{CDP_PORT}"))
-
-    async with _websockets.connect(page_ws, max_size=_RAW_MAX_FRAME_BYTES, open_timeout=_RAW_CONNECT_TIMEOUT_S) as pws:
-        page = _RawCdpPage(pws, target_id)
+        # Keep the browser connection alive until the owned target is closed.
+        # Discovery and page attachment may fail before there is a page socket
+        # through which to clean up, so ownership starts at createTarget.
         try:
-            await page._send("Page.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
-            await page._send("Network.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
-            await page._send("Runtime.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
-            status = await page.goto_and_status(url)
-            if status in _NAV_FAIL_STATUSES:
-                raise NavBlocked(status, page.url)
-            if wait_ms > 0:
-                await asyncio.sleep(wait_ms / 1000)
-            if STEALTH and sys.platform in ("win32", "darwin"):
-                await asyncio.to_thread(_hide_chrome_windows)
-            yield page
+            import urllib.request
+
+            try:
+                with urllib.request.urlopen(f"{CDP_URL}/json", timeout=3) as resp:
+                    targets = json.loads(resp.read())
+            except Exception as exc:
+                raise RuntimeError(f"CDP target list unavailable: {exc}") from exc
+            page_ws = next(
+                (t.get("webSocketDebuggerUrl") for t in targets if isinstance(t, dict) and t.get("id") == target_id),
+                None,
+            )
+            if not isinstance(page_ws, str) or not page_ws.startswith("ws"):
+                raise RuntimeError("CDP target has no websocket URL")
+            parts = urlsplit(page_ws)
+            page_ws = urlunsplit(parts._replace(netloc=f"{CDP_HOST}:{CDP_PORT}"))
+
+            async with _websockets.connect(
+                page_ws, max_size=_RAW_MAX_FRAME_BYTES, open_timeout=_RAW_CONNECT_TIMEOUT_S
+            ) as pws:
+                page = _RawCdpPage(pws, target_id)
+                await page._send("Page.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
+                await page._send("Network.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
+                await page._send("Runtime.enable", timeout=_RAW_CONNECT_TIMEOUT_S)
+                status = await page.goto_and_status(url)
+                if status in _NAV_FAIL_STATUSES:
+                    raise NavBlocked(status, page.url)
+                if wait_ms > 0:
+                    await asyncio.sleep(wait_ms / 1000)
+                if STEALTH and sys.platform in ("win32", "darwin"):
+                    await asyncio.to_thread(_hide_chrome_windows)
+                yield page
         finally:
             try:
-                await asyncio.wait_for(page.close(), timeout=_TAB_OP_TIMEOUT_S)
+                await asyncio.wait_for(
+                    browser._send("Target.closeTarget", {"targetId": target_id}, timeout=_RAW_CONNECT_TIMEOUT_S),
+                    timeout=_TAB_OP_TIMEOUT_S,
+                )
             except Exception:
                 pass
             # Closing the tab un-hides the app again; tuck it away between calls.

--- a/packages/mcp-core/tests/test_chrome_cdp_raw_lifecycle.py
+++ b/packages/mcp-core/tests/test_chrome_cdp_raw_lifecycle.py
@@ -1,0 +1,143 @@
+"""Raw CDP owns its target even when discovery or attachment fails."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import urllib.request
+from contextlib import asynccontextmanager
+from io import BytesIO
+from types import SimpleNamespace
+
+import pytest
+from mcp_core.transport import chrome_cdp
+
+
+@pytest.fixture
+def raw_browser(monkeypatch):
+    state = SimpleNamespace(fail=None, cleanup=None, sent=[], entered=[], exited=[], attaching=asyncio.Event())
+
+    class Socket:
+        def __init__(self, kind):
+            self.kind = kind
+            self.responses = asyncio.Queue()
+
+        async def send(self, raw):
+            message = json.loads(raw)
+            method = message["method"]
+            state.sent.append((self.kind, method, message["params"]))
+            if method == "Target.closeTarget":
+                if state.cleanup == "error":
+                    raise OSError("cleanup failed")
+                if state.cleanup == "hang":
+                    await asyncio.Event().wait()
+            if method == "Page.enable" and state.fail == "enable":
+                raise OSError("enable failed")
+            result = {"targetId": "owned"} if method == "Target.createTarget" else {}
+            await self.responses.put(json.dumps({"id": message["id"], "result": result}))
+            if method == "Page.navigate":
+                await self.responses.put(
+                    json.dumps(
+                        {
+                            "method": "Network.responseReceived",
+                            "params": {
+                                "type": "Document",
+                                "response": {"status": 403 if state.fail == "navigation" else 200},
+                            },
+                        }
+                    )
+                )
+                await self.responses.put(json.dumps({"method": "Page.loadEventFired"}))
+
+        async def recv(self):
+            return await self.responses.get()
+
+    @asynccontextmanager
+    async def connect(url, **options):
+        assert options["max_size"] == chrome_cdp._RAW_MAX_FRAME_BYTES
+        assert options["open_timeout"] == chrome_cdp._RAW_CONNECT_TIMEOUT_S
+        kind = "browser" if url.endswith("/browser") else "page"
+        if kind == "page":
+            assert "browser" not in state.exited
+            if state.fail == "connect":
+                raise OSError("connect failed")
+            if state.fail == "cancel_attach":
+                state.attaching.set()
+                await asyncio.Event().wait()
+        state.entered.append(kind)
+        try:
+            yield Socket(kind)
+        finally:
+            state.exited.append(kind)
+
+    def discover(url, timeout):
+        assert url == f"{chrome_cdp.CDP_URL}/json"
+        if state.fail == "discovery":
+            raise OSError("discovery failed")
+        if state.fail == "json":
+            return BytesIO(b"invalid json")
+        targets = [{"id": "foreign", "webSocketDebuggerUrl": "ws://localhost/foreign"}]
+        if state.fail != "missing":
+            targets.append({"id": "owned", "webSocketDebuggerUrl": "ws://localhost/page"})
+        return BytesIO(json.dumps(targets).encode())
+
+    monkeypatch.setattr(chrome_cdp, "STEALTH", False)
+    monkeypatch.setattr(chrome_cdp, "_browser_ws_url", lambda: "ws://localhost/browser")
+    monkeypatch.setattr(chrome_cdp, "_websockets", SimpleNamespace(connect=connect))
+    monkeypatch.setattr(urllib.request, "urlopen", discover)
+    return state
+
+
+def assert_owned_target_closed(state):
+    closes = [entry for entry in state.sent if entry[1] == "Target.closeTarget"]
+    assert closes == [("browser", "Target.closeTarget", {"targetId": "owned"})]
+    assert state.exited[-1] == "browser"
+
+
+@pytest.mark.parametrize("failure", ["discovery", "json", "missing", "connect", "enable", "navigation", "body"])
+async def test_raw_target_closed_after_every_postcreation_failure(raw_browser, failure):
+    raw_browser.fail = failure
+    with pytest.raises((RuntimeError, OSError, chrome_cdp.NavBlocked)):
+        async with chrome_cdp._raw_cdp_page("https://example.com", 0):
+            assert failure == "body", "the failing setup must never yield a page"
+            raise RuntimeError("body failed")
+    assert_owned_target_closed(raw_browser)
+
+
+async def test_raw_target_closed_once_on_success(raw_browser):
+    async with chrome_cdp._raw_cdp_page("https://example.com", 0) as page:
+        assert page._target_id == "owned"
+        assert not any(entry[1] == "Target.closeTarget" for entry in raw_browser.sent)
+    assert_owned_target_closed(raw_browser)
+    assert raw_browser.exited == ["page", "browser"]
+
+
+@pytest.mark.parametrize("cleanup", ["error", "hang"])
+@pytest.mark.parametrize("failure", ["missing", "body", "cancel_attach", "cancel_body"])
+async def test_raw_cleanup_is_bounded_and_preserves_original_failure(raw_browser, monkeypatch, cleanup, failure):
+    raw_browser.fail = failure
+    raw_browser.cleanup = cleanup
+    monkeypatch.setattr(chrome_cdp, "_TAB_OP_TIMEOUT_S", 0.02)
+    original = RuntimeError("body failed")
+
+    async def run():
+        async with chrome_cdp._raw_cdp_page("https://example.com", 0):
+            if failure == "cancel_body":
+                raw_browser.attaching.set()
+                await asyncio.Event().wait()
+            raise original
+
+    task = asyncio.create_task(run())
+    if failure.startswith("cancel_"):
+        await asyncio.wait_for(raw_browser.attaching.wait(), timeout=1)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=1)
+    else:
+        with pytest.raises(RuntimeError) as caught:
+            await asyncio.wait_for(task, timeout=1)
+        if failure == "body":
+            assert caught.value is original
+        else:
+            assert str(caught.value) == "CDP target has no websocket URL"
+    assert_owned_target_closed(raw_browser)

--- a/packages/mcp-core/tests/test_chrome_cdp_stealth.py
+++ b/packages/mcp-core/tests/test_chrome_cdp_stealth.py
@@ -249,15 +249,51 @@ async def test_new_tab_detaches_the_session_even_when_no_page_arrives(monkeypatc
     assert cdp.detached is True
 
 
-async def test_new_tab_serializes_target_ownership_for_concurrent_callers(monkeypatch):
-    """Each waiter must own the page event it caused, even under fan-out."""
-
-    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
-    ctx = _FakeContext(_FakeBrowser(_FakeCdp()))
-
+async def test_new_tab_matches_distinct_targets_under_interleaved_creation(monkeypatch):
+    """Broadcast pages arrive out of order while all six callers are pending."""
     import asyncio
 
-    pages = await asyncio.gather(*(chrome_cdp._new_tab(ctx) for _ in range(6)))  # type: ignore[arg-type]
+    created = []
+    all_created = asyncio.Event()
 
-    assert len(pages) == 6
-    assert all(page == "background-page" for page in pages)
+    class Cdp(_FakeCdp):
+        def __init__(self, target_id):
+            super().__init__()
+            self.target_id = target_id
+
+        async def send(self, method, params=None):
+            self.sent.append((method, params))
+            assert method == "Target.createTarget"
+            created.append(self.target_id)
+            if len(created) == 6:
+                ctx.pages.extend(reversed(created))
+                all_created.set()
+            await all_created.wait()
+            return {"targetId": self.target_id}
+
+    class Browser:
+        def __init__(self):
+            self.sessions = []
+
+        async def new_browser_cdp_session(self):
+            cdp = Cdp(f"target-{len(self.sessions)}")
+            self.sessions.append(cdp)
+            return cdp
+
+    class Context(_FakeContext):
+        async def new_cdp_session(self, page):
+            await asyncio.sleep(0)
+            return _FakePageCdp(page)
+
+    monkeypatch.setattr(chrome_cdp, "STEALTH", True)
+    browser = Browser()
+    ctx = Context(browser)
+    ctx.pages = ["foreign-user-tab"]
+
+    pages = await asyncio.wait_for(asyncio.gather(*(chrome_cdp._new_tab(ctx) for _ in range(6))), timeout=1)
+
+    assert pages == [f"target-{index}" for index in range(6)]
+    assert len(set(pages)) == 6
+    assert ctx.pages == ["foreign-user-tab", *reversed(created)]
+    assert all(session.detached for session in browser.sessions)
+    assert ctx.plain_pages == 0

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -559,10 +559,10 @@ async def taobao_search(
 
     ## Error Format
 
-    ToolError: TransportDownError when Chrome/CDP is unreachable or the page
-    lands on a login wall (log into taobao.com in the scraping profile, then
-    retry); ParserDriftError when a rendered page yields zero items, which means
-    the DOM shape moved.
+    ToolError: challenge_required when a login/CAPTCHA wall needs browser action;
+    retry after completing it in the scraping profile. TransportDownError when
+    Chrome/CDP is unreachable; ParserDriftError for unexplained empty extraction.
+    Challenge pages are never cached as successful search results.
     """
     log_event("taobao_search.start", query=query[:60], page=page)
     try:
@@ -581,7 +581,6 @@ async def taobao_search(
                     )
                 )
             tier = "cdp"
-            _cache.set(url, payload)
 
         wall_markers = _login_wall_markers(payload)
         if wall_markers:
@@ -591,6 +590,13 @@ async def taobao_search(
                     "Taobao requires user action in the Chrome scraping profile. Complete the visible login/CAPTCHA challenge, then retry.",
                     provider="taobao",
                     challenge_type="login_or_captcha",
+                )
+            )
+        if _anti_bot_challenge(payload):
+            raise_tool_error(
+                ChallengeRequiredError(
+                    "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
+                    provider="taobao",
                 )
             )
         items_raw = payload.get("items") if isinstance(payload.get("items"), list) else []
@@ -608,6 +614,8 @@ async def taobao_search(
         result = TaobaoSearchResponse(query=query, page=page, tier_used=tier, count=len(items), items=items)
         attached = R.attach_meta(result.model_dump(by_alias=True, exclude={"meta"}), warnings, source="taobao_search")
         result.meta = MetaOut(**attached["_meta"])
+        if tier == "cdp":
+            _cache.set(url, payload)
         return result
     except ToolError:
         raise
@@ -639,8 +647,9 @@ async def taobao_card(
     ## Error Format
 
     ToolError: BadRequestError when no id can be extracted; NotFoundError when
-    the item page reports itself gone; TransportDownError on login walls and CDP
-    failures; ParserDriftError when a rendered card has neither title nor price.
+    the item page reports itself gone; challenge_required on login/CAPTCHA walls;
+    TransportDownError on CDP failures; ParserDriftError when a rendered card has
+    neither title nor price and no detected challenge. Only successful cards are cached.
     """
     log_event("taobao_card.start", input=item_id_or_url[:80])
     try:
@@ -665,7 +674,6 @@ async def taobao_card(
                     )
                 )
             tier = "cdp"
-            _cache.set(url, payload)
 
         wall_markers = _login_wall_markers(payload)
         if wall_markers:
@@ -684,6 +692,13 @@ async def taobao_card(
         price, _old = prices_from_tile(payload)
         if price is None:
             price = R.coerce_price(payload.get("price_cny"))
+        if not title and price is None and _anti_bot_challenge(payload):
+            raise_tool_error(
+                ChallengeRequiredError(
+                    "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
+                    provider="taobao",
+                )
+            )
         if title is None and price is None:
             raise_tool_error(
                 ParserDriftError(
@@ -717,6 +732,8 @@ async def taobao_card(
             result.model_dump(by_alias=True, exclude={"meta"}), card_warnings, source="taobao_card"
         )
         result.meta = MetaOut(**attached["_meta"])
+        if tier == "cdp":
+            _cache.set(url, payload)
         return result
     except ToolError:
         raise

--- a/packages/taobao-connector/tests/test_server.py
+++ b/packages/taobao-connector/tests/test_server.py
@@ -136,6 +136,50 @@ async def test_search_maps_a_login_wall_to_transport_down(monkeypatch):
     assert "login" in str(excinfo.value).lower() or "登录" in str(excinfo.value)
 
 
+@pytest.mark.parametrize("kind", ["search_login", "search_captcha", "card_login", "card_captcha"])
+async def test_challenge_recovery_reads_browser_again_and_caches_only_success(monkeypatch, kind):
+    from mcp_core.cache import TTLCache
+
+    monkeypatch.setattr(server, "_cache", TTLCache(ttl_s=300))
+    blocked = (
+        {"title": "Security check", "items": [], "body_snippet": "Please complete CAPTCHA"}
+        if kind.endswith("captcha")
+        else LOGIN_WALL
+    )
+    if kind == "card_captcha":
+        blocked = {"title": None, "page_title": "Security check", "body_snippet": "Please complete CAPTCHA"}
+    healthy = CARD_EXTRACTED if kind.startswith("card") else SEARCH_EXTRACTED
+    reads = []
+
+    async def render(url, extract_js, wait_ms, ctx):
+        reads.append(url)
+        return blocked if len(reads) == 1 else healthy
+
+    monkeypatch.setattr(server, "_cdp_render", render)
+    call = server.taobao_card if kind.startswith("card") else server.taobao_search
+    query = "123456789012" if kind.startswith("card") else "手机"
+    with pytest.raises(ToolError) as excinfo:
+        await call(query)
+    error = json.loads(str(excinfo.value))
+    assert error["error"] == "challenge_required"
+    assert error["requires_user_action"] is True
+    assert len(server._cache) == 0
+
+    recovered = await call(query)
+    assert recovered.tier_used == "cdp"
+    assert recovered.status == "success"
+    cached = await call(query)
+    assert cached.tier_used == "cache"
+    assert len(reads) == 2
+
+
+async def test_product_card_mentioning_captcha_remains_product_data(monkeypatch):
+    _patch_render(monkeypatch, {**CARD_EXTRACTED, "body_snippet": "Please complete CAPTCHA"})
+    result = await server.taobao_card("123456789012")
+    assert result.title == CARD_EXTRACTED["title"]
+    assert result.price_cny == CARD_EXTRACTED["price_cny"]
+
+
 async def test_search_maps_zero_items_to_parser_drift(monkeypatch):
     _patch_render(monkeypatch, {"title": "手机-淘宝搜索", "items": []})
 

--- a/skills/lamoda-connector/SKILL.md
+++ b/skills/lamoda-connector/SKILL.md
@@ -26,7 +26,10 @@ Chrome over CDP.
 ## Gotchas
 - Lamoda exposes NO ratings anywhere — `rating` is not in the GraphQL schema.
   No review tools exist here by design.
-- A search page yielding zero SKUs is drift, not "no results" — verify manually.
+- An empty search with a detected visible challenge returns `challenge_required`;
+  it is not cached. Complete the interaction in the connected Chrome profile,
+  then retry. Empty extraction without challenge evidence remains parser drift,
+  not proof of "no results".
 - A missing price is `null`, never `0`: `price_rub: null` means Lamoda had no
   usable price — treat it as no data, never as a free item.
 ## DSH activation

--- a/skills/taobao-connector/SKILL.md
+++ b/skills/taobao-connector/SKILL.md
@@ -28,8 +28,10 @@ connector's canary at once.
 ## Gotchas
 - Prices stay in yuan. Comparing against ruble sources needs an explicit rate;
   a baked-in one would go silently stale.
-- A login wall (title 登录) means the scraping profile is logged out of
-  taobao.com — log in there, then retry.
+- A detected login/CAPTCHA wall returns `challenge_required` and
+  `requires_user_action=true`. Complete it in the scraping profile before retrying
+  the same operation. Failed payloads are not cached; a retry reads the browser
+  again. Successful results still use the normal TTL cache.
 - The operator's Chrome must be running with CDP (scripts/start_chrome_cdp.sh).
 ## DSH activation
 

--- a/work/evals/visual-evidence-contract.md
+++ b/work/evals/visual-evidence-contract.md
@@ -68,3 +68,38 @@ success, cancellation, expiration, concurrent source queries, and process restar
 before advertising seamless resume. Compare latency, requests, challenge rate,
 and completion rate on the same task set before claiming an improvement over
 the existing parser/CDP flow.
+
+### Implementation constraints from the lifecycle audit
+
+Challenge detection in Lamoda and Taobao currently runs after the page context
+has closed. Move decoding and classification inside the owned context before
+introducing retention; changing `finally` alone cannot retain the right page.
+Keep handles scoped to the MCP session, provider, original input and CDP endpoint.
+Resume must atomically claim the exact target ID, avoid `goto`, recheck the current
+host policy, and retain the original expiry rather than extending it on every
+retry. A retry in another session must not adopt a tab by matching its URL.
+
+Ordinary connector cleanup hides the scraping-profile browser globally on Windows
+and macOS. Active handoffs must suppress this hiding, and explicit handoff must
+reveal the owned window; activating a target alone does not prove visibility.
+Expiry, cancellation and shutdown may close only recorded owned targets. An
+in-memory lease cannot guarantee cleanup after a hard process kill while Chrome
+survives: document this limit and reject stale handles after restart rather than
+closing unknown tabs. A concurrent-ownership fixture must use distinct target
+IDs and interleaved page discovery, not a single reused fake target.
+
+Blocked payloads must never enter the success cache: otherwise even a completed
+browser challenge can keep returning the old failure until TTL expiry. This
+prerequisite is covered by sequential failure/success/cache regression tests.
+
+Live probe on 2026-09-12: `lamoda_search("кроссовки")` in the local scraping
+Chrome returned `challenge_required`, `requires_user_action=true`, and zero
+cache entries. This verifies real challenge detection and absence of a poisoned
+cache; it does not verify challenge completion, product extraction, or resume.
+
+The raw-CDP lifecycle prerequisite was also exercised against real local Chrome:
+a local HTTP fixture created one owned target, and the target disappeared on
+normal context exit. Injecting failure into `/json` discovery after real target
+creation also removed the owned target. Pre-existing target IDs were unchanged
+in both cases. This covers normal operation and one attachment failure; it is
+not a guarantee of cleanup when Chrome itself becomes unreachable.


### PR DESCRIPTION
After a browser challenge, Taobao and Lamoda could replay a cached blocked page for the default 120-second TTL. Taobao's public search also classified CAPTCHA-only pages as parser drift despite having a detector in selfcheck. Failed Taobao reads no longer enter the success cache; Lamoda does not cache detected challenges. Successful results retain caching. Public Taobao search and empty cards now return `challenge_required` for detected CAPTCHA evidence, while ordinary product cards mentioning CAPTCHA remain data.

Raw CDP could leak its newly created tab when target discovery or page-socket attachment failed. Its browser socket now stays open through the owned target's bounded cleanup. Cleanup preserves the original failure/cancellation and never selects an unrelated tab. The ownership concurrency test now uses six distinct interleaved targets and a foreign tab.

Validation:
- Taobao/Lamoda offline suites: 125 passed; CDP suites: 96 passed; DSH bundle: 6 passed.
- New recovery tests fail in five cases against pre-fix functions; raw lifecycle regressions fail in eight pre-fix cases.
- Real local Chrome: owned target removed after normal completion and after injected target-discovery failure; all pre-existing target IDs preserved.
- Live Lamoda search returned `challenge_required`, `requires_user_action=true`, zero cache entries. This confirms detection/cache behavior, not challenge completion.
- Ruff, mypy, version/stdout/test-count gates pass. Offline collection: 1438; wire gate passes (compare about 1551, full mount 16077 estimated tokens).

Updated source and vendored DSH skills and the existing vision/recovery design with verified lifecycle constraints. Exact challenge-tab handoff, expiry and resume remain follow-up work; this PR fixes their cache and ownership prerequisites. No solver or new dependency is introduced. Contributor attribution is unchanged: this is maintainer work.

Final CI run 34700811167 passed all 10 applicable jobs across Windows/Linux/macOS, coverage, lint/types, server startup, and DSH installation.
