### PR TITLE
feat: retain bounded browser challenges for session-scoped resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@
 
 ### Browser recovery
 
+- Optional `CHROME_CHALLENGE_HANDOFF_S` retains DOM-detected Lamoda search and
+  Taobao search/card challenge tabs. Same-session repeats read the owned page
+  without navigating again. Expiry is capped at 300 seconds from initial attach,
+  does not extend, and at most four leases are active. Error/comparison metadata
+  exposes `handoff_expires_at` only when retained. No new MCP tools are required.
+- Owned tabs close on success, failure, expiry, caller cancellation and graceful
+  shutdown. Active handoffs suppress profile hiding; owned-window foreground
+  activation is best-effort. Default behavior, browser-less compare installations,
+  and headless operation retain their existing behavior. Hard process-kill expiry
+  and HTTP failures rejected before DOM extraction are outside this feature.
 - Raw CDP now attempts bounded cleanup of its exact owned target even when
   target discovery or page-websocket attachment fails. Cancellation and cleanup
   errors preserve the original failure. Concurrent ownership tests now use six
@@ -28,7 +38,8 @@
   Successful sources remain available while the client waits for browser action.
 - DSH guidance retries only affected sources after action completes, preserving
   query settings and disclosing that old and retried offers have different
-  observation times. Temporary-tab retention and automatic resume remain pending.
+  observation times. Opt-in retention now supports explicit same-session repeats;
+  autonomous challenge completion remains outside this implementation.
 - Corrected the documented offline-test count that failed the previous CI run.
 
 ### Идентификация / Identity

--- a/README.md
+++ b/README.md
@@ -19,6 +19,11 @@
 [English version below](#english-version) · [Архитектура](docs/ARCHITECTURE.md) ·
 [Как добавить источник](docs/ADDING_A_SOURCE.md) · [Про анти-бот](docs/ANTI_BOT.md)
 
+Для проверок в браузере добавлен опциональный режим сохранения вкладки:
+`CHROME_CHALLENGE_HANDOFF_S=120`. После завершения проверки повтор того же
+запроса в той же MCP-сессии продолжает чтение этой вкладки. Поддержка и ограничения
+описаны в [настройке Chrome](docs/CDP_SETUP.md#optional-challenge-handoff).
+
 ---
 
 ## Что внутри
@@ -69,7 +74,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1438 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1482 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -562,7 +567,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1438 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1482 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -628,7 +633,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1438 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1482 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -711,7 +716,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1438 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1482 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1069,7 +1074,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1438 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1482 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1131,7 +1136,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1438 offline
+are confidently wrong, so the project is arranged around verification: 1482 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1482 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1485 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -567,7 +567,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1482 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1485 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -633,7 +633,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1482 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1485 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -716,7 +716,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1482 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1485 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1074,7 +1074,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1482 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1485 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1136,7 +1136,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1482 offline
+are confidently wrong, so the project is arranged around verification: 1485 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1438 offline tests, no network required. Three flavours:
+1482 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1482 offline tests, no network required. Three flavours:
+1485 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/CDP_SETUP.md
+++ b/docs/CDP_SETUP.md
@@ -51,6 +51,8 @@ An error with `handoff_expires_at` confirms a retained tab. Complete the interac
 in that tab, then repeat the same operation and arguments in the same MCP session.
 The connector reads that exact page without navigating again; a successful read
 closes it. For comparison, repeat the original query with only the affected source.
+Pending handoffs take precedence over successful-result caches, so another
+session's cached response cannot bypass the retained page.
 The original expiry never extends on retries. Different sessions and operations
 receive independent tabs; at most four handoffs are active per process. Concurrent
 reads of one lease or a full registry report a busy transport error.

--- a/docs/CDP_SETUP.md
+++ b/docs/CDP_SETUP.md
@@ -39,6 +39,31 @@ yourself via env; it is never stored by the project either.)
 
 ## Setup
 
+### Optional challenge handoff
+
+Set `CHROME_CHALLENGE_HANDOFF_S=120` in the MCP server's environment to retain
+DOM-detected Lamoda search and Taobao search/card challenge tabs for up to two
+minutes. Default `0` disables retention; the hard maximum is 300 seconds, including
+initial browser attachment/navigation. A headed Chrome and an active MCP session
+are required. This mode does not solve CAPTCHA or log into accounts.
+
+An error with `handoff_expires_at` confirms a retained tab. Complete the interaction
+in that tab, then repeat the same operation and arguments in the same MCP session.
+The connector reads that exact page without navigating again; a successful read
+closes it. For comparison, repeat the original query with only the affected source.
+The original expiry never extends on retries. Different sessions and operations
+receive independent tabs; at most four handoffs are active per process. Concurrent
+reads of one lease or a full registry report a busy transport error.
+
+The runtime attempts to reveal the owned browser window and prevents unrelated
+connector calls from hiding it while the handoff is active. Foreground activation
+is best-effort, especially for remote browsers. Expiry, errors, cancellation and
+graceful shutdown close owned tabs; a hard process kill cannot guarantee expiry
+in an external Chrome. Without `handoff_expires_at`, use the ordinary retry flow:
+HTTP errors rejected before DOM extraction, headless runs and calls without an
+MCP session do not retain a tab. No cookies, screenshots or browser profile copies
+are written by the handoff runtime.
+
 ### 1. Start Chrome with remote debugging
 
 **Windows (PowerShell):**

--- a/dsh/skills/compare-prices/SKILL.md
+++ b/dsh/skills/compare-prices/SKILL.md
@@ -96,8 +96,13 @@ from listings whose marketplace explicitly reports stock.
    source. `retryable=true` means a later retry can succeed after the challenge
    clears; it does not authorize a retry loop. Complete the required interaction
    in the connected scraping profile. A different browser profile has different
-   cookies. The connector closes its temporary tab; retaining the exact challenge
-   tab and automatically resuming are not implemented.
+   cookies. If `handoff_expires_at` is present, the challenged tab is retained:
+   complete the interaction there and repeat in the same MCP session before
+   expiry. The source reads that exact page without new navigation. Otherwise
+   the temporary tab closes normally. Retention is opt-in through
+   `CHROME_CHALLENGE_HANDOFF_S` and currently covers Lamoda search and Taobao
+   search/card DOM challenges. Do not change the original query or arguments
+   when resuming, and do not assume automatic CAPTCHA completion.
 3. After the browser action completes, call `compare_prices` with the same query,
    filters and limit, and `sources` restricted to the failed sources. Do not
    re-query healthy sources merely to recover one marketplace. This retry's

--- a/dsh/skills/lamoda-connector/SKILL.md
+++ b/dsh/skills/lamoda-connector/SKILL.md
@@ -30,6 +30,9 @@ Chrome over CDP.
   it is not cached. Complete the interaction in the connected Chrome profile,
   then retry. Empty extraction without challenge evidence remains parser drift,
   not proof of "no results".
+- With `CHROME_CHALLENGE_HANDOFF_S` enabled, `handoff_expires_at` confirms a
+  retained search tab. Complete its interaction, then repeat the same query in
+  the same MCP session before expiry to read that tab without a new navigation.
 - A missing price is `null`, never `0`: `price_rub: null` means Lamoda had no
   usable price — treat it as no data, never as a free item.
 ## DSH activation

--- a/dsh/skills/marketplace/SKILL.md
+++ b/dsh/skills/marketplace/SKILL.md
@@ -51,7 +51,10 @@ everything else is unaffected.
   before scheduling retries. Keep answered sources visible, show the affected
   marketplace and `challenge_type`, and retry that source after the browser
   interaction completes. A challenge is not an empty product search. See the
-  compare-prices skill for the retry contract and current tab-retention limits.
+  compare-prices skill for the retry contract. `handoff_expires_at` confirms that
+  the source retained its tab; repeat the same operation in the same MCP session
+  after browser action and before that expiry. See docs/CDP_SETUP.md for opt-in
+  configuration and supported sources.
 - A source whose optional deps are missing is simply absent from the set —
   `marketplace_sources` says which and why.
 - Set `MARKETPLACE_SOURCES` on the unified server to mount only a comma-separated

--- a/dsh/skills/taobao-connector/SKILL.md
+++ b/dsh/skills/taobao-connector/SKILL.md
@@ -32,6 +32,10 @@ connector's canary at once.
   `requires_user_action=true`. Complete it in the scraping profile before retrying
   the same operation. Failed payloads are not cached; a retry reads the browser
   again. Successful results still use the normal TTL cache.
+- With `CHROME_CHALLENGE_HANDOFF_S` enabled, `handoff_expires_at` confirms that
+  the challenged search/card tab is retained. Complete its interaction, then
+  repeat the same tool arguments in the same MCP session before expiry. No new
+  navigation is issued for that resume; expiry never extends on retries.
 - The operator's Chrome must be running with CDP (scripts/start_chrome_cdp.sh).
 ## DSH activation
 

--- a/packages/compare-connector/src/compare_connector/models_output.py
+++ b/packages/compare-connector/src/compare_connector/models_output.py
@@ -95,6 +95,10 @@ class SourceOutcome(BaseModel):
         default=False, description="Pause retries for this source until browser action completes."
     )
     challenge_type: str | None = Field(default=None, description="captcha, login, or login_or_captcha when known.")
+    handoff_expires_at: str | None = Field(
+        default=None,
+        description="UTC expiry when the challenged tab is retained; repeat the same request after action.",
+    )
 
 
 class CompareResponse(BaseModel):

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -46,6 +46,7 @@ from mcp_core.errors import BadRequestError, ConnectorError, ErrorCode, raise_to
 from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.redact import redact_error_text as _redact
+from mcp_core.runtime import browser_handoff_lifespan
 from mcp_core.source_selection import selected
 from pydantic import Field
 
@@ -63,7 +64,7 @@ SERVER_STARTED_AT = datetime.datetime.now(datetime.UTC).isoformat().replace("+00
 # a slow source must not hold the whole comparison hostage.
 SOURCE_TIMEOUT_S = float(os.environ.get("COMPARE_SOURCE_TIMEOUT", "45"))
 
-mcp = FastMCP(name="compare-connector", version=SERVER_VERSION)
+mcp = FastMCP(name="compare-connector", version=SERVER_VERSION, lifespan=browser_handoff_lifespan)
 
 _CARD_TOOL_NAMES = {
     "wildberries": "wb_card",
@@ -770,6 +771,16 @@ def _source_error(exc: Exception) -> dict[str, Any]:
         status = "blocked"
     elif code == ErrorCode.TIMEOUT:
         status = "timeout"
+    handoff_expires_at = None
+    raw_expiry = payload.get("handoff_expires_at")
+    if challenge and isinstance(raw_expiry, str):
+        try:
+            expiry = datetime.datetime.fromisoformat(raw_expiry)
+        except ValueError:
+            pass
+        else:
+            if expiry.tzinfo is not None:
+                handoff_expires_at = expiry.astimezone(datetime.UTC).isoformat().replace("+00:00", "Z")
     return {
         "status": status,
         "detail": _redact(str(payload.get("message", str(exc))))[:200],
@@ -777,6 +788,7 @@ def _source_error(exc: Exception) -> dict[str, Any]:
         "retryable": code.retryable,
         "requires_user_action": challenge,
         "challenge_type": challenge_type if challenge else None,
+        "handoff_expires_at": handoff_expires_at,
     }
 
 

--- a/packages/compare-connector/tests/test_browser_handoff.py
+++ b/packages/compare-connector/tests/test_browser_handoff.py
@@ -100,6 +100,14 @@ async def test_distinct_mcp_sessions_do_not_share_challenge_tabs(browser):
         recovered = (await first.call_tool("compare_prices", arguments)).structured_content
         assert recovered["complete"] is True
         assert browser[0].closed and not browser[1].closed
+        blocked = (await second.call_tool("compare_prices", arguments)).structured_content
+        assert blocked["complete"] is False  # A's success cache must not bypass B's owned page
+        assert blocked["source_outcomes"][0]["handoff_expires_at"]
+        assert not browser[1].closed
+        browser[1].solved = True
+        recovered_b = (await second.call_tool("compare_prices", arguments)).structured_content
+        assert recovered_b["complete"] is True
+        assert len(browser) == 2 and browser[1].closed
     assert all(page.closed for page in browser)
 
 
@@ -113,17 +121,28 @@ async def test_mcp_shutdown_closes_pending_handoff(browser):
 @pytest.mark.parametrize("kind", ["search", "card"])
 async def test_taobao_tools_resume_the_retained_page(browser, kind):
     arguments = {"query": "test"} if kind == "search" else {"item_id_or_url": "123456789012"}
-    async with Client(taobao.mcp) as client:
+    async with Client(taobao.mcp) as client, Client(taobao.mcp) as second:
         with pytest.raises(ToolError) as excinfo:
             await client.call_tool(f"taobao_{kind}", arguments)
         error = json.loads(str(excinfo.value))
         assert error["handoff_expires_at"]
         assert error["challenge_type"] == "captcha"
         assert len(browser) == 1 and not browser[0].closed
+        with pytest.raises(ToolError):
+            await second.call_tool(f"taobao_{kind}", arguments)
+        assert len(browser) == 2
         browser[0].solved = True
         recovered = (await client.call_tool(f"taobao_{kind}", arguments)).structured_content
         assert recovered["status"] == "success"
-        assert len(browser) == 1 and browser[0].closed
+        assert len(browser) == 2 and browser[0].closed
+        with pytest.raises(ToolError) as second_error:
+            await second.call_tool(f"taobao_{kind}", arguments)
+        assert json.loads(str(second_error.value))["handoff_expires_at"]
+        assert not browser[1].closed
+        browser[1].solved = True
+        recovered_b = (await second.call_tool(f"taobao_{kind}", arguments)).structured_content
+        assert recovered_b["status"] == "success"
+        assert len(browser) == 2 and browser[1].closed
 
 
 def test_compare_import_does_not_require_browser_extra():

--- a/packages/compare-connector/tests/test_browser_handoff.py
+++ b/packages/compare-connector/tests/test_browser_handoff.py
@@ -1,0 +1,142 @@
+"""A real MCP client can recover a source on the same owned browser page."""
+
+import json
+import subprocess
+import sys
+from contextlib import asynccontextmanager
+
+import pytest
+from compare_connector import server as compare
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+from lamoda_connector import server as lamoda
+from mcp_core.cache import TTLCache
+from mcp_core.transport import browser_handoff as handoff
+from taobao_connector import server as taobao
+
+
+@pytest.fixture
+async def browser(monkeypatch):
+    pages = []
+
+    class Page:
+        url = "https://www.lamoda.ru/catalogsearch/result/?q=test"
+        solved = False
+        closed = False
+
+        async def evaluate(self, expression):
+            return json.dumps(
+                {
+                    "items": [
+                        {"sku": "MP002XM1RMM3", "item_id": "123456789012", "title": "Test shoes", "price_rub": 500}
+                    ]
+                    if self.solved
+                    else [],
+                    "body_snippet": "" if self.solved else "CAPTCHA: Подтвердите, что вы не робот",
+                    "title": "Test shoes" if self.solved else None,
+                    "page_title": "Test shoes" if self.solved else "Security check",
+                    "price_cny": 500 if self.solved else None,
+                    "_handoff_expires_at": "untrusted page value",
+                }
+            )
+
+    @asynccontextmanager
+    async def open_page(url, wait_ms, **kwargs):
+        page = Page()
+        page.url = url
+        pages.append(page)
+        try:
+            yield page
+        finally:
+            page.closed = True
+
+    async def current_url(page):
+        return page.url
+
+    async def reveal(page):
+        pass
+
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", "60")
+    monkeypatch.setattr(handoff.chrome_cdp, "HEADLESS", False)
+    monkeypatch.setattr(handoff.chrome_cdp, "open_page", open_page)
+    monkeypatch.setattr(handoff.chrome_cdp, "current_page_url", current_url)
+    monkeypatch.setattr(handoff.chrome_cdp, "reveal_owned_page", reveal)
+    monkeypatch.setattr(lamoda, "_cache", TTLCache(ttl_s=120))
+    monkeypatch.setattr(lamoda, "_min_gap", 0)
+    lamoda._pacer.reset()
+    monkeypatch.setattr(taobao, "_cache", TTLCache(ttl_s=120))
+    monkeypatch.setattr(taobao, "_min_gap", 0)
+    taobao._pacer.reset()
+    monkeypatch.setattr(compare, "SOURCES", {"lamoda": lamoda})
+    yield pages
+    await handoff.close_handoffs()
+
+
+async def test_compare_mcp_retains_source_session_and_resumes_without_navigation(browser):
+    arguments = {"query": "test", "sources": ["lamoda"]}
+    async with Client(compare.mcp) as client:
+        first = (await client.call_tool("compare_prices", arguments)).structured_content
+        outcome = first["source_outcomes"][0]
+        assert outcome["requires_user_action"] is True
+        assert outcome["handoff_expires_at"].endswith("Z")
+        assert "untrusted" not in outcome["handoff_expires_at"]
+        assert len(browser) == 1 and not browser[0].closed
+        browser[0].solved = True
+        second = (await client.call_tool("compare_prices", arguments)).structured_content
+        assert second["complete"] is True
+        assert second["cheapest"]["price_rub"] == 500
+        assert second["source_outcomes"][0]["handoff_expires_at"] is None
+        assert len(browser) == 1 and browser[0].closed
+
+
+async def test_distinct_mcp_sessions_do_not_share_challenge_tabs(browser):
+    arguments = {"query": "test", "sources": ["lamoda"]}
+    async with Client(compare.mcp) as first, Client(compare.mcp) as second:
+        await first.call_tool("compare_prices", arguments)
+        await second.call_tool("compare_prices", arguments)
+        assert len(browser) == 2
+        assert all(not page.closed for page in browser)
+        browser[0].solved = True
+        recovered = (await first.call_tool("compare_prices", arguments)).structured_content
+        assert recovered["complete"] is True
+        assert browser[0].closed and not browser[1].closed
+    assert all(page.closed for page in browser)
+
+
+async def test_mcp_shutdown_closes_pending_handoff(browser):
+    async with Client(compare.mcp) as client:
+        await client.call_tool("compare_prices", {"query": "test", "sources": ["lamoda"]})
+        assert len(browser) == 1 and not browser[0].closed
+    assert browser[0].closed
+
+
+@pytest.mark.parametrize("kind", ["search", "card"])
+async def test_taobao_tools_resume_the_retained_page(browser, kind):
+    arguments = {"query": "test"} if kind == "search" else {"item_id_or_url": "123456789012"}
+    async with Client(taobao.mcp) as client:
+        with pytest.raises(ToolError) as excinfo:
+            await client.call_tool(f"taobao_{kind}", arguments)
+        error = json.loads(str(excinfo.value))
+        assert error["handoff_expires_at"]
+        assert error["challenge_type"] == "captcha"
+        assert len(browser) == 1 and not browser[0].closed
+        browser[0].solved = True
+        recovered = (await client.call_tool(f"taobao_{kind}", arguments)).structured_content
+        assert recovered["status"] == "success"
+        assert len(browser) == 1 and browser[0].closed
+
+
+def test_compare_import_does_not_require_browser_extra():
+    script = """
+import builtins
+original = builtins.__import__
+def without_browser(name, *args, **kwargs):
+    if name == 'playwright' or name.startswith('playwright.'):
+        raise ImportError('browser extra deliberately unavailable')
+    return original(name, *args, **kwargs)
+builtins.__import__ = without_browser
+from compare_connector import server
+assert server.mcp.name == 'compare-connector'
+"""
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stderr

--- a/packages/compare-connector/tests/test_server.py
+++ b/packages/compare-connector/tests/test_server.py
@@ -269,6 +269,12 @@ def test_challenge_metadata_does_not_leak_credentials_or_upstream_instructions()
     assert result["requires_user_action"] is True
 
 
+@pytest.mark.parametrize("expiry", [None, [], "https://example.invalid/?token=secret", "2026-09-12T00:00:00"])
+def test_invalid_handoff_expiry_does_not_become_recovery_instructions(expiry):
+    result = server._source_error(ToolError(json.dumps({"error": "challenge_required", "handoff_expires_at": expiry})))
+    assert result["handoff_expires_at"] is None
+
+
 async def test_a_generic_failure_is_reported_as_error_not_blocked(monkeypatch):
     """Anti-bot blocks and ordinary bugs need different responses, so they differ."""
 

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -31,6 +31,7 @@ from typing import Annotated, Any
 
 import httpx
 from fastmcp import Context, FastMCP
+from fastmcp.server.dependencies import get_context as current_context
 from fastmcp.server.middleware.error_handling import RetryMiddleware
 from mcp.types import ToolAnnotations
 from mcp_core import resilience as R
@@ -49,7 +50,9 @@ from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
+from mcp_core.runtime import browser_handoff_lifespan
 from mcp_core.transport import build_client
+from mcp_core.transport.browser_handoff import read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -100,6 +103,7 @@ _HEADERS = {
 
 mcp = FastMCP(
     name="lamoda-connector",
+    lifespan=browser_handoff_lifespan,
     version=SERVER_VERSION,
     instructions=(
         "Lamoda fashion catalog: text search runs in the operator's Chrome over "
@@ -337,16 +341,36 @@ async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
     url = f"{SITE_BASE}/catalogsearch/result/?q={urllib.parse.quote(query)}"
 
     async def _attempt() -> dict[str, Any]:
+        async def read(page):
+            raw = await asyncio.wait_for(page.evaluate(_SEARCH_EXTRACT_JS), timeout=30.0)
+            if not isinstance(raw, str) or len(raw.encode()) > MAX_BODY_BYTES:
+                raise_tool_error(TransportDownError("extracted page data missing or over the body cap"))
+            data = json.loads(raw)
+            if not isinstance(data, dict):
+                raise_tool_error(ParserDriftError("search extractor returned a non-object payload"))
+            data.pop("_handoff_expires_at", None)
+            return data
+
+        try:
+            scope = (ctx or current_context()).session_id
+        except RuntimeError:
+            scope = None
         async with _cdp_lock:
             await _polite_wait()
-            async with open_page(url, wait_ms=8000) as page:
-                raw = await asyncio.wait_for(page.evaluate(_SEARCH_EXTRACT_JS), timeout=30.0)
-        if not isinstance(raw, str) or len(raw.encode()) > MAX_BODY_BYTES:
-            raise ToolError(TransportDownError("extracted page data missing or over the body cap"))
-        data = json.loads(raw)
-        if not isinstance(data, dict):
-            raise ToolError(ParserDriftError("search extractor returned a non-object payload"))
-        return data
+            if scope is None:
+                async with open_page(url, wait_ms=8000) as page:
+                    return await read(page)
+            data, expires_at = await read_with_handoff(
+                url=url,
+                wait_ms=8000,
+                scope=scope,
+                operation="lamoda_search",
+                read=read,
+                challenge=lambda payload: "captcha" if _anti_bot_challenge(payload) else None,
+            )
+            if expires_at:
+                data["_handoff_expires_at"] = expires_at
+            return data
 
     try:
         payload = await asyncio.wait_for(_attempt(), timeout=max(0.01, float(TIMEOUT)))
@@ -391,6 +415,7 @@ async def lamoda_search(
                 ChallengeRequiredError(
                     "Lamoda requires user action in the connected Chrome. Complete the visible challenge, then retry.",
                     provider="lamoda",
+                    handoff_expires_at=payload.get("_handoff_expires_at"),
                 )
             )
         items_raw = payload.get("items") if isinstance(payload.get("items"), list) else []

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -31,7 +31,6 @@ from typing import Annotated, Any
 
 import httpx
 from fastmcp import Context, FastMCP
-from fastmcp.server.dependencies import get_context as current_context
 from fastmcp.server.middleware.error_handling import RetryMiddleware
 from mcp.types import ToolAnnotations
 from mcp_core import resilience as R
@@ -50,9 +49,9 @@ from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
-from mcp_core.runtime import browser_handoff_lifespan
+from mcp_core.runtime import browser_handoff_lifespan, current_mcp_session_id
 from mcp_core.transport import build_client
-from mcp_core.transport.browser_handoff import read_with_handoff
+from mcp_core.transport.browser_handoff import has_pending_handoff, read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -335,10 +334,12 @@ async def _graphql_card(sku: str, ctx: Context | None) -> dict[str, Any]:
 async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
     """Tier-2: render the search page in the operator's Chrome, extract tiles."""
     cache_key = f"search:{query}"
-    cached = _cache.get(cache_key)
+    url = f"{SITE_BASE}/catalogsearch/result/?q={urllib.parse.quote(query)}"
+    scope = current_mcp_session_id(ctx)
+    pending = has_pending_handoff(scope=scope, operation="lamoda_search", url=url)
+    cached = None if pending else _cache.get(cache_key)
     if cached is not None:
         return cached
-    url = f"{SITE_BASE}/catalogsearch/result/?q={urllib.parse.quote(query)}"
 
     async def _attempt() -> dict[str, Any]:
         async def read(page):
@@ -351,10 +352,6 @@ async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
             data.pop("_handoff_expires_at", None)
             return data
 
-        try:
-            scope = (ctx or current_context()).session_id
-        except RuntimeError:
-            scope = None
         async with _cdp_lock:
             await _polite_wait()
             if scope is None:

--- a/packages/mcp-core/src/mcp_core/errors.py
+++ b/packages/mcp-core/src/mcp_core/errors.py
@@ -106,15 +106,24 @@ class PermissionDeniedError(ConnectorError):
 class ChallengeRequiredError(ConnectorError):
     """A marketplace requires a user-mediated browser challenge completion."""
 
-    def __init__(self, message: str, *, provider: str | None = None, challenge_type: str = "captcha") -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider: str | None = None,
+        challenge_type: str = "captcha",
+        handoff_expires_at: str | None = None,
+    ) -> None:
         super().__init__(ErrorCode.CHALLENGE_REQUIRED, message, provider=provider, status_code=403)
         self.challenge_type = challenge_type
+        self.handoff_expires_at = handoff_expires_at
 
     def to_dict(self) -> dict:
         return {
             **super().to_dict(),
             "requires_user_action": True,
             "challenge_type": self.challenge_type,
+            **({"handoff_expires_at": self.handoff_expires_at} if self.handoff_expires_at else {}),
         }
 
 

--- a/packages/mcp-core/src/mcp_core/runtime.py
+++ b/packages/mcp-core/src/mcp_core/runtime.py
@@ -32,13 +32,21 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from fastmcp.server.dependencies import get_http_request
+from fastmcp.server.dependencies import get_context, get_http_request
 from fastmcp.server.middleware import Middleware
 
 from mcp_core.logging import log_event
 
 if TYPE_CHECKING:
-    from fastmcp import FastMCP
+    from fastmcp import Context, FastMCP
+
+
+def current_mcp_session_id(ctx: Context | None = None) -> str | None:
+    """Resolve direct and mounted tool calls; CLI probes have no MCP session."""
+    try:
+        return (ctx or get_context()).session_id
+    except RuntimeError:
+        return None
 
 
 @asynccontextmanager

--- a/packages/mcp-core/src/mcp_core/runtime.py
+++ b/packages/mcp-core/src/mcp_core/runtime.py
@@ -26,6 +26,9 @@ from __future__ import annotations
 import logging
 import os
 import secrets
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -36,6 +39,18 @@ from mcp_core.logging import log_event
 
 if TYPE_CHECKING:
     from fastmcp import FastMCP
+
+
+@asynccontextmanager
+async def browser_handoff_lifespan(server: FastMCP) -> AsyncIterator[dict]:
+    """Release loaded CDP leases without requiring the optional browser extra."""
+    try:
+        yield {}
+    finally:
+        handoff = sys.modules.get("mcp_core.transport.browser_handoff")
+        if handoff is not None:
+            await handoff.close_handoffs()
+
 
 # The transport strings FastMCP 3.x accepts for these servers. "stdio" is the
 # default and the only one existing client configs rely on. "http" is the

--- a/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
+++ b/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
@@ -62,8 +62,21 @@ class _Lease:
 _leases: dict[Key, _Lease] = {}
 
 
+def _key(scope: str, operation: str, url: str) -> Key:
+    return scope, operation, url, chrome_cdp.CDP_URL, chrome_cdp.SCRAPING_PROFILE
+
+
+def has_pending_handoff(*, scope: str | None, operation: str, url: str) -> bool:
+    """Whether this exact operation owns a lease, including busy/expiring cleanup."""
+    if not scope:
+        return False
+    return _key(scope, operation, url) in _leases
+
+
 async def _run(key: Key, lease: _Lease, url: str, wait_ms: int) -> None:
     current: _Request | None = None
+    terminal_error: Exception = TransportDownError("Browser handoff ended; retry the operation")
+    cancelled = False
     guard = object()
     chrome_cdp._HANDOFF_VISIBILITY_GUARDS.add(guard)
     try:
@@ -90,25 +103,38 @@ async def _run(key: Key, lease: _Lease, url: str, wait_ms: int) -> None:
                 finally:
                     lease.cleaning = True
     except TimeoutError:
+        terminal_error = UpstreamTimeoutError("Browser handoff deadline expired")
         if current is not None and not current.result.done():
-            current.result.set_exception(UpstreamTimeoutError("Browser handoff deadline expired"))
+            current.result.set_exception(terminal_error)
     except asyncio.CancelledError:
+        cancelled = True
         if current is not None and not current.result.done():
             current.result.cancel()
         raise
     except Exception as exc:
+        terminal_error = exc
         if current is not None and not current.result.done():
             current.result.set_exception(exc)
     finally:
         lease.cleaning = True
         chrome_cdp._HANDOFF_VISIBILITY_GUARDS.discard(guard)
+        if _leases.get(key) is lease:
+            del _leases[key]
+        # A retry may wake Queue.get just before deadline cancellation. In that
+        # case get has not dequeued it, and ``current`` is still None. Settle
+        # every queued caller on all exits, before cleanup yields again.
+        while not lease.requests.empty():
+            pending = lease.requests.get_nowait()
+            if not pending.result.done():
+                if cancelled:
+                    pending.result.cancel()
+                else:
+                    pending.result.set_exception(terminal_error)
         if chrome_cdp.STEALTH and not chrome_cdp._HANDOFF_VISIBILITY_GUARDS:
             try:
                 await asyncio.wait_for(asyncio.to_thread(chrome_cdp._hide_chrome_windows), timeout=8)
             except Exception:
                 pass
-        if _leases.get(key) is lease:
-            del _leases[key]
 
 
 async def _stop(lease: _Lease) -> None:
@@ -124,13 +150,16 @@ async def _stop(lease: _Lease) -> None:
         finally:
             # A task cancelled before its first instruction never enters _run's
             # finally block. Remove only that lease, never its replacement.
-            for key, registered in tuple(_leases.items()):
-                if registered is lease:
-                    del _leases[key]
-            while not lease.requests.empty():
-                pending = lease.requests.get_nowait()
-                if not pending.result.done():
-                    pending.result.cancel()
+            # A second caller cancellation may interrupt this shield while
+            # transport cleanup continues; _run still owns that registry slot.
+            if lease.task.done():
+                for key, registered in tuple(_leases.items()):
+                    if registered is lease:
+                        del _leases[key]
+                while not lease.requests.empty():
+                    pending = lease.requests.get_nowait()
+                    if not pending.result.done():
+                        pending.result.cancel()
 
 
 async def close_handoffs() -> None:
@@ -160,7 +189,7 @@ async def read_with_handoff(
         async with chrome_cdp.open_page(url, wait_ms, allowed_hosts=allowed_hosts) as page:
             return await read(page), None
 
-    key = (scope, operation, url, chrome_cdp.CDP_URL, chrome_cdp.SCRAPING_PROFILE)
+    key = _key(scope, operation, url)
     loop = asyncio.get_running_loop()
     lease = _leases.get(key)
     if lease is not None and lease.busy:

--- a/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
+++ b/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
@@ -1,0 +1,197 @@
+"""Bounded, process-local ownership of browser challenge tabs.
+
+No browser storage or extracted content is persisted. A lease keeps its original
+context manager alive; resuming never searches for tabs or navigates again.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import math
+import os
+from collections.abc import Awaitable, Callable, Collection
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from urllib.parse import urlsplit
+
+from mcp_core.errors import TransportDownError, UpstreamTimeoutError
+from mcp_core.transport import chrome_cdp
+from mcp_core.transport.chrome_cdp import PageLike
+
+Read = Callable[[PageLike], Awaitable[dict[str, Any]]]
+Challenge = Callable[[dict[str, Any]], str | None]
+Result = tuple[dict[str, Any], str | None]
+Key = tuple[str, str, str, str, str]
+_MAX_LEASES = 4
+
+
+class HandoffBusyError(TransportDownError):
+    """An owned tab is already being read, or the bounded registry is full."""
+
+    def __init__(self) -> None:
+        super().__init__("Browser handoff is busy; retry the same operation later", status_code=409)
+
+
+def _duration_s() -> float:
+    try:
+        value = float(os.environ.get("CHROME_CHALLENGE_HANDOFF_S", "0"))
+    except ValueError:
+        return 0
+    return min(value, 300) if math.isfinite(value) and value > 0 else 0
+
+
+@dataclass
+class _Request:
+    read: Read
+    challenge: Challenge
+    hosts: frozenset[str]
+    result: asyncio.Future[Result]
+
+
+@dataclass
+class _Lease:
+    deadline: float
+    expires_at: str
+    requests: asyncio.Queue[_Request] = field(default_factory=asyncio.Queue)
+    busy: bool = True
+    cleaning: bool = False
+    task: asyncio.Task[None] | None = None
+
+
+_leases: dict[Key, _Lease] = {}
+
+
+async def _run(key: Key, lease: _Lease, url: str, wait_ms: int) -> None:
+    current: _Request | None = None
+    guard = object()
+    chrome_cdp._HANDOFF_VISIBILITY_GUARDS.add(guard)
+    try:
+        current = await lease.requests.get()
+        async with asyncio.timeout_at(lease.deadline):
+            async with chrome_cdp.open_page(url, wait_ms, allowed_hosts=current.hosts) as page:
+                try:
+                    while True:
+                        chrome_cdp._check_final_host(await chrome_cdp.current_page_url(page), current.hosts)
+                        payload = await current.read(page)
+                        # Navigation during extraction also invalidates the result.
+                        chrome_cdp._check_final_host(await chrome_cdp.current_page_url(page), current.hosts)
+                        blocked = current.challenge(payload)
+                        if not blocked:
+                            current.result.set_result((payload, None))
+                            return
+                        await chrome_cdp.reveal_owned_page(page)
+                        lease.busy = False
+                        current.result.set_result((payload, lease.expires_at))
+                        # Do not retain payloads, futures, or caller closures between requests.
+                        del payload
+                        current = None
+                        current = await lease.requests.get()
+                finally:
+                    lease.cleaning = True
+    except TimeoutError:
+        if current is not None and not current.result.done():
+            current.result.set_exception(UpstreamTimeoutError("Browser handoff deadline expired"))
+    except asyncio.CancelledError:
+        if current is not None and not current.result.done():
+            current.result.cancel()
+        raise
+    except Exception as exc:
+        if current is not None and not current.result.done():
+            current.result.set_exception(exc)
+    finally:
+        lease.cleaning = True
+        chrome_cdp._HANDOFF_VISIBILITY_GUARDS.discard(guard)
+        if chrome_cdp.STEALTH and not chrome_cdp._HANDOFF_VISIBILITY_GUARDS:
+            try:
+                await asyncio.wait_for(asyncio.to_thread(chrome_cdp._hide_chrome_windows), timeout=8)
+            except Exception:
+                pass
+        if _leases.get(key) is lease:
+            del _leases[key]
+
+
+async def _stop(lease: _Lease) -> None:
+    if lease.task is not None:
+        # A second cancellation must not interrupt the transport's bounded tab
+        # close while the first cancellation (or normal success) is cleaning up.
+        if not lease.cleaning and not lease.task.cancelling():
+            lease.task.cancel()
+        try:
+            await asyncio.shield(lease.task)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            # A task cancelled before its first instruction never enters _run's
+            # finally block. Remove only that lease, never its replacement.
+            for key, registered in tuple(_leases.items()):
+                if registered is lease:
+                    del _leases[key]
+            while not lease.requests.empty():
+                pending = lease.requests.get_nowait()
+                if not pending.result.done():
+                    pending.result.cancel()
+
+
+async def close_handoffs() -> None:
+    """Release all owned tabs during graceful server shutdown."""
+    await asyncio.gather(*(_stop(lease) for lease in tuple(_leases.values())))
+
+
+async def read_with_handoff(
+    *,
+    url: str,
+    wait_ms: int,
+    scope: str | None,
+    operation: str,
+    read: Read,
+    challenge: Challenge,
+    allowed_hosts: Collection[str] | None = None,
+) -> Result:
+    """Read once, or resume the exact same session's owned challenge tab.
+
+    Retention requires explicit positive CHROME_CHALLENGE_HANDOFF_S, a session
+    scope and a headed browser. Expiry includes initial attach/navigation and is
+    never extended by retries. The returned timestamp only describes retention;
+    foreground activation is best-effort on the connected browser's machine.
+    """
+    duration = _duration_s()
+    if not duration or not scope or chrome_cdp.HEADLESS:
+        async with chrome_cdp.open_page(url, wait_ms, allowed_hosts=allowed_hosts) as page:
+            return await read(page), None
+
+    key = (scope, operation, url, chrome_cdp.CDP_URL, chrome_cdp.SCRAPING_PROFILE)
+    loop = asyncio.get_running_loop()
+    lease = _leases.get(key)
+    if lease is not None and lease.busy:
+        raise HandoffBusyError()
+    if lease is not None and lease.deadline <= loop.time():
+        # Mark busy until cleanup completes: a concurrent retry must not open a duplicate.
+        lease.busy = True
+        await _stop(lease)
+        lease = None
+    if lease is None:
+        if len(_leases) >= _MAX_LEASES:
+            raise HandoffBusyError()
+        lease = _Lease(
+            deadline=loop.time() + duration,
+            expires_at=(datetime.now(UTC) + timedelta(seconds=duration)).isoformat(),
+        )
+        _leases[key] = lease
+    lease.busy = True
+    hosts = frozenset(allowed_hosts or {urlsplit(url).hostname or ""})
+    result: asyncio.Future[Result] = loop.create_future()
+    lease.requests.put_nowait(_Request(read, challenge, hosts, result))
+    if lease.task is None:
+        lease.task = asyncio.create_task(_run(key, lease, url, wait_ms), name="browser-handoff")
+    try:
+        response = await asyncio.shield(result)
+        if response[1] is None:
+            await asyncio.shield(lease.task)
+        return response
+    except BaseException:
+        await _stop(lease)
+        # Consume a concurrent extractor failure if cancellation won the race.
+        if result.done() and not result.cancelled():
+            result.exception()
+        raise

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -143,6 +143,10 @@ STEALTH = os.environ.get("CHROME_STEALTH", "1") != "0"
 # headless Chrome readily, so this stays off by default.
 HEADLESS = os.environ.get("CHROME_HEADLESS", "0") == "1"
 
+# Owned challenge workers hold a guard throughout their lifecycle. Other reads
+# must not hide a profile window while the operator is using a retained tab.
+_HANDOFF_VISIBILITY_GUARDS: set[object] = set()
+
 
 def _chrome_candidates() -> list[str]:
     """Chrome/Chromium executables to try, most preferred first."""
@@ -357,6 +361,8 @@ def _hide_chrome_windows() -> None:
     the app the way ⌘H does — the window keeps its Space and never takes focus,
     which is what stops the desktop from switching mid-call.
     """
+    if _HANDOFF_VISIBILITY_GUARDS:
+        return
     if sys.platform == "darwin":
         for pid in _scraping_profile_pids():
             try:
@@ -678,6 +684,53 @@ class _RawCdpPage:
             await self._send("Target.closeTarget", {"targetId": self._target_id}, timeout=10.0)
         except Exception:
             pass
+
+
+async def current_page_url(page: PageLike) -> str:
+    """Refresh raw-CDP navigation state without reading document content."""
+    if isinstance(page, _RawCdpPage):
+        result = await page._send("Page.getFrameTree")
+        url = result.get("frameTree", {}).get("frame", {}).get("url")
+        if not isinstance(url, str) or not url:
+            raise RuntimeError("CDP returned no current main frame URL")
+        page._url = url
+        return url
+    return page.url
+
+
+async def reveal_owned_page(page: PageLike) -> bool:
+    """Best-effort reveal of the owned target's window, never all profile windows."""
+    session: Any = None
+    try:
+        async with asyncio.timeout(_RAW_CONNECT_TIMEOUT_S):
+            if isinstance(page, _RawCdpPage):
+                send = page._send
+                target_id = page._target_id
+            elif isinstance(page, Page):
+                session = await page.context.new_cdp_session(page)
+                send = session.send
+                target_id = (await send("Target.getTargetInfo"))["targetInfo"]["targetId"]
+            else:
+                return False
+            info = await send("Browser.getWindowForTarget", {"targetId": target_id})
+            window_id = info["windowId"]
+            await send("Browser.setWindowBounds", {"windowId": window_id, "bounds": {"windowState": "normal"}})
+            bounds = info.get("bounds", {})
+            if bounds.get("left", 0) < -10000 or bounds.get("top", 0) < -10000:
+                await send("Browser.setWindowBounds", {"windowId": window_id, "bounds": {"left": 80, "top": 80}})
+            if isinstance(page, Page):
+                await page.bring_to_front()
+            else:
+                await send("Page.bringToFront")
+            return True
+    except Exception:
+        return False
+    finally:
+        if session is not None:
+            try:
+                await asyncio.wait_for(session.detach(), timeout=_RAW_CONNECT_TIMEOUT_S)
+            except Exception:
+                pass
 
 
 @asynccontextmanager

--- a/packages/mcp-core/tests/test_browser_handoff.py
+++ b/packages/mcp-core/tests/test_browser_handoff.py
@@ -369,3 +369,82 @@ async def test_cancel_during_success_cleanup_waits_for_exact_owned_close(browser
         await caller
     assert closed.is_set()
     assert not handoff._leases
+
+
+async def test_idle_expiry_settles_retry_queued_before_getter_resumes(browser, monkeypatch):
+    original_timeout_at = asyncio.timeout_at
+    deadlines = []
+
+    def capture_timeout(when):
+        timeout = original_timeout_at(when)
+        deadlines.append(timeout)
+        return timeout
+
+    monkeypatch.setattr(handoff.asyncio, "timeout_at", capture_timeout)
+    await call()
+    lease = next(iter(handoff._leases.values()))
+    original_put = lease.requests.put_nowait
+    reader = AsyncMock(return_value={"products": ["should not run"]})
+
+    def put_at_deadline(request):
+        original_put(request)
+        # Deliver the real timeout cancellation after waking Queue.get, before
+        # the worker can dequeue/assign ``current``. No timing sleeps required.
+        deadlines[0]._on_timeout()
+
+    monkeypatch.setattr(lease.requests, "put_nowait", put_at_deadline)
+    with pytest.raises(UpstreamTimeoutError, match="deadline expired"):
+        await asyncio.wait_for(call(read=reader), timeout=1)
+    reader.assert_not_called()
+    assert lease.requests.empty()
+    assert browser[0].closed
+    assert not handoff._leases
+
+
+async def test_pending_lookup_includes_busy_expired_lease_without_mutation(browser, monkeypatch):
+    lookup = {"scope": "session-1", "operation": "search", "url": "https://shop.test/search?q=a"}
+    assert not handoff.has_pending_handoff(**lookup)
+    await call()
+    lease = next(iter(handoff._leases.values()))
+    assert handoff.has_pending_handoff(**lookup)
+    lease.busy = True
+    lease.deadline = asyncio.get_running_loop().time() - 1
+    assert handoff.has_pending_handoff(**lookup)
+    assert next(iter(handoff._leases.values())) is lease
+    for changes in ({"scope": None}, {"scope": "other"}, {"operation": "card"}, {"url": "https://shop.test/"}):
+        assert not handoff.has_pending_handoff(**{**lookup, **changes})
+    monkeypatch.setattr(chrome_cdp, "CDP_URL", "http://different.test:9222")
+    assert not handoff.has_pending_handoff(**lookup)
+
+
+async def test_second_caller_cancellation_keeps_lease_until_worker_closes(browser, monkeypatch):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    closed = asyncio.Event()
+
+    @asynccontextmanager
+    async def delayed_close(url, wait_ms=0, *, allowed_hosts=None):
+        try:
+            yield SimpleNamespace(url=url, extracted=0)
+        finally:
+            entered.set()
+            await release.wait()
+            closed.set()
+
+    monkeypatch.setattr(chrome_cdp, "open_page", delayed_close)
+    caller = asyncio.create_task(call(read=success))
+    await entered.wait()
+    lease = next(iter(handoff._leases.values()))
+    caller.cancel()
+    await asyncio.sleep(0)
+    caller.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    assert not closed.is_set()
+    assert next(iter(handoff._leases.values())) is lease
+    assert not lease.task.done()
+    assert chrome_cdp._HANDOFF_VISIBILITY_GUARDS
+    release.set()
+    await asyncio.wait_for(lease.task, timeout=1)
+    assert closed.is_set()
+    assert not handoff._leases

--- a/packages/mcp-core/tests/test_browser_handoff.py
+++ b/packages/mcp-core/tests/test_browser_handoff.py
@@ -1,0 +1,371 @@
+"""Ownership, bounded recovery and cancellation checks without real browser data."""
+
+from __future__ import annotations
+
+import asyncio
+import gc
+import weakref
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from mcp_core.errors import UpstreamTimeoutError
+from mcp_core.transport import browser_handoff as handoff
+from mcp_core.transport import chrome_cdp
+
+
+@pytest.fixture
+async def browser(monkeypatch):
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", "30")
+    monkeypatch.setattr(chrome_cdp, "HEADLESS", False)
+    pages = []
+
+    @asynccontextmanager
+    async def open_page(url, wait_ms=0, *, allowed_hosts=None):
+        page = SimpleNamespace(url=url, closed=False, extracted=0, released=asyncio.Event())
+        pages.append(page)
+        try:
+            yield page
+        finally:
+            page.closed = True
+            page.released.set()
+
+    monkeypatch.setattr(chrome_cdp, "open_page", open_page)
+    monkeypatch.setattr(chrome_cdp, "reveal_owned_page", AsyncMock(return_value=True))
+    monkeypatch.setattr(chrome_cdp, "_hide_chrome_windows", lambda: None)
+    yield pages
+    await handoff.close_handoffs()
+    assert not handoff._leases
+    assert not chrome_cdp._HANDOFF_VISIBILITY_GUARDS
+
+
+async def blocked(page):
+    page.extracted += 1
+    return {"challenge": "captcha", "visit": page.extracted}
+
+
+async def success(page):
+    page.extracted += 1
+    return {"products": ["observed"]}
+
+
+def call(**kwargs):
+    return handoff.read_with_handoff(
+        **{
+            "url": "https://shop.test/search?q=a",
+            "wait_ms": 0,
+            "scope": "session-1",
+            "operation": "search",
+            "read": blocked,
+            "challenge": lambda payload: payload.get("challenge"),
+            **kwargs,
+        }
+    )
+
+
+@pytest.mark.parametrize("duration", ["0", "-1", "bad", "nan", "inf", "-inf", ""])
+async def test_disabled_or_invalid_duration_preserves_short_lifecycle(browser, monkeypatch, duration):
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", duration)
+    payload, expiry = await call()
+    assert payload["challenge"] == "captcha"
+    assert expiry is None
+    assert browser[0].closed
+    assert not handoff._leases
+
+
+async def test_missing_scope_and_headless_disable_retention(browser, monkeypatch):
+    assert (await call(scope=None))[1] is None
+    monkeypatch.setattr(chrome_cdp, "HEADLESS", True)
+    assert (await call())[1] is None
+    assert all(page.closed for page in browser)
+
+
+def test_duration_has_hard_five_minute_cap(monkeypatch):
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", "999999")
+    assert handoff._duration_s() == 300
+
+
+async def test_challenge_resumes_exact_page_with_new_read_and_immutable_expiry(browser):
+    first, expiry = await call()
+    assert expiry is not None
+    assert first["visit"] == 1
+    assert not browser[0].closed
+    again, next_expiry = await call()
+    assert again["visit"] == 2
+    assert next_expiry == expiry
+    payload, final_expiry = await call(read=success)
+    assert payload == {"products": ["observed"]}
+    assert final_expiry is None
+    assert len(browser) == 1  # Opening a context is the only navigation path.
+    assert browser[0].closed
+    assert not handoff._leases
+
+
+@pytest.mark.parametrize(
+    "changes",
+    [{"scope": "session-2"}, {"operation": "card"}, {"url": "https://shop.test/search?q=b"}],
+)
+async def test_other_session_operation_or_query_never_adopts_retained_page(browser, changes):
+    await call()
+    await call(**changes)
+    assert len(browser) == 2
+    assert all(not page.closed for page in browser)
+
+
+@pytest.mark.parametrize("setting", ["CDP_URL", "SCRAPING_PROFILE"])
+async def test_other_endpoint_or_profile_never_adopts_retained_page(browser, monkeypatch, setting):
+    await call()
+    monkeypatch.setattr(chrome_cdp, setting, "other-private-value")
+    await call()
+    assert len(browser) == 2
+
+
+async def test_busy_initial_and_resume_never_open_duplicate(browser):
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def pending(page):
+        started.set()
+        await release.wait()
+        return await blocked(page)
+
+    for _ in range(2):
+        started.clear()
+        release.clear()
+        task = asyncio.create_task(call(read=pending))
+        await started.wait()
+        with pytest.raises(handoff.HandoffBusyError) as caught:
+            await call()
+        assert caught.value.status_code == 409
+        assert caught.value.code.retryable
+        release.set()
+        await task
+    assert len(browser) == 1
+
+
+async def test_retention_expires_and_closes_without_a_retry(browser, monkeypatch):
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", "0.05")
+    await call()
+    task = next(iter(handoff._leases.values())).task
+    await asyncio.wait_for(browser[0].released.wait(), timeout=1)
+    await asyncio.wait_for(task, timeout=1)
+    assert not handoff._leases
+
+
+async def test_deadline_cancels_extractor_and_closes(browser, monkeypatch):
+    monkeypatch.setenv("CHROME_CHALLENGE_HANDOFF_S", "0.05")
+    cancelled = asyncio.Event()
+
+    async def pending(page):
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    with pytest.raises(UpstreamTimeoutError):
+        await call(read=pending)
+    assert cancelled.is_set()
+    assert browser[0].closed
+
+
+@pytest.mark.parametrize("resume", [False, True])
+async def test_caller_cancellation_cleans_worker_and_owned_page(browser, resume):
+    if resume:
+        await call()
+    started = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def pending(page):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    task = asyncio.create_task(call(read=pending))
+    await started.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert cancelled.is_set()
+    assert browser[0].closed
+    assert not handoff._leases
+
+
+async def test_extractor_failure_releases_retained_page(browser):
+    await call()
+
+    async def fail(page):
+        raise ValueError("extractor failed")
+
+    with pytest.raises(ValueError, match="extractor failed"):
+        await call(read=fail)
+    assert browser[0].closed
+
+
+async def test_moved_page_is_closed_before_new_extraction(browser):
+    await call()
+    browser[0].url = "https://outside.test/private"
+    read = AsyncMock()
+    with pytest.raises(chrome_cdp.NavigationPolicyError):
+        await call(read=read)
+    read.assert_not_called()
+    assert browser[0].closed
+
+
+async def test_new_policy_checked_on_resume_and_navigation_during_read_rejected(browser):
+    await call(allowed_hosts=["shop.test", "login.shop.test"])
+    browser[0].url = "https://login.shop.test/challenge"
+    with pytest.raises(chrome_cdp.NavigationPolicyError):
+        await call(allowed_hosts=["shop.test"])
+
+    async def navigate(page):
+        page.url = "https://outside.test/private"
+        return {"products": ["should not escape"]}
+
+    with pytest.raises(chrome_cdp.NavigationPolicyError):
+        await call(read=navigate)
+    assert all(page.closed for page in browser)
+
+
+async def test_capacity_does_not_evict_an_existing_handoff(browser):
+    for index in range(4):
+        await call(scope=f"session-{index}")
+    with pytest.raises(handoff.HandoffBusyError):
+        await call(scope="overflow")
+    assert len(browser) == 4
+    await call(scope="session-0", read=success)
+    await call(scope="overflow")
+    assert len(browser) == 5
+
+
+async def test_shutdown_releases_all_pages(browser):
+    await call(scope="one")
+    await call(scope="two")
+    await handoff.close_handoffs()
+    assert all(page.closed for page in browser)
+    assert not handoff._leases
+
+
+async def test_challenge_worker_does_not_hold_caller_closure_or_payload(browser):
+    class Payload(dict):
+        pass
+
+    class Reader:
+        async def __call__(self, page):
+            return Payload(challenge="captcha")
+
+    reader = Reader()
+    reader_ref = weakref.ref(reader)
+    payload, _ = await call(read=reader)
+    payload_ref = weakref.ref(payload)
+    del payload, reader
+    # asyncio's completed shield callback lives until the next event-loop tick.
+    await asyncio.sleep(0)
+    gc.collect()
+    assert reader_ref() is None
+    assert payload_ref() is None
+
+
+async def test_hide_guard_is_active_only_for_owned_workers(browser, monkeypatch):
+    await call()
+    assert chrome_cdp._HANDOFF_VISIBILITY_GUARDS
+    monkeypatch.setattr(chrome_cdp.sys, "platform", "darwin")
+    lookup = AsyncMock()
+    monkeypatch.setattr(chrome_cdp, "_scraping_profile_pids", lookup)
+    chrome_cdp._hide_chrome_windows()
+    lookup.assert_not_called()
+    await call(read=success)
+    assert not chrome_cdp._HANDOFF_VISIBILITY_GUARDS
+
+
+async def test_raw_current_url_refreshes_cached_navigation_without_dom_evaluation():
+    page = chrome_cdp._RawCdpPage(AsyncMock(), "owned")
+    page._send = AsyncMock(return_value={"frameTree": {"frame": {"url": "https://new.test/"}}})
+    assert await chrome_cdp.current_page_url(page) == "https://new.test/"
+    page._send.assert_awaited_once_with("Page.getFrameTree")
+
+
+async def test_raw_reveal_restores_only_owned_window():
+    page = chrome_cdp._RawCdpPage(AsyncMock(), "owned")
+    page._send = AsyncMock(side_effect=[{"windowId": 42, "bounds": {"left": -32000}}, {}, {}, {}])
+    assert await chrome_cdp.reveal_owned_page(page)
+    calls = page._send.call_args_list
+    assert calls[0].args == ("Browser.getWindowForTarget", {"targetId": "owned"})
+    assert calls[1].args[1] == {"windowId": 42, "bounds": {"windowState": "normal"}}
+    assert calls[2].args[1] == {"windowId": 42, "bounds": {"left": 80, "top": 80}}
+    assert calls[3].args == ("Page.bringToFront",)
+
+
+async def test_reveal_failure_is_honest_and_nonfatal():
+    page = chrome_cdp._RawCdpPage(AsyncMock(), "owned")
+    page._send = AsyncMock(side_effect=RuntimeError("unsupported Browser command"))
+    assert await chrome_cdp.reveal_owned_page(page) is False
+
+
+async def test_prestart_cancellation_releases_registry_and_pending_caller(browser):
+    loop = asyncio.get_running_loop()
+    key = ("scope", "operation", "url", "endpoint", "profile")
+    lease = handoff._Lease(deadline=loop.time() + 30, expires_at="unused")
+    future = loop.create_future()
+    lease.requests.put_nowait(handoff._Request(blocked, lambda p: None, frozenset(), future))
+    handoff._leases[key] = lease
+    lease.task = asyncio.create_task(handoff._run(key, lease, "https://shop.test/", 0))
+    # No event-loop yield between task creation and _stop cancelling it.
+    await handoff._stop(lease)
+    assert future.cancelled()
+    assert not handoff._leases
+    assert not browser
+
+
+async def test_expired_retry_cleanup_cannot_create_two_replacements(browser, monkeypatch):
+    await call()
+    lease = next(iter(handoff._leases.values()))
+    lease.deadline = asyncio.get_running_loop().time() - 1
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    original_stop = handoff._stop
+
+    async def delayed_stop(old):
+        entered.set()
+        await release.wait()
+        await original_stop(old)
+
+    monkeypatch.setattr(handoff, "_stop", delayed_stop)
+    first = asyncio.create_task(call())
+    await entered.wait()
+    with pytest.raises(handoff.HandoffBusyError):
+        await call()
+    release.set()
+    await first
+    assert len(browser) == 2
+    assert browser[0].closed and not browser[1].closed
+
+
+async def test_cancel_during_success_cleanup_waits_for_exact_owned_close(browser, monkeypatch):
+    entered = asyncio.Event()
+    release = asyncio.Event()
+    closed = asyncio.Event()
+
+    @asynccontextmanager
+    async def delayed_close(url, wait_ms=0, *, allowed_hosts=None):
+        try:
+            yield SimpleNamespace(url=url, extracted=0)
+        finally:
+            entered.set()
+            await release.wait()
+            closed.set()
+
+    monkeypatch.setattr(chrome_cdp, "open_page", delayed_close)
+    caller = asyncio.create_task(call(read=success))
+    await entered.wait()
+    caller.cancel()
+    await asyncio.sleep(0)
+    assert not closed.is_set()
+    assert not caller.done()
+    release.set()
+    with pytest.raises(asyncio.CancelledError):
+        await caller
+    assert closed.is_set()
+    assert not handoff._leases

--- a/packages/mcp-core/tests/test_errors.py
+++ b/packages/mcp-core/tests/test_errors.py
@@ -8,3 +8,10 @@ def test_challenge_required_error_is_machine_readable_and_retryable():
     assert payload["retryable"] is True
     assert payload["requires_user_action"] is True
     assert payload["challenge_type"] == "captcha"
+    assert "handoff_expires_at" not in payload
+
+
+def test_retained_challenge_has_explicit_expiry():
+    expiry = "2026-09-12T15:00:00Z"
+    payload = ChallengeRequiredError("complete the browser challenge", handoff_expires_at=expiry).to_dict()
+    assert payload["handoff_expires_at"] == expiry

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -42,7 +42,6 @@ import urllib.parse
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
-from fastmcp.server.dependencies import get_context as current_context
 from fastmcp.server.middleware.error_handling import RetryMiddleware
 from mcp.types import ToolAnnotations
 from mcp_core import resilience as R
@@ -61,8 +60,8 @@ from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
-from mcp_core.runtime import browser_handoff_lifespan
-from mcp_core.transport.browser_handoff import read_with_handoff
+from mcp_core.runtime import browser_handoff_lifespan, current_mcp_session_id
+from mcp_core.transport.browser_handoff import has_pending_handoff, read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -423,10 +422,7 @@ async def _cdp_render(url: str, extract_js: str, wait_ms: int, ctx: Context | No
         data.pop("_handoff_expires_at", None)
         return data
 
-    try:
-        scope = (ctx or current_context()).session_id
-    except RuntimeError:
-        scope = None
+    scope = current_mcp_session_id(ctx)
     async with _cdp_lock:
         await _polite_wait()
         if scope is None:
@@ -603,7 +599,8 @@ async def taobao_search(
     try:
         params = urllib.parse.urlencode({"q": query.strip(), "page": str(page)})
         url = f"{SEARCH_BASE}?{params}"
-        cached = _cache.get(url)
+        pending = has_pending_handoff(scope=current_mcp_session_id(ctx), operation="taobao_search", url=url)
+        cached = None if pending else _cache.get(url)
         if cached is not None:
             payload, tier = cached, "cache"
         else:
@@ -698,7 +695,8 @@ async def taobao_card(
                 )
             )
         url = f"{ITEM_BASE}?id={item_id}"
-        cached = _cache.get(url)
+        pending = has_pending_handoff(scope=current_mcp_session_id(ctx), operation="taobao_card", url=url)
+        cached = None if pending else _cache.get(url)
         if cached is not None:
             payload, tier = cached, "cache"
         else:

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -42,6 +42,7 @@ import urllib.parse
 from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
+from fastmcp.server.dependencies import get_context as current_context
 from fastmcp.server.middleware.error_handling import RetryMiddleware
 from mcp.types import ToolAnnotations
 from mcp_core import resilience as R
@@ -60,6 +61,8 @@ from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
+from mcp_core.runtime import browser_handoff_lifespan
+from mcp_core.transport.browser_handoff import read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -91,6 +94,7 @@ _ITEM_ID_RE = re.compile(r"[?&]id=(\d{9,13})\b")
 
 mcp = FastMCP(
     name="taobao-connector",
+    lifespan=browser_handoff_lifespan,
     version=SERVER_VERSION,
     instructions=(
         "Taobao listings: search and item cards, prices in yuan (CNY). Every "
@@ -408,16 +412,37 @@ async def _cdp_render(url: str, extract_js: str, wait_ms: int, ctx: Context | No
     operator's browser. The extracted JSON is capped like any HTTP body — an
     inflated page would otherwise cross the CDP serialization pipeline raw.
     """
+
+    async def read(page):
+        raw = await asyncio.wait_for(page.evaluate(extract_js), timeout=30.0)
+        if not isinstance(raw, str) or len(raw.encode()) > MAX_BODY_BYTES:
+            raise_tool_error(TransportDownError("extracted page data missing or over the body cap"))
+        data = json.loads(raw)
+        if not isinstance(data, dict):
+            raise_tool_error(ParserDriftError("page extractor returned a non-object payload"))
+        data.pop("_handoff_expires_at", None)
+        return data
+
+    try:
+        scope = (ctx or current_context()).session_id
+    except RuntimeError:
+        scope = None
     async with _cdp_lock:
         await _polite_wait()
-        async with open_page(url, wait_ms=wait_ms) as page:
-            raw = await asyncio.wait_for(page.evaluate(extract_js), timeout=30.0)
-    if not isinstance(raw, str) or len(raw.encode()) > MAX_BODY_BYTES:
-        raise ToolError(TransportDownError("extracted page data missing or over the body cap"))
-    data = json.loads(raw)
-    if not isinstance(data, dict):
-        raise ToolError(ParserDriftError("page extractor returned a non-object payload"))
-    return data
+        if scope is None:
+            async with open_page(url, wait_ms=wait_ms) as page:
+                return await read(page)
+        data, expires_at = await read_with_handoff(
+            url=url,
+            wait_ms=wait_ms,
+            scope=scope,
+            operation="taobao_card" if url.startswith(ITEM_BASE) else "taobao_search",
+            read=read,
+            challenge=_page_challenge_kind,
+        )
+        if expires_at:
+            data["_handoff_expires_at"] = expires_at
+        return data
 
 
 # The word test for the wall body snippet: the same markers
@@ -535,6 +560,16 @@ def _anti_bot_challenge(data: dict[str, Any]) -> bool:
     return isinstance(snippet, str) and bool(_CHALLENGE_TEXT_RE.search(snippet))
 
 
+def _page_challenge_kind(data: dict[str, Any]) -> str | None:
+    if _login_wall_markers(data):
+        return "login_or_captcha"
+    if "page_title" in data:
+        price, _ = prices_from_tile(data)
+        if data.get("title") or price is not None or R.coerce_price(data.get("price_cny")) is not None:
+            return None
+    return "captcha" if _anti_bot_challenge(data) else None
+
+
 @mcp.tool(
     name="taobao_search",
     annotations=ToolAnnotations(
@@ -590,6 +625,7 @@ async def taobao_search(
                     "Taobao requires user action in the Chrome scraping profile. Complete the visible login/CAPTCHA challenge, then retry.",
                     provider="taobao",
                     challenge_type="login_or_captcha",
+                    handoff_expires_at=payload.get("_handoff_expires_at"),
                 )
             )
         if _anti_bot_challenge(payload):
@@ -597,6 +633,7 @@ async def taobao_search(
                 ChallengeRequiredError(
                     "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
                     provider="taobao",
+                    handoff_expires_at=payload.get("_handoff_expires_at"),
                 )
             )
         items_raw = payload.get("items") if isinstance(payload.get("items"), list) else []
@@ -683,6 +720,7 @@ async def taobao_card(
                     "Taobao requires user action in the Chrome scraping profile. Complete the visible login/CAPTCHA challenge, then retry.",
                     provider="taobao",
                     challenge_type="login_or_captcha",
+                    handoff_expires_at=payload.get("_handoff_expires_at"),
                 )
             )
         title = payload.get("title")
@@ -697,6 +735,7 @@ async def taobao_card(
                 ChallengeRequiredError(
                     "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
                     provider="taobao",
+                    handoff_expires_at=payload.get("_handoff_expires_at"),
                 )
             )
         if title is None and price is None:

--- a/skills/compare-prices/SKILL.md
+++ b/skills/compare-prices/SKILL.md
@@ -96,8 +96,13 @@ from listings whose marketplace explicitly reports stock.
    source. `retryable=true` means a later retry can succeed after the challenge
    clears; it does not authorize a retry loop. Complete the required interaction
    in the connected scraping profile. A different browser profile has different
-   cookies. The connector closes its temporary tab; retaining the exact challenge
-   tab and automatically resuming are not implemented.
+   cookies. If `handoff_expires_at` is present, the challenged tab is retained:
+   complete the interaction there and repeat in the same MCP session before
+   expiry. The source reads that exact page without new navigation. Otherwise
+   the temporary tab closes normally. Retention is opt-in through
+   `CHROME_CHALLENGE_HANDOFF_S` and currently covers Lamoda search and Taobao
+   search/card DOM challenges. Do not change the original query or arguments
+   when resuming, and do not assume automatic CAPTCHA completion.
 3. After the browser action completes, call `compare_prices` with the same query,
    filters and limit, and `sources` restricted to the failed sources. Do not
    re-query healthy sources merely to recover one marketplace. This retry's

--- a/skills/lamoda-connector/SKILL.md
+++ b/skills/lamoda-connector/SKILL.md
@@ -30,6 +30,9 @@ Chrome over CDP.
   it is not cached. Complete the interaction in the connected Chrome profile,
   then retry. Empty extraction without challenge evidence remains parser drift,
   not proof of "no results".
+- With `CHROME_CHALLENGE_HANDOFF_S` enabled, `handoff_expires_at` confirms a
+  retained search tab. Complete its interaction, then repeat the same query in
+  the same MCP session before expiry to read that tab without a new navigation.
 - A missing price is `null`, never `0`: `price_rub: null` means Lamoda had no
   usable price — treat it as no data, never as a free item.
 ## DSH activation

--- a/skills/marketplace/SKILL.md
+++ b/skills/marketplace/SKILL.md
@@ -51,7 +51,10 @@ everything else is unaffected.
   before scheduling retries. Keep answered sources visible, show the affected
   marketplace and `challenge_type`, and retry that source after the browser
   interaction completes. A challenge is not an empty product search. See the
-  compare-prices skill for the retry contract and current tab-retention limits.
+  compare-prices skill for the retry contract. `handoff_expires_at` confirms that
+  the source retained its tab; repeat the same operation in the same MCP session
+  after browser action and before that expiry. See docs/CDP_SETUP.md for opt-in
+  configuration and supported sources.
 - A source whose optional deps are missing is simply absent from the set —
   `marketplace_sources` says which and why.
 - Set `MARKETPLACE_SOURCES` on the unified server to mount only a comma-separated

--- a/skills/taobao-connector/SKILL.md
+++ b/skills/taobao-connector/SKILL.md
@@ -32,6 +32,10 @@ connector's canary at once.
   `requires_user_action=true`. Complete it in the scraping profile before retrying
   the same operation. Failed payloads are not cached; a retry reads the browser
   again. Successful results still use the normal TTL cache.
+- With `CHROME_CHALLENGE_HANDOFF_S` enabled, `handoff_expires_at` confirms that
+  the challenged search/card tab is retained. Complete its interaction, then
+  repeat the same tool arguments in the same MCP session before expiry. No new
+  navigation is issued for that resume; expiry never extends on retries.
 - The operator's Chrome must be running with CDP (scripts/start_chrome_cdp.sh).
 ## DSH activation
 

--- a/work/evals/visual-evidence-contract.md
+++ b/work/evals/visual-evidence-contract.md
@@ -59,29 +59,31 @@ metadata, with no automatic retries. Taobao and Lamoda search use the new code;
 other adapters can still return legacy transport failures. A subset retry uses
 the existing `sources` argument and does not merge old observations on the server.
 
-Remaining implementation: an opt-in, bounded browser handoff must retain only
-the challenged owned tab, stop navigation by other tasks into that tab, expose
-the same profile to the operator, expire abandoned handoffs, and resume once
-after completion. Both Playwright and raw-CDP paths currently close temporary
-tabs in `finally`; claiming exact-tab resume today would be incorrect. Test
-success, cancellation, expiration, concurrent source queries, and process restart
-before advertising seamless resume. Compare latency, requests, challenge rate,
-and completion rate on the same task set before claiming an improvement over
-the existing parser/CDP flow.
+Implemented opt-in handoff: `CHROME_CHALLENGE_HANDOFF_S` retains the owned page
+context for Lamoda search and Taobao search/card DOM challenges. Same-session
+repeats with the same operation, URL and profile read the retained page without
+`goto`. Four process-local leases are allowed, capped at 300 seconds including
+initial attachment. `handoff_expires_at` is reported only when retained; repeated
+challenges never extend it. Success, failure, cancellation, expiry and graceful
+shutdown release the context. Foreground activation is best-effort. Raw HTTP
+errors rejected before DOM extraction cannot be handed off by this version.
+
+Still pending: native-vision image delivery in the host, autonomous challenge
+completion, and identical-task comparisons of latency, requests, challenge rate
+and completion rate. No universal improvement over parser/CDP operation is claimed.
 
 ### Implementation constraints from the lifecycle audit
 
-Challenge detection in Lamoda and Taobao currently runs after the page context
-has closed. Move decoding and classification inside the owned context before
-introducing retention; changing `finally` alone cannot retain the right page.
-Keep handles scoped to the MCP session, provider, original input and CDP endpoint.
-Resume must atomically claim the exact target ID, avoid `goto`, recheck the current
-host policy, and retain the original expiry rather than extending it on every
-retry. A retry in another session must not adopt a tab by matching its URL.
+The lifecycle audit found that challenge detection ran after the page context
+closed. Decoding and classification now run inside the retained context. The
+runtime binds leases to the MCP session, provider operation, original URL and CDP
+endpoint/profile. Resume atomically claims that context, avoids `goto`, rechecks
+the current host policy before and after reading, and retains the original expiry.
+A retry in another session never adopts the page by matching its URL.
 
 Ordinary connector cleanup hides the scraping-profile browser globally on Windows
-and macOS. Active handoffs must suppress this hiding, and explicit handoff must
-reveal the owned window; activating a target alone does not prove visibility.
+and macOS. Active handoffs now suppress this hiding and attempt to restore the
+owned window's bounds; a successful protocol command is not proof of OS visibility.
 Expiry, cancellation and shutdown may close only recorded owned targets. An
 in-memory lease cannot guarantee cleanup after a hard process kill while Chrome
 survives: document this limit and reject stale handles after restart rather than
@@ -103,3 +105,19 @@ normal context exit. Injecting failure into `/json` discovery after real target
 creation also removed the owned target. Pre-existing target IDs were unchanged
 in both cases. This covers normal operation and one attachment failure; it is
 not a guarantee of cleanup when Chrome itself becomes unreachable.
+
+The retained-context runtime was exercised on real Chrome with a local HTML
+fixture: a marker set before the challenge remained present on resume, proving
+there was no new navigation. An independent browser request completed while the
+lease remained intact. Clicking the fixture's continue button and repeating the
+read closed only the retained target; all pre-existing target IDs were preserved.
+This is a lifecycle test, not a solved marketplace CAPTCHA. MCP Client tests also
+cover actual Lamoda/Taobao dispatch, session isolation, expiry propagation and
+graceful shutdown. Native vision remains a host-side integration task.
+
+A real MCP Client → compare → Lamoda probe on 2026-09-12 also returned
+`challenge_required` with a retained expiry and one live owned page. Chrome
+additionally exposed two worker targets, so verification counts page targets
+separately rather than assuming every CDP target is a tab. Graceful MCP shutdown
+removed the owned page and preserved all pre-existing pages. The marketplace
+challenge itself was not completed in this probe.


### PR DESCRIPTION
Lamoda and Taobao previously closed a challenge tab before the caller could complete it. An opt-in `CHROME_CHALLENGE_HANDOFF_S` now retains DOM-detected Lamoda search and Taobao search/card challenges. Repeating the same operation in the same MCP session reads the exact live page without navigating again; errors and comparison outcomes expose `handoff_expires_at` only while retained.

Leases are scoped by session, operation, URL and CDP/profile, capped at four per process and 300 seconds including initial attachment. Retries never extend expiry. Success, errors, expiry, caller cancellation and graceful shutdown release owned tabs. Active handoffs suppress global profile hiding and attempt to reveal only the owned window. The default remains disabled, with no new MCP tools or mandatory browser dependency for the base compare profile.

Validation:
- Common core: 418 passed, including cancellation/expiry races, prestart cancellation, capacity, scope isolation, fresh URL checks and cleanup.
- Compare/Taobao/Lamoda/DSH integration selection: 271 passed; real MCP Client tests cover same-tab source dispatch, separate sessions, shutdown and browser-less imports.
- Ruff, mypy, version/stdout/test-count and wire gates pass. Offline collection: 1485; schemas remain approximately 1551/16077 tokens.
- Real Chrome local fixture retained DOM state across resume with an independent request in between, then closed only the owned target.
- Real MCP Client → compare → Lamoda produced a retained challenge page; graceful shutdown removed it and preserved existing pages. CDP worker targets were counted separately from page targets after an initial overly broad observer assertion.

Limits: no CAPTCHA solver or native-vision image delivery; only DOM challenges yielded by the transport are retained, not early HTTP errors. Foreground activation is best-effort. Hard process kills cannot enforce expiry in an external Chrome. Source/vendored skills, setup docs and the existing research record describe these limits. Attribution remains maintainer work; no third-party code was copied.

Independent review caught and resolved two issues before merge: queued retries now settle when an idle lease expires, and a pending session-owned tab takes precedence over another session's successful cache. Added deadline-order, repeated-cancellation, and cross-session cache regressions. Follow-up review found no remaining issues in those fixes.

Final CI run 34702841411 for the reviewed follow-up commit passed all 10 applicable jobs on Windows/Linux/macOS, coverage, types/lint, server startup and DSH installation.
