### PR TITLE
feat: expose retained browser viewport to native vision

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
         # stored baseline is a review signal, not an invisible context-cost
         # regression. Latency is intentionally reported by the probe but is not
         # gated because hosted runner load is variable.
-        run: uv run python scripts/mcp_wire.py --baseline work/performance/wire-baseline.json --max-token-regression-percent 10
+        run: uv run python scripts/mcp_wire.py compare-mcp decision-mcp marketplace-mcp --baseline work/performance/wire-baseline.json --max-token-regression-percent 10
 
       - name: One version, everywhere
         # A release version is written down in seventy-two places. Preparing
@@ -207,7 +207,7 @@ jobs:
               "ozon": 3,
               "detmir": 3,
               "yandex": 2,
-              "compare": 3,
+              "compare": 4,
               "avito": 3,
               "taobao": 2,
               "megamarket": 2,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,16 @@
   Taobao search/card challenge tabs. Same-session repeats read the owned page
   without navigating again. Expiry is capped at 300 seconds from initial attach,
   does not extend, and at most four leases are active. Error/comparison metadata
-  exposes `handoff_expires_at` only when retained. No new MCP tools are required.
+  exposes `handoff_expires_at` and an opaque `handoff_id` only when retained.
+- New `compare_browser_snapshot(handoff_id)` returns a bounded JPEG viewport and
+  capture metadata through standard MCP image content. It never navigates or
+  invokes an OCR/vision service; a capable MCP client can use its own native
+  vision. Handles are same-session and expire with the retained lease.
+- DSH mounts exactly one profile with precedence full, decision, compare. This
+  fixes duplicate compare/decision mounts and the full+decision flag conflict.
+- The snapshot tool deliberately adds about 265 wire tokens: compare 1816,
+  decision 2071, unified 16342. Baselines and the public tool contract were
+  updated for this addition; CI now gates the middle profile too.
 - Owned tabs close on success, failure, expiry, caller cancellation and graceful
   shutdown. Active handoffs suppress profile hiding; owned-window foreground
   activation is best-effort. Default behavior, browser-less compare installations,

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@
 | **Ситилинк**      | 2            | ваш Chrome (Qrator)                                                        | Поиск и карточки электроники                                                              |
 | **AliExpress**    | 2            | ваш Chrome (x5sec)                                                       | Поиск и карточки, цены в рублях                            |
 | **Циан**          | 2            | ваш Chrome (WAF по IP)                                                     | Недвижимость: поиск по фильтрам (продажа, аренда, посуточно) и карточка объявления         |
-| **Сравнение**     | 3            | опрашивает всё перечисленное                                               | «Где дешевле?» одним вызовом                                                              |
+| **Сравнение**     | 4            | опрашивает всё перечисленное                                               | «Где дешевле?» одним вызовом                                                              |
 | **MPStats**       | 2            | платный аккаунт MPStats, cookie `mp_auth` (опционально)                    | Продажи/остатки/графики за 30 дней по SKU Ozon/WB, остатки по складам (FBS/FBO)           |
 
 Читается анонимно, без браузера: Wildberries, Яндекс Маркет, Детский мир и
@@ -60,10 +60,10 @@ MPStats стоит особняком: это единственный **пла�
 поэтому он опционален и подключается по желанию, на остальные тринадцать
 серверов он не влияет никак.
 
-Всего 38 инструментов в 14 серверах на общем рантайме `mcp-core`. Плюс объединённый
+Всего 39 инструментов в 14 серверах на общем рантайме `mcp-core`. Плюс объединённый
 `marketplace-mcp`, который монтирует всё разом — одна запись в конфиге клиента
 вместо четырнадцати. Он добавляет свой инструмент `marketplace_sources` (какие коннекторы
-поднялись, а какие отвалились и почему), так что в нём 39 инструментов: 38
+поднялись, а какие отвалились и почему), так что в нём 40 инструментов: 39
 смонтированных плюс этот.
 
 ## Быстрый старт
@@ -74,7 +74,7 @@ MPStats стоит особняком: это единственный **пла�
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"   # 1485 офлайн-тестов, сеть не нужна
+uv run pytest -q -m "not live and not cdp"   # 1589 офлайн-тестов, сеть не нужна
 ```
 
 Проверка живого эндпоинта:
@@ -567,7 +567,7 @@ TTL.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1485 офлайн-тестов
+uv run pytest -q -m "not live and not cdp"    # 1589 офлайн-тестов
 uv run pytest -q -m "not live"                # то, что гоняет CI
 uv run pytest -q -m "not live" --cov          # покрытие, порог 70% в CI
 uv run ruff check . && uv run ruff format --check .
@@ -633,7 +633,7 @@ CI прогоняет тесты на Ubuntu, Windows и macOS против Pyth
 ## Как это сделано
 
 Код и документацию я писал вместе с ИИ-ассистентами. Они работают быстро и
-ошибаются уверенно, поэтому проект устроен вокруг проверки: 1485 офлайн-тестов,
+ошибаются уверенно, поэтому проект устроен вокруг проверки: 1589 офлайн-тестов,
 аудит перед выпуском, тесты, которые прогоняют настоящий экстрактор по снятой с
 сайта разметке. В заметках к релизу перечислено, какие источники сверены с живыми
 страницами вручную и какие остались непроверенными.
@@ -684,7 +684,7 @@ it every other server is unaffected.
 | **Citilink**      | 2     | your Chrome (Qrator)                                                          | Electronics search and cards                                                                       |
 | **AliExpress**    | 2     | your Chrome (x5sec)                                                           | Search and cards, ruble prices                            |
 | **Cian**          | 2     | your Chrome (WAF by IP)                                                      | Real estate: filter search (sale, long-term rent, daily) and one offer's card                      |
-| **Compare**       | 3     | aggregates the above                                                          | "Where is this cheapest?" in one call                                                              |
+| **Compare**       | 4     | aggregates the above                                                          | "Where is this cheapest?" in one call                                                              |
 | **MPStats**       | 2     | paid MPStats account, `mp_auth` cookie (optional)                             | 30-day sales/stock graphs per Ozon/WB SKU, warehouse split (FBS/FBO)                               |
 
 Anonymous, no browser: Wildberries, Yandex Market, Detsky Mir and Lamoda cards.
@@ -701,10 +701,10 @@ MPStats stands apart as the only **paid** source: without `MPSTATS_MP_AUTH` the
 server boots but its tools answer `auth_missing`. It is therefore optional —
 plug it in if you have an account; the other thirteen servers never notice.
 
-38 tools across 14 stdio MCP servers, sharing one runtime (`mcp-core`), plus the
+39 tools across 14 stdio MCP servers, sharing one runtime (`mcp-core`), plus the
 unified `marketplace-mcp` that mounts them all under one client entry. It adds its
 own `marketplace_sources` tool — which connectors mounted, and which dropped out and
-why — so it exposes 39 tools: the 38 mounted plus that one. stdio is the default;
+why — so it exposes 40 tools: the 39 mounted plus that one. stdio is the default;
 HTTP transport is opt-in for remote deployment — see
 [docs/DEPLOYMENT.md](docs/DEPLOYMENT.md).
 
@@ -716,7 +716,7 @@ Requires **Python 3.12+** and [uv](https://docs.astral.sh/uv/).
 git clone https://github.com/Vladimir-Human/ru-marketplace-mcp.git
 cd ru-marketplace-mcp
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1485 offline tests, no network needed
+uv run pytest -q -m "not live and not cdp"    # 1589 offline tests, no network needed
 ```
 
 Client configuration mirrors the Russian section above. Each server is a console
@@ -1074,7 +1074,7 @@ import, and `compare_prices` queries the same subset.
 
 ```bash
 uv sync --all-packages
-uv run pytest -q -m "not live and not cdp"    # 1485 offline tests
+uv run pytest -q -m "not live and not cdp"    # 1589 offline tests
 uv run pytest -q -m "not live"                # what CI runs
 uv run pytest -q -m "not live" --cov          # coverage, CI enforces a 70% floor
 uv run ruff check . && uv run ruff format --check .
@@ -1136,7 +1136,7 @@ harvesting.
 ## How this was built
 
 I wrote the code and the documentation with AI assistants. They are fast and they
-are confidently wrong, so the project is arranged around verification: 1485 offline
+are confidently wrong, so the project is arranged around verification: 1589 offline
 tests, an audit before the release, tests that run the real extractor against
 markup captured from the live site. The release notes say which sources were
 compared against live pages by hand and which were left unverified.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -198,7 +198,7 @@ session, so a crafted path must never become a request for a personal endpoint.
 
 ## Testing
 
-1485 offline tests, no network required. Three flavours:
+1589 offline tests, no network required. Three flavours:
 
 **Unit tests** for pure logic — coercion, merging, ranking, cross-platform process
 handling.

--- a/docs/CDP_SETUP.md
+++ b/docs/CDP_SETUP.md
@@ -64,7 +64,10 @@ graceful shutdown close owned tabs; a hard process kill cannot guarantee expiry
 in an external Chrome. Without `handoff_expires_at`, use the ordinary retry flow:
 HTTP errors rejected before DOM extraction, headless runs and calls without an
 MCP session do not retain a tab. No cookies, screenshots or browser profile copies
-are written by the handoff runtime.
+are written by the handoff runtime. A retained error also carries an opaque
+`handoff_id`; a vision-capable MCP client may pass it to
+`compare_browser_snapshot(handoff_id)` to receive the current viewport as an
+image plus metadata. The snapshot does not solve or interpret the challenge.
 
 ### 1. Start Chrome with remote debugging
 

--- a/dsh/README.md
+++ b/dsh/README.md
@@ -1,8 +1,8 @@
 # ru-marketplace-mcp for DeepSeek Harness
 
 Read-only MCP servers for Russian marketplaces: prices, stock, ratings, reviews
-and cross-marketplace price comparison. This bundle ships 14 Agent Skills plus
-two MCP server rows that are **off by default**.
+and cross-marketplace price comparison. This bundle ships 15 Agent Skills plus
+three mutually exclusive MCP server rows that are **off by default**.
 
 ## Why off by default
 
@@ -12,9 +12,10 @@ over the stdio MCP wire with `scripts/mcp_wire.py`:
 
 | Mode | Cost while mounted | Model-facing tools |
 |---|---|---|
-| Skills only (default) | ~390 tokens for 14 catalog rows | 0 |
-| `compare-mcp` (recommended) | ~0.9k tokens per request | 3 |
-| `marketplace-mcp` (full) | ~13.6k tokens per request | 36 |
+| Skills only (default) | 15 skill catalog entries; no MCP schemas | 0 |
+| `compare-mcp` (recommended) | ~1.8k tokens per request | 4 |
+| `decision-mcp` (shortlist inspection) | ~2.1k tokens per request | 5 |
+| `marketplace-mcp` (full) | ~16.3k tokens per request | 40 |
 
 The 11 `*_selfcheck` tools that previously inflated the full server to 45 tools
 are now CLI-only (`marketplace-mcp doctor`); only model-facing tools are
@@ -62,7 +63,21 @@ published over MCP.
    ```
 
    With only `RU_MARKETPLACE_MCP_DIR` set, the recommended compare mode
-   activates: `mcp__rumarket__compare_prices` and `mcp__rumarket__compare_sources`.
+   activates: `compare_prices`, `compare_sources`, `compare_verify_offer`, and
+   `compare_browser_snapshot` (under the client's `rumarket` namespace).
+
+## Middle profile and native vision
+
+Set `RU_MARKETPLACE_MCP_DECISION=1` to add `decision_inspect` without mounting
+every source tool. If both decision and full flags are set, full wins. Only one
+MCP row is active: full, otherwise decision, otherwise compare.
+
+With `CHROME_CHALLENGE_HANDOFF_S=120`, supported DOM challenges can retain their
+owned browser tab. A client/model that accepts MCP images can call
+`compare_browser_snapshot(handoff_id)` using the handle in the error or comparison
+outcome. It receives a bounded JPEG viewport and capture metadata directly;
+no separate OCR model or service is invoked. The handle only works in the same
+MCP session and does not extend expiry. Text-only clients should skip this tool.
 
 ## Enabling the full server
 
@@ -76,8 +91,8 @@ $env:RU_MARKETPLACE_MCP_FULL = "1"   # PowerShell
 export RU_MARKETPLACE_MCP_FULL=1     # POSIX shell
 ```
 
-The enabled row then changes from `compare-mcp` (3 tools) to `marketplace-mcp`
-(39 tools). Both rows share `serverName: rumarket`, and their `disabled`
+The enabled row then changes from `compare-mcp` (4 tools) to `marketplace-mcp`
+(40 tools). All three rows share `serverName: rumarket`, and their `disabled`
 conditions are mutually exclusive, so exactly one server instance runs at a
 time.
 
@@ -95,7 +110,7 @@ No MCP process survives profile restart without `RU_MARKETPLACE_MCP_DIR`.
 
 Since v1.8.0 every release tag builds a stdio image and proves it with a real
 MCP session over `docker run --rm -i` before publishing to the MCP Registry:
-initialize, `tools/list` (37 tools) and a `marketplace_sources` call. Use the
+initialize, `tools/list` and a `marketplace_sources` call. Use the
 published GHCR image instead of a local clone:
 
 ```yaml
@@ -114,8 +129,8 @@ published GHCR image instead of a local clone:
     failOnStartupError: false
 ```
 
-The image defaults to the unified server; full-mode wire cost applies
-(~13.6k tokens per request), so opt in deliberately.
+The image defaults to the unified server. Its tool set matches that release tag;
+unreleased tools in this source checkout are not present in older images.
 
 ## Source
 

--- a/dsh/cordis.patch.yml
+++ b/dsh/cordis.patch.yml
@@ -1,10 +1,10 @@
 # The 15 skills are always available and cost only their catalog rows.
-# Both MCP rows stay disabled until RU_MARKETPLACE_MCP_DIR is set. Once
+# All MCP rows stay disabled until RU_MARKETPLACE_MCP_DIR is set. Once
 # enabled they are paid on EVERY request; wire-measured figures (post output-
 # schema compaction, scripts/mcp_wire.py):
-#   compare-mcp      ~0.9k tokens
-#   decision-mcp     ~1.5k tokens (comparison plus shortlist card inspector)
-#   marketplace-mcp  ~13.6k tokens
+#   compare-mcp      ~1.8k tokens
+#   decision-mcp     ~2.1k tokens (comparison plus shortlist card inspector)
+#   marketplace-mcp  ~16.3k tokens
 - insert:
     - id: ru-marketplace-skills
       name: '@deepseek-ai/dsh-skill-filesystem'
@@ -16,10 +16,10 @@
           - !!js "process.getBuiltinModule('node:path').join(process.getBuiltinModule('node:module').createRequire(baseUrl).resolve('ru-marketplace-mcp-dsh/package.json'), '..', 'skills')"
 
     # Recommended and cheap: price comparison across WB, Detsky Mir and Yandex.
-    # 3 tools, ~0.9k wire tokens per request while mounted.
+    # 4 tools, ~1.8k wire tokens per request while mounted.
     - id: ru-marketplace-compare
       name: '@deepseek-ai/dsh-mcp-client'
-      disabled: !!js "!process.env.RU_MARKETPLACE_MCP_DIR || !!process.env.RU_MARKETPLACE_MCP_FULL"
+      disabled: !!js "!process.env.RU_MARKETPLACE_MCP_DIR || !!process.env.RU_MARKETPLACE_MCP_FULL || !!process.env.RU_MARKETPLACE_MCP_DECISION"
       config:
         serverName: rumarket
         transport: stdio
@@ -49,12 +49,12 @@
           - decision-mcp
         failOnStartupError: false
 
-    # Deliberate full-mount choice: 36 model-facing tools, ~13.6k wire tokens
+    # Deliberate full-mount choice: 40 model-facing tools, ~16.3k wire tokens
     # per request. Operator-only *_selfcheck tools are no longer published over
     # MCP; `marketplace-mcp doctor` still runs them from the CLI.
     - id: ru-marketplace-full
       name: '@deepseek-ai/dsh-mcp-client'
-      disabled: !!js "!process.env.RU_MARKETPLACE_MCP_DIR || !!process.env.RU_MARKETPLACE_MCP_DECISION || !process.env.RU_MARKETPLACE_MCP_FULL"
+      disabled: !!js "!process.env.RU_MARKETPLACE_MCP_DIR || !process.env.RU_MARKETPLACE_MCP_FULL"
       config:
         serverName: rumarket
         transport: stdio

--- a/dsh/skills/compare-prices/SKILL.md
+++ b/dsh/skills/compare-prices/SKILL.md
@@ -46,6 +46,10 @@ rank its rows against rouble sources.
 - `decision_inspect(source, product_id_or_url)` — return a native shortlisted
   card through the decision profile; use `compare_verify_offer` for an explicit
   identity verdict.
+- `compare_browser_snapshot(handoff_id)` — returns the current retained viewport
+  as MCP image content plus metadata for a same-session, unexpired handle. It
+  never solves, OCRs, or sends the image to another service. Skip it when the
+  client has no image input capability; a missing or foreign handle is `not_found`.
 
 ## Reading the result correctly
 

--- a/dsh/skills/marketplace/SKILL.md
+++ b/dsh/skills/marketplace/SKILL.md
@@ -10,8 +10,8 @@ One server mounting every installed connector as a namespaced toolset:
 `lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `cian_*`, `mpstats_*` plus
 `compare_prices` / `compare_sources` and its own `marketplace_sources`. Tool
 names keep their prefixes, so habits and configs carry over — but the operator
-wires a single `marketplace` entry instead of fourteen. The server exposes 39
-tools: 38 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
+wires a single `marketplace` entry instead of fourteen. The server exposes 40
+tools: 39 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
 source: without `MPSTATS_MP_AUTH` its tools answer `auth_missing` while
 everything else is unaffected.
 

--- a/packages/compare-connector/src/compare_connector/models_output.py
+++ b/packages/compare-connector/src/compare_connector/models_output.py
@@ -99,6 +99,9 @@ class SourceOutcome(BaseModel):
         default=None,
         description="UTC expiry when the challenged tab is retained; repeat the same request after action.",
     )
+    handoff_id: str | None = Field(
+        default=None, description="Opaque same-session handle for an optional browser snapshot."
+    )
 
 
 class CompareResponse(BaseModel):

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -40,13 +40,14 @@ from typing import Annotated, Any
 
 from fastmcp import Context, FastMCP
 from fastmcp.exceptions import ToolError
-from mcp.types import ToolAnnotations
+from fastmcp.tools import ToolResult
+from mcp.types import ImageContent, TextContent, ToolAnnotations
 from mcp_core import resilience as R
-from mcp_core.errors import BadRequestError, ConnectorError, ErrorCode, raise_tool_error
+from mcp_core.errors import BadRequestError, ConnectorError, ErrorCode, NotFoundError, raise_tool_error
 from mcp_core.logging import log_event
 from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.redact import redact_error_text as _redact
-from mcp_core.runtime import browser_handoff_lifespan
+from mcp_core.runtime import browser_handoff_lifespan, current_mcp_session_id
 from mcp_core.source_selection import selected
 from pydantic import Field
 
@@ -781,6 +782,7 @@ def _source_error(exc: Exception) -> dict[str, Any]:
         else:
             if expiry.tzinfo is not None:
                 handoff_expires_at = expiry.astimezone(datetime.UTC).isoformat().replace("+00:00", "Z")
+    raw_handoff_id = payload.get("handoff_id")
     return {
         "status": status,
         "detail": _redact(str(payload.get("message", str(exc))))[:200],
@@ -789,6 +791,11 @@ def _source_error(exc: Exception) -> dict[str, Any]:
         "requires_user_action": challenge,
         "challenge_type": challenge_type if challenge else None,
         "handoff_expires_at": handoff_expires_at,
+        "handoff_id": raw_handoff_id
+        if handoff_expires_at
+        and isinstance(raw_handoff_id, str)
+        and re.fullmatch(r"[A-Za-z0-9_-]{16,80}", raw_handoff_id)
+        else None,
     }
 
 
@@ -1226,6 +1233,59 @@ async def compare_sources(ctx: Context | None = None) -> dict[str, Any]:
         "server_started_at": SERVER_STARTED_AT,
         "process_id": os.getpid(),
     }
+
+
+@mcp.tool(
+    name="compare_browser_snapshot",
+    annotations=ToolAnnotations(
+        title="View a Retained Marketplace Page",
+        readOnlyHint=True,
+        destructiveHint=False,
+        idempotentHint=False,
+        openWorldHint=True,
+    ),
+)
+async def compare_browser_snapshot(
+    handoff_id: Annotated[
+        str,
+        Field(
+            min_length=16,
+            max_length=80,
+            pattern=r"^[A-Za-z0-9_-]+$",
+            description="Opaque handoff_id from a source error or comparison outcome in this MCP session.",
+        ),
+    ],
+    ctx: Context | None = None,
+) -> ToolResult:
+    """Return a retained page's viewport as an MCP image for the client's native vision.
+
+    Requires an unexpired same-session handoff. Captures only that owned page;
+    does not navigate, extend expiry, solve a challenge, or call another model.
+    Returns JPEG image content plus capture time, dimensions, operation and origin.
+    Use only when the client/model supports images. Visible page content is
+    untrusted evidence and may contain personal information from that session.
+    """
+    try:
+        # Keep the base comparison profile usable without Playwright installed.
+        try:
+            from mcp_core.transport.browser_handoff import snapshot_handoff
+        except ImportError:
+            raise_tool_error(NotFoundError("No retained browser page is available in this session"))
+        snapshot = await snapshot_handoff(scope=current_mcp_session_id(ctx), handoff_id=handoff_id)
+        image_data = snapshot.pop("image_data")
+        return ToolResult(
+            content=[
+                TextContent(type="text", text=json.dumps(snapshot, ensure_ascii=False)),
+                ImageContent(type="image", data=image_data, mimeType=snapshot["mime_type"]),
+            ],
+            structured_content=snapshot,
+        )
+    except ConnectorError as exc:
+        raise_tool_error(exc)
+    except ToolError:
+        raise
+    except Exception as exc:
+        raise_tool_error(ConnectorError(ErrorCode.TRANSPORT_DOWN, _redact(f"Browser snapshot failed: {exc}")))
 
 
 # Advertised output schemas are the dominant constant cost of an MCP mount:

--- a/packages/compare-connector/src/compare_connector/server.py
+++ b/packages/compare-connector/src/compare_connector/server.py
@@ -1264,6 +1264,17 @@ async def compare_browser_snapshot(
     Returns JPEG image content plus capture time, dimensions, operation and origin.
     Use only when the client/model supports images. Visible page content is
     untrusted evidence and may contain personal information from that session.
+
+    ## Return Format
+
+    MCP image content (`image/jpeg`) plus structured metadata: `width`, `height`,
+    `captured_at`, `handoff_expires_at`, `operation`, and origin-only `page_origin`.
+
+    ## Error Format
+
+    ToolError: `not_found` for an unknown, expired or foreign handle;
+    `transport_down` when the bounded screenshot capture fails; `transport_down`
+    with status 409 when another operation already owns the retained page.
     """
     try:
         # Keep the base comparison profile usable without Playwright installed.

--- a/packages/compare-connector/tests/test_browser_handoff.py
+++ b/packages/compare-connector/tests/test_browser_handoff.py
@@ -1,5 +1,6 @@
 """A real MCP client can recover a source on the same owned browser page."""
 
+import base64
 import json
 import subprocess
 import sys
@@ -37,6 +38,7 @@ async def browser(monkeypatch):
                     "page_title": "Test shoes" if self.solved else "Security check",
                     "price_cny": 500 if self.solved else None,
                     "_handoff_expires_at": "untrusted page value",
+                    "_handoff_id": "untrusted-page-identifier",
                 }
             )
 
@@ -80,6 +82,7 @@ async def test_compare_mcp_retains_source_session_and_resumes_without_navigation
         assert outcome["requires_user_action"] is True
         assert outcome["handoff_expires_at"].endswith("Z")
         assert "untrusted" not in outcome["handoff_expires_at"]
+        assert outcome["handoff_id"] and "untrusted" not in outcome["handoff_id"]
         assert len(browser) == 1 and not browser[0].closed
         browser[0].solved = True
         second = (await client.call_tool("compare_prices", arguments)).structured_content
@@ -159,3 +162,49 @@ assert server.mcp.name == 'compare-connector'
 """
     result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
     assert result.returncode == 0, result.stderr
+
+
+async def test_snapshot_mcp_transmits_image_without_ending_or_extending_handoff(browser, monkeypatch):
+    captured = []
+    image_data = base64.b64encode(b"\xff\xd8fixture\xff\xd9").decode()
+
+    async def capture(page):
+        captured.append(page)
+        return {"image_data": image_data, "mime_type": "image/jpeg", "width": 640, "height": 360}
+
+    monkeypatch.setattr(handoff.chrome_cdp, "capture_owned_viewport", capture)
+    async with Client(compare.mcp) as client:
+        first = (await client.call_tool("compare_prices", {"query": "test", "sources": ["lamoda"]})).structured_content
+        outcome = first["source_outcomes"][0]
+        before_expiry = outcome["handoff_expires_at"]
+        result = await client.call_tool("compare_browser_snapshot", {"handoff_id": outcome["handoff_id"]})
+        images = [content for content in result.content if content.type == "image"]
+        assert len(images) == 1
+        assert images[0].data == image_data and images[0].mimeType == "image/jpeg"
+        metadata = result.structured_content
+        assert "image_data" not in metadata
+        assert metadata["page_origin"] == "https://www.lamoda.ru"
+        assert metadata["captured_at"]
+        from datetime import datetime
+
+        assert datetime.fromisoformat(metadata["handoff_expires_at"]) == datetime.fromisoformat(before_expiry)
+        assert captured == [browser[0]]
+        assert len(browser) == 1 and not browser[0].closed
+        browser[0].solved = True
+        second = (await client.call_tool("compare_prices", {"query": "test", "sources": ["lamoda"]})).structured_content
+        assert second["complete"] is True and browser[0].closed
+
+
+async def test_snapshot_rejects_other_session_and_unknown_handle_without_capture(browser, monkeypatch):
+    async def capture(page):
+        pytest.fail("foreign or missing handle must not capture any page")
+
+    monkeypatch.setattr(handoff.chrome_cdp, "capture_owned_viewport", capture)
+    async with Client(compare.mcp) as owner, Client(compare.mcp) as other:
+        result = (await owner.call_tool("compare_prices", {"query": "test", "sources": ["lamoda"]})).structured_content
+        handle = result["source_outcomes"][0]["handoff_id"]
+        for client, candidate in [(other, handle), (owner, "unknown-handoff-123456")]:
+            with pytest.raises(ToolError) as excinfo:
+                await client.call_tool("compare_browser_snapshot", {"handoff_id": candidate})
+            assert json.loads(str(excinfo.value))["error"] == "not_found"
+        assert len(browser) == 1 and not browser[0].closed

--- a/packages/compare-connector/tests/test_server.py
+++ b/packages/compare-connector/tests/test_server.py
@@ -47,7 +47,7 @@ def test_server_version_matches_pyproject():
 
 async def test_registered_tools_are_stable():
     names = {tool.name for tool in await server.mcp.list_tools()}
-    assert names == {"compare_prices", "compare_sources", "compare_verify_offer"}
+    assert names == {"compare_prices", "compare_sources", "compare_verify_offer", "compare_browser_snapshot"}
 
 
 async def test_compare_verify_offer_dispatches_to_source_card(monkeypatch):
@@ -273,6 +273,12 @@ def test_challenge_metadata_does_not_leak_credentials_or_upstream_instructions()
 def test_invalid_handoff_expiry_does_not_become_recovery_instructions(expiry):
     result = server._source_error(ToolError(json.dumps({"error": "challenge_required", "handoff_expires_at": expiry})))
     assert result["handoff_expires_at"] is None
+
+
+@pytest.mark.parametrize("handle", [None, 12345678901234567, [], "https://example.invalid/token", "short"])
+def test_invalid_handoff_id_does_not_become_a_snapshot_target(handle):
+    payload = {"error": "challenge_required", "handoff_expires_at": "2026-09-12T15:00:00Z", "handoff_id": handle}
+    assert server._source_error(ToolError(json.dumps(payload)))["handoff_id"] is None
 
 
 async def test_a_generic_failure_is_reported_as_error_not_blocked(monkeypatch):

--- a/packages/lamoda-connector/src/lamoda_connector/server.py
+++ b/packages/lamoda-connector/src/lamoda_connector/server.py
@@ -51,7 +51,7 @@ from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
 from mcp_core.runtime import browser_handoff_lifespan, current_mcp_session_id
 from mcp_core.transport import build_client
-from mcp_core.transport.browser_handoff import has_pending_handoff, read_with_handoff
+from mcp_core.transport.browser_handoff import get_handoff_id, has_pending_handoff, read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -350,6 +350,7 @@ async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
             if not isinstance(data, dict):
                 raise_tool_error(ParserDriftError("search extractor returned a non-object payload"))
             data.pop("_handoff_expires_at", None)
+            data.pop("_handoff_id", None)
             return data
 
         async with _cdp_lock:
@@ -367,6 +368,7 @@ async def _cdp_render_search(query: str, ctx: Context | None) -> dict[str, Any]:
             )
             if expires_at:
                 data["_handoff_expires_at"] = expires_at
+                data["_handoff_id"] = get_handoff_id(scope=scope, operation="lamoda_search", url=url)
             return data
 
     try:
@@ -413,6 +415,7 @@ async def lamoda_search(
                     "Lamoda requires user action in the connected Chrome. Complete the visible challenge, then retry.",
                     provider="lamoda",
                     handoff_expires_at=payload.get("_handoff_expires_at"),
+                    handoff_id=payload.get("_handoff_id"),
                 )
             )
         items_raw = payload.get("items") if isinstance(payload.get("items"), list) else []

--- a/packages/marketplace-connector/src/marketplace_connector/cli.py
+++ b/packages/marketplace-connector/src/marketplace_connector/cli.py
@@ -168,24 +168,25 @@ def _dsh_command(script: str, root: pathlib.Path | None) -> tuple[str, list[str]
 
 
 def _dsh_patch_block() -> tuple[str, str]:
-    """The dsh ``cordis.patch.yml`` rows for the two supported mounts.
+    """The dsh ``cordis.patch.yml`` rows for the three supported mounts.
 
     Unlike Claude/Cursor, DeepSeek Harness does not consume an ``mcpServers``
     JSON block: a plugin patch inserts ``@deepseek-ai/dsh-mcp-client`` rows.
-    Both rows ship disabled at zero context cost until the operator opts in
+    All rows ship disabled at zero context cost until the operator opts in
     (measured cost of the enabled rows is paid on EVERY client request).
 
-    The two rows deliberately share one ``serverName``. Their ``disabled``
+    The three rows deliberately share one ``serverName``. Their ``disabled``
     expressions are mutually exclusive, so only one instance is ever alive:
-    ``RU_MARKETPLACE_MCP_FULL`` unset selects the cheap ``compare-mcp`` row,
-    and set selects the unified row in its place.
+    ``RU_MARKETPLACE_MCP_FULL`` selects the unified row, otherwise
+    ``RU_MARKETPLACE_MCP_DECISION`` selects the middle row, and with neither
+    switch set the cheap ``compare-mcp`` row is selected.
     """
     root = _workspace_root()
     compare_cmd, compare_args, compare_note = _dsh_command("compare-mcp", root)
     compare_row = _dsh_row(
         "ru-marketplace-compare",
         compare_cmd,
-        f"!process.env.{DSH_ENV_DIR} || !!process.env.{DSH_ENV_FULL}",
+        f"!process.env.{DSH_ENV_DIR} || !!process.env.{DSH_ENV_FULL} || !!process.env.{DSH_ENV_DECISION}",
         compare_args,
     )
     decision_cmd, decision_args, decision_note = _dsh_command("decision-mcp", root)
@@ -205,7 +206,7 @@ def _dsh_patch_block() -> tuple[str, str]:
 
     block = (
         "# Add these rows to the `- insert:` list of your cordis.patch.yml (dsh).\n"
-        "# Both rows start disabled (zero tool-schema cost until the env gates are\n"
+        "# All rows start disabled (zero tool-schema cost until the env gates are\n"
         "# set) and their conditions are mutually exclusive.\n"
         "- insert:\n" + compare_row + "\n" + decision_row + "\n" + full_row
     )

--- a/packages/marketplace-connector/tests/fixtures/public_contract.json
+++ b/packages/marketplace-connector/tests/fixtures/public_contract.json
@@ -413,6 +413,26 @@
       "type": "object"
     }
   },
+  "compare_browser_snapshot": {
+    "output": {
+      "type": "object"
+    },
+    "parameters": {
+      "additionalProperties": false,
+      "properties": {
+        "handoff_id": {
+          "maxLength": 80,
+          "minLength": 16,
+          "pattern": "^[A-Za-z0-9_-]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "handoff_id"
+      ],
+      "type": "object"
+    }
+  },
   "compare_prices": {
     "output": {
       "properties": {

--- a/packages/marketplace-connector/tests/test_dsh_bundle.py
+++ b/packages/marketplace-connector/tests/test_dsh_bundle.py
@@ -13,6 +13,7 @@ contain only YAML, JSON and Markdown — never an executable.
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -104,3 +105,49 @@ def test_dsh_manifest_points_at_the_patch_and_has_no_scoped_name():
     assert patch.is_file(), f"dsh manifest patch path does not exist: {patch}"
     assert "skills" in manifest["files"]
     assert "cordis.patch.yml" in manifest["files"]
+
+
+@pytest.mark.parametrize("source", ["bundle", "cli"])
+@pytest.mark.parametrize(
+    ("directory", "decision", "full", "expected"),
+    [
+        ("", "", "", []),
+        ("", "1", "", []),
+        ("", "", "1", []),
+        ("", "1", "1", []),
+        ("checkout", "", "", ["compare"]),
+        ("checkout", "1", "", ["decision"]),
+        ("checkout", "", "1", ["full"]),
+        ("checkout", "1", "1", ["full"]),
+    ],
+)
+def test_dsh_profile_flags_activate_exactly_the_requested_mount(source, directory, decision, full, expected):
+    """Evaluate the shipped guards: full wins, then decision, then compare."""
+    if source == "bundle":
+        patch = (DSH_ROOT / "cordis.patch.yml").read_text(encoding="utf-8")
+    else:
+        from marketplace_connector.cli import _dsh_patch_block
+
+        patch, _ = _dsh_patch_block()
+
+    env = {"DIR": directory, "DECISION": decision, "FULL": full}
+    guards = re.findall(
+        r'- id: ru-marketplace-(compare|decision|full)\s+.*?disabled: !!js "([^"]+)"',
+        patch,
+        flags=re.DOTALL,
+    )
+    assert len(guards) == 3
+    enabled = []
+    for name, expression in guards:
+        # These guards deliberately use only OR and JS string truthiness.
+        # Reject unsupported syntax instead of silently approximating it.
+        terms = expression.split(" || ")
+        disabled = []
+        for term in terms:
+            match = re.fullmatch(r"(!{1,2})process\.env\.RU_MARKETPLACE_MCP_(DIR|DECISION|FULL)", term)
+            assert match, f"unsupported DSH guard: {term}"
+            value = bool(env[match[2]])
+            disabled.append(value if match[1] == "!!" else not value)
+        if not any(disabled):
+            enabled.append(name)
+    assert enabled == expected

--- a/packages/marketplace-connector/tests/test_server.py
+++ b/packages/marketplace-connector/tests/test_server.py
@@ -51,13 +51,13 @@ def test_tool_names_keep_their_source_prefixes():
 def test_the_mounted_count_matches_the_imported_sources():
     tools = asyncio.run(server.mcp.list_tools())
     names = {t.name for t in tools}
-    # 8 + 3 + 2 + 3 + 3 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 3 + 2 = 38 mounted tools across
+    # 8 + 3 + 2 + 3 + 3 + 2 + 2 + 2 + 2 + 2 + 2 + 2 + 4 + 2 = 39 mounted tools across
     # 14 servers, plus marketplace_sources, which this server owns rather than
     # mounts. Operator-only *_selfcheck diagnostics are not MCP tools.
     own = {"marketplace_sources"}
     assert own <= names
-    assert len(tools) == 39, f"expected 38 mounted tools + 1 own, got {len(tools)}"
-    assert len(names - own) == 38
+    assert len(tools) == 40, f"expected 39 mounted tools + 1 own, got {len(tools)}"
+    assert len(names - own) == 39
 
 
 def test_marketplace_sources_reports_what_mounted():

--- a/packages/marketplace-connector/tests/test_wire_frugality.py
+++ b/packages/marketplace-connector/tests/test_wire_frugality.py
@@ -24,8 +24,9 @@ def test_no_operator_selfcheck_is_registered_as_a_tool():
     assert not leaked, f"operator-only selfchecks leaked into the MCP surface: {leaked}"
     # The count changed from 45 to 34 on purpose (11 selfchecks left), from
     # 34 to 36 when the aliexpress connector (2 tools) joined the mount, and
-    # from 37 to 39 when the cian connector (2 tools) joined.
-    assert len(tools) == 39
+    # from 37 to 39 when the cian connector (2 tools) joined, then to 40 with
+    # the comparison browser snapshot tool.
+    assert len(tools) == 40
 
 
 def test_every_output_schema_is_wire_frugal():

--- a/packages/mcp-core/src/mcp_core/errors.py
+++ b/packages/mcp-core/src/mcp_core/errors.py
@@ -113,10 +113,12 @@ class ChallengeRequiredError(ConnectorError):
         provider: str | None = None,
         challenge_type: str = "captcha",
         handoff_expires_at: str | None = None,
+        handoff_id: str | None = None,
     ) -> None:
         super().__init__(ErrorCode.CHALLENGE_REQUIRED, message, provider=provider, status_code=403)
         self.challenge_type = challenge_type
         self.handoff_expires_at = handoff_expires_at
+        self.handoff_id = handoff_id
 
     def to_dict(self) -> dict:
         return {
@@ -124,6 +126,7 @@ class ChallengeRequiredError(ConnectorError):
             "requires_user_action": True,
             "challenge_type": self.challenge_type,
             **({"handoff_expires_at": self.handoff_expires_at} if self.handoff_expires_at else {}),
+            **({"handoff_id": self.handoff_id} if self.handoff_id else {}),
         }
 
 

--- a/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
+++ b/packages/mcp-core/src/mcp_core/transport/browser_handoff.py
@@ -9,13 +9,14 @@ from __future__ import annotations
 import asyncio
 import math
 import os
+import secrets
 from collections.abc import Awaitable, Callable, Collection
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
 from typing import Any
 from urllib.parse import urlsplit
 
-from mcp_core.errors import TransportDownError, UpstreamTimeoutError
+from mcp_core.errors import NotFoundError, TransportDownError, UpstreamTimeoutError
 from mcp_core.transport import chrome_cdp
 from mcp_core.transport.chrome_cdp import PageLike
 
@@ -47,12 +48,15 @@ class _Request:
     challenge: Challenge
     hosts: frozenset[str]
     result: asyncio.Future[Result]
+    snapshot: bool = False
 
 
 @dataclass
 class _Lease:
     deadline: float
     expires_at: str
+    handoff_id: str = field(default_factory=lambda: secrets.token_urlsafe(18))
+    hosts: frozenset[str] = frozenset()
     requests: asyncio.Queue[_Request] = field(default_factory=asyncio.Queue)
     busy: bool = True
     cleaning: bool = False
@@ -73,6 +77,14 @@ def has_pending_handoff(*, scope: str | None, operation: str, url: str) -> bool:
     return _key(scope, operation, url) in _leases
 
 
+def get_handoff_id(*, scope: str | None, operation: str, url: str) -> str | None:
+    """Return an opaque handle only for this exact live operation's lease."""
+    lease = _leases.get(_key(scope, operation, url)) if scope else None
+    if lease is None or lease.cleaning or lease.deadline <= asyncio.get_running_loop().time():
+        return None
+    return lease.handoff_id
+
+
 async def _run(key: Key, lease: _Lease, url: str, wait_ms: int) -> None:
     current: _Request | None = None
     terminal_error: Exception = TransportDownError("Browser handoff ended; retry the operation")
@@ -85,10 +97,29 @@ async def _run(key: Key, lease: _Lease, url: str, wait_ms: int) -> None:
             async with chrome_cdp.open_page(url, wait_ms, allowed_hosts=current.hosts) as page:
                 try:
                     while True:
-                        chrome_cdp._check_final_host(await chrome_cdp.current_page_url(page), current.hosts)
+                        hosts = lease.hosts if current.snapshot else current.hosts
+                        chrome_cdp._check_final_host(await chrome_cdp.current_page_url(page), hosts)
                         payload = await current.read(page)
                         # Navigation during extraction also invalidates the result.
-                        chrome_cdp._check_final_host(await chrome_cdp.current_page_url(page), current.hosts)
+                        final_url = await chrome_cdp.current_page_url(page)
+                        chrome_cdp._check_final_host(final_url, hosts)
+                        if current.snapshot:
+                            parsed = urlsplit(final_url)
+                            host = parsed.hostname or ""
+                            origin_host = f"[{host}]" if ":" in host else host
+                            payload.update(
+                                captured_at=datetime.now(UTC).isoformat(),
+                                handoff_expires_at=lease.expires_at,
+                                operation=key[1],
+                                page_origin=f"{parsed.scheme}://{origin_host}"
+                                + (f":{parsed.port}" if parsed.port else ""),
+                            )
+                            current.result.set_result((payload, lease.expires_at))
+                            del payload
+                            current = None
+                            lease.busy = False
+                            current = await lease.requests.get()
+                            continue
                         blocked = current.challenge(payload)
                         if not blocked:
                             current.result.set_result((payload, None))
@@ -167,6 +198,39 @@ async def close_handoffs() -> None:
     await asyncio.gather(*(_stop(lease) for lease in tuple(_leases.values())))
 
 
+async def snapshot_handoff(*, scope: str | None, handoff_id: str) -> dict[str, Any]:
+    """Capture a retained page in this session; never open or navigate a tab."""
+    if not handoff_id.isascii():
+        raise NotFoundError("Browser handoff is unavailable")
+    loop = asyncio.get_running_loop()
+    found = next(
+        (
+            lease
+            for key, lease in _leases.items()
+            if scope
+            and key[0] == scope
+            and key[3:] == (chrome_cdp.CDP_URL, chrome_cdp.SCRAPING_PROFILE)
+            and secrets.compare_digest(lease.handoff_id, handoff_id)
+        ),
+        None,
+    )
+    if found is None or found.cleaning or found.deadline <= loop.time():
+        raise NotFoundError("Browser handoff is unavailable")
+    if found.busy:
+        raise HandoffBusyError()
+    found.busy = True
+    result: asyncio.Future[Result] = loop.create_future()
+    found.requests.put_nowait(_Request(chrome_cdp.capture_owned_viewport, lambda _: None, found.hosts, result, True))
+    try:
+        response = await asyncio.shield(result)
+        return response[0]
+    except BaseException:
+        await _stop(found)
+        if result.done() and not result.cancelled():
+            result.exception()
+        raise
+
+
 async def read_with_handoff(
     *,
     url: str,
@@ -190,6 +254,7 @@ async def read_with_handoff(
             return await read(page), None
 
     key = _key(scope, operation, url)
+    hosts = frozenset(allowed_hosts or {urlsplit(url).hostname or ""})
     loop = asyncio.get_running_loop()
     lease = _leases.get(key)
     if lease is not None and lease.busy:
@@ -205,10 +270,10 @@ async def read_with_handoff(
         lease = _Lease(
             deadline=loop.time() + duration,
             expires_at=(datetime.now(UTC) + timedelta(seconds=duration)).isoformat(),
+            hosts=hosts,
         )
         _leases[key] = lease
     lease.busy = True
-    hosts = frozenset(allowed_hosts or {urlsplit(url).hostname or ""})
     result: asyncio.Future[Result] = loop.create_future()
     lease.requests.put_nowait(_Request(read, challenge, hosts, result))
     if lease.task is None:

--- a/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
+++ b/packages/mcp-core/src/mcp_core/transport/chrome_cdp.py
@@ -35,7 +35,10 @@ the browser launches normally, or headless when ``CHROME_HEADLESS=1``.
 from __future__ import annotations
 
 import asyncio
+import base64
+import binascii
 import json
+import math
 import os
 import re
 import shutil
@@ -684,6 +687,116 @@ class _RawCdpPage:
             await self._send("Target.closeTarget", {"targetId": self._target_id}, timeout=10.0)
         except Exception:
             pass
+
+
+_MAX_HANDOFF_IMAGE_BYTES = 2 * 1024 * 1024
+
+
+def _handoff_jpeg(encoded: Any) -> tuple[int, int]:
+    """Read the encoded image dimensions, not CSS dimensions (which ignore DPR)."""
+    encoded_limit = 4 * ((_MAX_HANDOFF_IMAGE_BYTES + 2) // 3)
+    if not isinstance(encoded, str) or len(encoded) > encoded_limit:
+        raise RuntimeError("CDP screenshot returned no image data within the size limit")
+    try:
+        data = base64.b64decode(encoded, validate=True)
+    except (ValueError, binascii.Error) as exc:
+        raise RuntimeError("CDP screenshot returned invalid base64") from exc
+    if not data or len(data) > _MAX_HANDOFF_IMAGE_BYTES:
+        raise RuntimeError("CDP screenshot exceeds the bounded image size")
+    if not data.startswith(b"\xff\xd8\xff") or not data.endswith(b"\xff\xd9"):
+        raise RuntimeError("CDP screenshot returned invalid JPEG data")
+    offset = 2
+    while offset < len(data) - 2:
+        if data[offset] != 0xFF:
+            break
+        while offset < len(data) and data[offset] == 0xFF:
+            offset += 1
+        if offset >= len(data):
+            break
+        marker = data[offset]
+        offset += 1
+        # Stop before compressed image data; it cannot contain a frame header.
+        if marker in (0xDA, 0xD9) or offset + 2 > len(data):
+            break
+        length = int.from_bytes(data[offset : offset + 2], "big")
+        if length < 2 or offset + length > len(data) - 2:
+            break
+        # SOF markers exclude DHT (C4), JPG (C8), and DAC (CC).
+        if marker in (0xC0, 0xC1, 0xC2, 0xC3, 0xC5, 0xC6, 0xC7, 0xC9, 0xCA, 0xCB, 0xCD, 0xCE, 0xCF):
+            if length < 8:
+                break
+            height = int.from_bytes(data[offset + 3 : offset + 5], "big")
+            width = int.from_bytes(data[offset + 5 : offset + 7], "big")
+            components = data[offset + 7]
+            if width > 0 and height > 0 and components > 0 and length == 8 + 3 * components:
+                return width, height
+            break
+        offset += length
+    raise RuntimeError("CDP screenshot returned invalid JPEG dimensions")
+
+
+async def capture_owned_viewport(page: PageLike) -> dict[str, Any]:
+    """Capture only the current owned viewport through CDP.
+
+    This deliberately avoids DOM/content extraction and never writes the image
+    to disk.  A bounded JPEG makes the result safe to pass to a vision model.
+    """
+    session: Any = None
+    try:
+        # One budget covers attach, metrics and capture, including event-heavy
+        # raw-CDP streams whose individual recv timeout can otherwise restart.
+        async with asyncio.timeout(_RAW_CONNECT_TIMEOUT_S):
+            if isinstance(page, _RawCdpPage):
+                send = page._send
+            elif isinstance(page, Page):
+                session = await page.context.new_cdp_session(page)
+                send = session.send
+            else:
+                raise TypeError("unsupported page implementation")
+            metrics = await send("Page.getLayoutMetrics")
+            viewport = metrics.get("cssVisualViewport") or metrics.get("cssLayoutViewport") or {}
+            dimensions = [viewport.get("clientWidth"), viewport.get("clientHeight")]
+            offsets = [viewport.get("pageX", 0), viewport.get("pageY", 0)]
+            if any(
+                not isinstance(value, (int, float)) or isinstance(value, bool) or not math.isfinite(value)
+                for value in dimensions + offsets
+            ):
+                raise RuntimeError("CDP returned invalid viewport geometry")
+            width, height = viewport["clientWidth"], viewport["clientHeight"]
+            x, y = offsets
+            if not (0 < width <= 10000 and 0 < height <= 10000 and x >= 0 and y >= 0):
+                raise RuntimeError("CDP returned invalid viewport geometry")
+            scale = min(1.0, 1440 / width, 900 / height)
+            for _attempt in range(2):
+                result = await send(
+                    "Page.captureScreenshot",
+                    {
+                        "format": "jpeg",
+                        "quality": 70,
+                        "fromSurface": True,
+                        "captureBeyondViewport": False,
+                        "clip": {"x": x, "y": y, "width": width, "height": height, "scale": scale},
+                    },
+                )
+                encoded = result.get("data")
+                image_width, image_height = _handoff_jpeg(encoded)
+                if image_width <= 1440 and image_height <= 900:
+                    return {
+                        "image_data": encoded,
+                        "mime_type": "image/jpeg",
+                        "width": image_width,
+                        "height": image_height,
+                    }
+                # CDP may multiply CSS clip dimensions by device pixel ratio.
+                # Correct once using the real frame size, never guessed CSS DPR.
+                scale *= min(1440 / image_width, 900 / image_height)
+            raise RuntimeError("CDP screenshot exceeds the bounded pixel dimensions")
+    finally:
+        if session is not None:
+            try:
+                await asyncio.wait_for(session.detach(), timeout=_RAW_CONNECT_TIMEOUT_S)
+            except Exception:
+                pass
 
 
 async def current_page_url(page: PageLike) -> str:

--- a/packages/mcp-core/tests/test_browser_handoff.py
+++ b/packages/mcp-core/tests/test_browser_handoff.py
@@ -10,7 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
-from mcp_core.errors import UpstreamTimeoutError
+from mcp_core.errors import NotFoundError, UpstreamTimeoutError
 from mcp_core.transport import browser_handoff as handoff
 from mcp_core.transport import chrome_cdp
 
@@ -448,3 +448,193 @@ async def test_second_caller_cancellation_keeps_lease_until_worker_closes(browse
     await asyncio.wait_for(lease.task, timeout=1)
     assert closed.is_set()
     assert not handoff._leases
+
+
+def snapshot_id():
+    return handoff.get_handoff_id(scope="session-1", operation="search", url="https://shop.test/search?q=a")
+
+
+async def test_snapshot_keeps_exact_lease_deadline_page_and_returns_sanitized_origin(browser, monkeypatch):
+    _, expiry = await call()
+    lease = next(iter(handoff._leases.values()))
+    deadline = lease.deadline
+    identifier = snapshot_id()
+    assert identifier and "session-1" not in identifier
+    browser[0].url = "https://shop.test:8443/private?token=must-not-escape#secret"
+    capture = AsyncMock(side_effect=lambda page: {"image_data": "encoded"})
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", capture)
+    for _ in range(2):
+        payload = await handoff.snapshot_handoff(scope="session-1", handoff_id=identifier)
+        assert payload["page_origin"] == "https://shop.test:8443"
+        assert payload["operation"] == "search"
+        assert payload["handoff_expires_at"] == expiry
+        assert payload["captured_at"]
+        assert next(iter(handoff._leases.values())) is lease
+        assert lease.deadline == deadline
+        assert snapshot_id() == identifier
+        assert len(browser) == 1 and not browser[0].closed
+    assert all(args.args == (browser[0],) for args in capture.await_args_list)
+    assert (await call(read=success))[1] is None
+    assert browser[0].closed
+    assert snapshot_id() is None
+
+
+@pytest.mark.parametrize(
+    "scenario", ["unknown", "foreign", "no-session", "expired", "cleaning", "profile", "endpoint", "unicode"]
+)
+async def test_unavailable_snapshot_never_opens_or_captures(browser, monkeypatch, scenario):
+    await call()
+    identifier = snapshot_id()
+    lease = next(iter(handoff._leases.values()))
+    scope = "session-1"
+    if scenario == "unknown":
+        identifier = "unknown"
+    elif scenario == "unicode":
+        identifier = "невозможный-id"
+    elif scenario == "foreign":
+        scope = "session-2"
+    elif scenario == "no-session":
+        scope = None
+    elif scenario == "expired":
+        lease.deadline = asyncio.get_running_loop().time() - 1
+    elif scenario == "cleaning":
+        lease.cleaning = True
+    elif scenario == "profile":
+        monkeypatch.setattr(chrome_cdp, "SCRAPING_PROFILE", "different")
+    elif scenario == "endpoint":
+        monkeypatch.setattr(chrome_cdp, "CDP_URL", "http://different.test")
+    capture = AsyncMock()
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", capture)
+    with pytest.raises(NotFoundError):
+        await handoff.snapshot_handoff(scope=scope, handoff_id=identifier)
+    capture.assert_not_called()
+    assert len(browser) == 1
+    # The synthetic cleaning flag must not disable fixture shutdown cancellation.
+    lease.cleaning = False
+
+
+async def test_snapshot_and_resume_cannot_overlap(browser, monkeypatch):
+    await call()
+    identifier = snapshot_id()
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def capture(page):
+        entered.set()
+        await release.wait()
+        return {"image_data": "encoded"}
+
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", capture)
+    task = asyncio.create_task(handoff.snapshot_handoff(scope="session-1", handoff_id=identifier))
+    await entered.wait()
+    with pytest.raises(handoff.HandoffBusyError):
+        await handoff.snapshot_handoff(scope="session-1", handoff_id=identifier)
+    with pytest.raises(handoff.HandoffBusyError):
+        await call(read=success)
+    release.set()
+    await task
+    entered.clear()
+    release.clear()
+
+    async def read(page):
+        entered.set()
+        await release.wait()
+        return await blocked(page)
+
+    task = asyncio.create_task(call(read=read))
+    await entered.wait()
+    with pytest.raises(handoff.HandoffBusyError):
+        await handoff.snapshot_handoff(scope="session-1", handoff_id=identifier)
+    release.set()
+    await task
+    assert len(browser) == 1
+
+
+@pytest.mark.parametrize("during", [False, True])
+async def test_snapshot_rechecks_original_host_policy_before_and_after_capture(browser, monkeypatch, during):
+    await call(allowed_hosts=["shop.test", "login.shop.test"])
+    identifier = snapshot_id()
+    browser[0].url = "https://login.shop.test/challenge"
+
+    async def capture(page):
+        page.url = "https://outside.test/private"
+        return {"image_data": "must not escape"}
+
+    mock = AsyncMock(side_effect=capture)
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", mock)
+    if not during:
+        browser[0].url = "https://outside.test/private"
+    with pytest.raises(chrome_cdp.NavigationPolicyError):
+        await handoff.snapshot_handoff(scope="session-1", handoff_id=identifier)
+    assert mock.await_count == int(during)
+    assert browser[0].closed and not handoff._leases
+
+
+@pytest.mark.parametrize("stop", ["cancel", "expire"])
+async def test_snapshot_cancellation_or_deadline_cleans_exact_page(browser, monkeypatch, stop):
+    timeout_contexts = []
+    original_timeout_at = asyncio.timeout_at
+
+    def record(when):
+        timeout = original_timeout_at(when)
+        timeout_contexts.append(timeout)
+        return timeout
+
+    monkeypatch.setattr(handoff.asyncio, "timeout_at", record)
+    await call()
+    entered = asyncio.Event()
+    cancelled = asyncio.Event()
+
+    async def capture(page):
+        entered.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", capture)
+    task = asyncio.create_task(handoff.snapshot_handoff(scope="session-1", handoff_id=snapshot_id()))
+    await entered.wait()
+    if stop == "cancel":
+        task.cancel()
+        error = asyncio.CancelledError
+    else:
+        timeout_contexts[0]._on_timeout()
+        error = UpstreamTimeoutError
+    with pytest.raises(error):
+        await asyncio.wait_for(task, timeout=1)
+    assert cancelled.is_set()
+    assert len(browser) == 1 and browser[0].closed
+    assert not handoff._leases
+
+
+@pytest.mark.parametrize("stop", ["expire", "cancel"])
+async def test_termination_settles_queued_snapshot_before_getter_resumes(browser, monkeypatch, stop):
+    timeouts = []
+    original_timeout_at = asyncio.timeout_at
+
+    def record(when):
+        timeout = original_timeout_at(when)
+        timeouts.append(timeout)
+        return timeout
+
+    monkeypatch.setattr(handoff.asyncio, "timeout_at", record)
+    await call()
+    lease = next(iter(handoff._leases.values()))
+    original_put = lease.requests.put_nowait
+    capture = AsyncMock()
+    monkeypatch.setattr(chrome_cdp, "capture_owned_viewport", capture)
+
+    def put_at_deadline(request):
+        original_put(request)
+        if stop == "expire":
+            timeouts[0]._on_timeout()
+        else:
+            lease.task.cancel()
+
+    monkeypatch.setattr(lease.requests, "put_nowait", put_at_deadline)
+    with pytest.raises(UpstreamTimeoutError if stop == "expire" else asyncio.CancelledError):
+        await asyncio.wait_for(handoff.snapshot_handoff(scope="session-1", handoff_id=snapshot_id()), timeout=1)
+    capture.assert_not_called()
+    assert lease.requests.empty()
+    assert browser[0].closed and not handoff._leases

--- a/packages/mcp-core/tests/test_chrome_cdp_snapshot.py
+++ b/packages/mcp-core/tests/test_chrome_cdp_snapshot.py
@@ -1,0 +1,279 @@
+"""Viewport capture validation and bounded CDP lifetime, without a browser."""
+
+import asyncio
+import base64
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+from mcp_core.transport import chrome_cdp as cdp
+
+
+def jpeg(width=1440, height=810, extra=b""):
+    # Minimal SOF0 envelope: decoding actual pixels is a separate live probe.
+    frame = b"\x08" + height.to_bytes(2, "big") + width.to_bytes(2, "big") + b"\x01\x01\x11\x00"
+    data = b"\xff\xd8\xff\xc0\x00\x0b" + frame + extra + b"\xff\xd9"
+    return base64.b64encode(data).decode()
+
+
+JPEG = jpeg()
+
+
+@pytest.fixture(params=["raw", "playwright"])
+def capture(request):
+    send = AsyncMock()
+    session = SimpleNamespace(send=send, detach=AsyncMock())
+    if request.param == "raw":
+        page = cdp._RawCdpPage(AsyncMock(), "owned-only")
+        page._send = send
+    else:
+        page = Mock(spec=cdp.Page)
+        page.context = SimpleNamespace(new_cdp_session=AsyncMock(return_value=session))
+    return page, send, session, request.param
+
+
+def metrics(**changes):
+    return {"cssVisualViewport": {"clientWidth": 1920, "clientHeight": 1080, "pageX": 23.5, "pageY": 1700, **changes}}
+
+
+async def test_scrolled_viewport_scale_and_transport_cleanup(capture):
+    page, send, session, kind = capture
+    send.side_effect = [metrics(), {"data": JPEG}]
+    result = await cdp.capture_owned_viewport(page)
+    assert result == {"image_data": JPEG, "mime_type": "image/jpeg", "width": 1440, "height": 810}
+    assert send.await_args_list[0].args == ("Page.getLayoutMetrics",)
+    assert send.await_args_list[1].args == (
+        "Page.captureScreenshot",
+        {
+            "format": "jpeg",
+            "quality": 70,
+            "fromSurface": True,
+            "captureBeyondViewport": False,
+            "clip": {"x": 23.5, "y": 1700, "width": 1920, "height": 1080, "scale": 0.75},
+        },
+    )
+    if kind == "playwright":
+        page.context.new_cdp_session.assert_awaited_once_with(page)
+        session.detach.assert_awaited_once()
+    else:
+        session.detach.assert_not_called()
+
+
+async def test_layout_fallback_small_viewport_is_not_upscaled(capture):
+    page, send, _, _ = capture
+    send.side_effect = [
+        {"cssLayoutViewport": {"clientWidth": 320, "clientHeight": 200, "pageY": 500}},
+        {"data": jpeg(320, 200)},
+    ]
+    result = await cdp.capture_owned_viewport(page)
+    assert (result["width"], result["height"]) == (320, 200)
+    assert send.await_args_list[1].args[1]["clip"] == {"x": 0, "y": 500, "width": 320, "height": 200, "scale": 1}
+
+
+@pytest.mark.parametrize(
+    "change",
+    [
+        {"clientWidth": 0},
+        {"clientHeight": -1},
+        {"clientWidth": 10001},
+        {"clientHeight": None},
+        {"clientWidth": float("nan")},
+        {"clientHeight": float("inf")},
+        {"clientWidth": "1920"},
+        {"clientWidth": True},
+        {"pageX": float("nan")},
+        {"pageY": -1},
+        {"pageX": "12"},
+    ],
+)
+async def test_invalid_geometry_never_captures(capture, change):
+    page, send, session, kind = capture
+    send.return_value = metrics(**change)
+    with pytest.raises(RuntimeError, match="viewport geometry"):
+        await cdp.capture_owned_viewport(page)
+    assert send.await_count == 1
+    if kind == "playwright":
+        session.detach.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "data, message",
+    [
+        (None, "no image data"),
+        (42, "no image data"),
+        ("%%%", "invalid base64"),
+        ("абв", "invalid base64"),
+        ("", "bounded image size"),
+        (base64.b64encode(b"not jpeg").decode(), "invalid JPEG"),
+        (base64.b64encode(b"\xff\xd8\xfftruncated").decode(), "invalid JPEG"),
+    ],
+)
+async def test_bad_image_payload_is_rejected(capture, data, message):
+    page, send, session, kind = capture
+    send.side_effect = [metrics(), {"data": data}]
+    with pytest.raises(RuntimeError, match=message):
+        await cdp.capture_owned_viewport(page)
+    if kind == "playwright":
+        session.detach.assert_awaited_once()
+
+
+@pytest.mark.parametrize("size, accepted", [(20, True), (21, False), (30, False)])
+async def test_encoded_and_decoded_byte_limits(capture, monkeypatch, size, accepted):
+    page, send, _, _ = capture
+    monkeypatch.setattr(cdp, "_MAX_HANDOFF_IMAGE_BYTES", 20)
+    encoded = jpeg(extra=b"x" * (size - 17))
+    send.side_effect = [metrics(), {"data": encoded}]
+    if accepted:
+        assert (await cdp.capture_owned_viewport(page))["image_data"] == encoded
+    else:
+        with pytest.raises(RuntimeError, match="size"):
+            await cdp.capture_owned_viewport(page)
+
+
+async def test_metrics_and_capture_share_one_deadline(capture, monkeypatch):
+    page, send, session, kind = capture
+    original_timeout = asyncio.timeout
+    budgets = []
+
+    def record_timeout(seconds):
+        timeout = original_timeout(seconds)
+        budgets.append(timeout)
+        return timeout
+
+    async def delayed(method, params=None):
+        if method == "Page.getLayoutMetrics":
+            return metrics()
+        # Trigger the actual enclosing budget after metrics have completed.
+        budgets[0]._on_timeout()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(cdp.asyncio, "timeout", record_timeout)
+    send.side_effect = delayed
+    with pytest.raises(TimeoutError):
+        await cdp.capture_owned_viewport(page)
+    assert len(budgets) == 1
+    if kind == "playwright":
+        session.detach.assert_awaited_once()
+
+
+async def test_playwright_attach_is_inside_deadline(monkeypatch):
+    page = Mock(spec=cdp.Page)
+    cancelled = asyncio.Event()
+
+    async def attach(page):
+        try:
+            await asyncio.Event().wait()
+        finally:
+            cancelled.set()
+
+    page.context = SimpleNamespace(new_cdp_session=AsyncMock(side_effect=attach))
+    monkeypatch.setattr(cdp, "_RAW_CONNECT_TIMEOUT_S", 0.01)
+    with pytest.raises(TimeoutError):
+        await asyncio.wait_for(cdp.capture_owned_viewport(page), timeout=1)
+    assert cancelled.is_set()
+
+
+async def test_capture_cancellation_still_detaches(capture):
+    page, send, session, kind = capture
+    entered = asyncio.Event()
+
+    async def pending(*args):
+        entered.set()
+        await asyncio.Event().wait()
+
+    send.side_effect = pending
+    task = asyncio.create_task(cdp.capture_owned_viewport(page))
+    await entered.wait()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    if kind == "playwright":
+        session.detach.assert_awaited_once()
+
+
+async def test_playwright_detach_has_its_own_bounded_cleanup(monkeypatch):
+    page = Mock(spec=cdp.Page)
+    detached = asyncio.Event()
+
+    async def detach():
+        try:
+            await asyncio.Event().wait()
+        finally:
+            detached.set()
+
+    session = SimpleNamespace(send=AsyncMock(side_effect=[metrics(), {"data": JPEG}]), detach=detach)
+    page.context = SimpleNamespace(new_cdp_session=AsyncMock(return_value=session))
+    monkeypatch.setattr(cdp, "_RAW_CONNECT_TIMEOUT_S", 0.01)
+    assert (await asyncio.wait_for(cdp.capture_owned_viewport(page), timeout=1))["image_data"] == JPEG
+    assert detached.is_set()
+
+
+async def test_jpeg_dimensions_are_authoritative_and_dpr_is_corrected_once(capture):
+    page, send, _, _ = capture
+    send.side_effect = [
+        metrics(clientWidth=1253, clientHeight=628),
+        {"data": jpeg(1565, 785)},
+        {"data": jpeg(1440, 722)},
+    ]
+    result = await cdp.capture_owned_viewport(page)
+    assert (result["width"], result["height"]) == (1440, 722)
+    first = send.await_args_list[1].args[1]["clip"]
+    second = send.await_args_list[2].args[1]["clip"]
+    assert first == {"x": 23.5, "y": 1700, "width": 1253, "height": 628, "scale": 1}
+    assert second == {**first, "scale": 1440 / 1565}
+
+
+async def test_actual_pixels_remaining_oversize_are_rejected_after_one_retry(capture):
+    page, send, session, kind = capture
+    send.side_effect = [metrics(), {"data": jpeg(1920, 1080)}, {"data": jpeg(1920, 1080)}]
+    with pytest.raises(RuntimeError, match="bounded pixel"):
+        await cdp.capture_owned_viewport(page)
+    assert send.await_count == 3
+    if kind == "playwright":
+        session.detach.assert_awaited_once()
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        b"\xff\xd8\xff\xd9",  # Missing frame header.
+        b"\xff\xd8\xff\xe0\x00\x01\xff\xd9",  # Invalid segment size.
+        b"\xff\xd8\xff\xc0\xff\xffshort\xff\xd9",  # Truncated segment.
+        b"\xff\xd8\xff\xc0\x00\x07short\xff\xd9",  # Short frame.
+        b"\xff\xd8\xff\xff\xd9",  # Marker padding, no frame.
+        base64.b64decode(jpeg(0, 400)),
+        base64.b64decode(jpeg(500, 0)),
+    ],
+)
+def test_invalid_jpeg_frame_dimensions(data):
+    with pytest.raises(RuntimeError, match="JPEG"):
+        cdp._handoff_jpeg(base64.b64encode(data).decode())
+
+
+def test_jpeg_frame_after_app_segment_and_progressive_frame():
+    raw = base64.b64decode(jpeg(601, 399))
+    # A real JPEG commonly has APP/DQT/DHT segments before SOF.
+    raw = raw[:2] + b"\xff\xe0\x00\x06meta" + raw[2:]
+    raw = raw.replace(b"\xff\xc0", b"\xff\xc2")
+    assert cdp._handoff_jpeg(base64.b64encode(raw).decode()) == (601, 399)
+
+
+async def test_raw_snapshot_uses_matching_cdp_responses_without_navigation():
+    ws = SimpleNamespace(
+        send=AsyncMock(),
+        recv=AsyncMock(
+            side_effect=[
+                json.dumps({"method": "Page.frameNavigated", "params": {"frame": {"url": "https://shop.test/card"}}}),
+                json.dumps({"id": 1, "result": metrics()}),
+                json.dumps({"id": 2, "result": {"data": JPEG}}),
+            ]
+        ),
+    )
+    page = cdp._RawCdpPage(ws, "owned")
+    assert (await cdp.capture_owned_viewport(page))["image_data"] == JPEG
+    assert [json.loads(call.args[0])["method"] for call in ws.send.await_args_list] == [
+        "Page.getLayoutMetrics",
+        "Page.captureScreenshot",
+    ]
+    assert page.url == "https://shop.test/card"

--- a/packages/mcp-core/tests/test_errors.py
+++ b/packages/mcp-core/tests/test_errors.py
@@ -9,9 +9,13 @@ def test_challenge_required_error_is_machine_readable_and_retryable():
     assert payload["requires_user_action"] is True
     assert payload["challenge_type"] == "captcha"
     assert "handoff_expires_at" not in payload
+    assert "handoff_id" not in payload
 
 
 def test_retained_challenge_has_explicit_expiry():
     expiry = "2026-09-12T15:00:00Z"
-    payload = ChallengeRequiredError("complete the browser challenge", handoff_expires_at=expiry).to_dict()
+    payload = ChallengeRequiredError(
+        "complete the browser challenge", handoff_expires_at=expiry, handoff_id="opaque-handoff-token"
+    ).to_dict()
     assert payload["handoff_expires_at"] == expiry
+    assert payload["handoff_id"] == "opaque-handoff-token"

--- a/packages/taobao-connector/src/taobao_connector/server.py
+++ b/packages/taobao-connector/src/taobao_connector/server.py
@@ -61,7 +61,7 @@ from mcp_core.output_schema import apply_compact_output_schemas
 from mcp_core.pacing import Pacer
 from mcp_core.redact import redact_error_text as _redact
 from mcp_core.runtime import browser_handoff_lifespan, current_mcp_session_id
-from mcp_core.transport.browser_handoff import has_pending_handoff, read_with_handoff
+from mcp_core.transport.browser_handoff import get_handoff_id, has_pending_handoff, read_with_handoff
 from mcp_core.transport.chrome_cdp import NavBlocked, open_page
 from pydantic import Field
 
@@ -420,6 +420,7 @@ async def _cdp_render(url: str, extract_js: str, wait_ms: int, ctx: Context | No
         if not isinstance(data, dict):
             raise_tool_error(ParserDriftError("page extractor returned a non-object payload"))
         data.pop("_handoff_expires_at", None)
+        data.pop("_handoff_id", None)
         return data
 
     scope = current_mcp_session_id(ctx)
@@ -438,6 +439,9 @@ async def _cdp_render(url: str, extract_js: str, wait_ms: int, ctx: Context | No
         )
         if expires_at:
             data["_handoff_expires_at"] = expires_at
+            data["_handoff_id"] = get_handoff_id(
+                scope=scope, operation="taobao_card" if url.startswith(ITEM_BASE) else "taobao_search", url=url
+            )
         return data
 
 
@@ -623,6 +627,7 @@ async def taobao_search(
                     provider="taobao",
                     challenge_type="login_or_captcha",
                     handoff_expires_at=payload.get("_handoff_expires_at"),
+                    handoff_id=payload.get("_handoff_id"),
                 )
             )
         if _anti_bot_challenge(payload):
@@ -631,6 +636,7 @@ async def taobao_search(
                     "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
                     provider="taobao",
                     handoff_expires_at=payload.get("_handoff_expires_at"),
+                    handoff_id=payload.get("_handoff_id"),
                 )
             )
         items_raw = payload.get("items") if isinstance(payload.get("items"), list) else []
@@ -719,6 +725,7 @@ async def taobao_card(
                     provider="taobao",
                     challenge_type="login_or_captcha",
                     handoff_expires_at=payload.get("_handoff_expires_at"),
+                    handoff_id=payload.get("_handoff_id"),
                 )
             )
         title = payload.get("title")
@@ -734,6 +741,7 @@ async def taobao_card(
                     "Taobao requires CAPTCHA completion in the Chrome scraping profile, then retry.",
                     provider="taobao",
                     handoff_expires_at=payload.get("_handoff_expires_at"),
+                    handoff_id=payload.get("_handoff_id"),
                 )
             )
         if title is None and price is None:

--- a/scripts/e2e_stdio_check.py
+++ b/scripts/e2e_stdio_check.py
@@ -24,15 +24,14 @@ from mcp.client.stdio import stdio_client
 
 # script name -> how many model-facing tools it must expose. Operator-only
 # *_selfcheck canaries are no longer MCP tools (they run via
-# `marketplace-mcp doctor`), which is why every figure is one lower than the
-# pre-dsh contract and the marketplace server is 39, not 47.
+# `marketplace-mcp doctor`). The unified server exposes 40 model-facing tools.
 EXPECTED_TOOLS = {
     "wb-mcp": 8,
     "ozon-mcp": 3,
     "detmir-mcp": 3,
     "yandex-mcp": 2,
-    "compare-mcp": 3,
-    "decision-mcp": 4,  # compare trio + decision_inspect
+    "compare-mcp": 4,
+    "decision-mcp": 5,  # compare tools + decision_inspect
     "avito-mcp": 3,
     "taobao-mcp": 2,
     "megamarket-mcp": 2,
@@ -42,7 +41,7 @@ EXPECTED_TOOLS = {
     "aliexpress-mcp": 2,
     "cian-mcp": 2,
     "mpstats-mcp": 2,
-    "marketplace-mcp": 39,  # 38 mounted + marketplace_sources
+    "marketplace-mcp": 40,  # 39 mounted + marketplace_sources
 }
 
 TIMEOUT_S = 60.0

--- a/skills/compare-prices/SKILL.md
+++ b/skills/compare-prices/SKILL.md
@@ -46,6 +46,10 @@ rank its rows against rouble sources.
 - `decision_inspect(source, product_id_or_url)` — return a native shortlisted
   card through the decision profile; use `compare_verify_offer` for an explicit
   identity verdict.
+- `compare_browser_snapshot(handoff_id)` — returns the current retained viewport
+  as MCP image content plus metadata for a same-session, unexpired handle. It
+  never solves, OCRs, or sends the image to another service. Skip it when the
+  client has no image input capability; a missing or foreign handle is `not_found`.
 
 ## Reading the result correctly
 

--- a/skills/marketplace/SKILL.md
+++ b/skills/marketplace/SKILL.md
@@ -10,8 +10,8 @@ One server mounting every installed connector as a namespaced toolset:
 `lamoda_*`, `dns_*`, `citilink_*`, `aliexpress_*`, `cian_*`, `mpstats_*` plus
 `compare_prices` / `compare_sources` and its own `marketplace_sources`. Tool
 names keep their prefixes, so habits and configs carry over — but the operator
-wires a single `marketplace` entry instead of fourteen. The server exposes 39
-tools: 38 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
+wires a single `marketplace` entry instead of fourteen. The server exposes 40
+tools: 39 mounted plus `marketplace_sources`. `mpstats_*` is the optional paid
 source: without `MPSTATS_MP_AUTH` its tools answer `auth_missing` while
 everything else is unaffected.
 

--- a/work/evals/visual-evidence-contract.md
+++ b/work/evals/visual-evidence-contract.md
@@ -30,7 +30,10 @@ MPN/GTIN match from a title or replace structured pagination. A visible CAPTCHA 
 login wall is recorded as `blocked`; the client must not attempt to bypass it.
 
 This contract is deliberately optional and client-side: native vision capability
-is runtime-specific and is not silently assumed by the MCP server.
+is runtime-specific and is not silently assumed by the MCP server. The
+`compare_browser_snapshot(handoff_id)` tool now supplies a bounded JPEG viewport
+through standard MCP image content when a retained page exists. The server does
+not OCR, classify or send the image to another model.
 
 ## Browser recovery direction (2026-09-12)
 

--- a/work/performance/wire-baseline.json
+++ b/work/performance/wire-baseline.json
@@ -3,11 +3,15 @@
   "profiles": {
     "compare-mcp": {
       "script": "compare-mcp",
-      "tool_count": 3,
-      "wire_tokens": 1551,
-      "latency_ms": 1977.4,
-      "schema_sha256": "dda9fa27247f4819b8ff61f0a7ba3ee2eeac92f4cb9bd77eb2b7cb9b117cea7d",
+      "tool_count": 4,
+      "wire_tokens": 1816,
+      "latency_ms": 2706.4,
+      "schema_sha256": "ec75910a4c462e90a7bfb39531fab4e1d1e4edafb76bb4efceb958ecf40ee99b",
       "tools": [
+        {
+          "name": "compare_browser_snapshot",
+          "tokens": 265
+        },
         {
           "name": "compare_prices",
           "tokens": 709
@@ -22,12 +26,41 @@
         }
       ]
     },
+    "decision-mcp": {
+      "script": "decision-mcp",
+      "tool_count": 5,
+      "wire_tokens": 2071,
+      "latency_ms": 2163.7,
+      "schema_sha256": "b2c52ab6e9b6372ddc0f649f590e0ead77de05ba401ac7d138ff69bb01f112de",
+      "tools": [
+        {
+          "name": "compare_browser_snapshot",
+          "tokens": 265
+        },
+        {
+          "name": "compare_prices",
+          "tokens": 709
+        },
+        {
+          "name": "compare_sources",
+          "tokens": 250
+        },
+        {
+          "name": "compare_verify_offer",
+          "tokens": 592
+        },
+        {
+          "name": "decision_inspect",
+          "tokens": 255
+        }
+      ]
+    },
     "marketplace-mcp": {
       "script": "marketplace-mcp",
-      "tool_count": 39,
-      "wire_tokens": 16030,
-      "latency_ms": 2044.8,
-      "schema_sha256": "60d3fd965526d146a4cd37a7e9413c5acdc05657190832025bec8ffdbcfb60ca",
+      "tool_count": 40,
+      "wire_tokens": 16342,
+      "latency_ms": 1998.0,
+      "schema_sha256": "324fdf63fe5236dabf6232e884d336c966fbe471453c6514471935c31c6ce012",
       "tools": [
         {
           "name": "aliexpress_card",
@@ -64,6 +97,10 @@
         {
           "name": "citilink_search",
           "tokens": 221
+        },
+        {
+          "name": "compare_browser_snapshot",
+          "tokens": 265
         },
         {
           "name": "compare_prices",
@@ -103,7 +140,7 @@
         },
         {
           "name": "lamoda_search",
-          "tokens": 241
+          "tokens": 253
         },
         {
           "name": "marketplace_sources",
@@ -139,11 +176,11 @@
         },
         {
           "name": "taobao_card",
-          "tokens": 321
+          "tokens": 343
         },
         {
           "name": "taobao_search",
-          "tokens": 304
+          "tokens": 317
         },
         {
           "name": "wb_card",


### PR DESCRIPTION
Adds compare_browser_snapshot(handoff_id), returning standard MCP JPEG image content from a same-session retained Lamoda/Taobao challenge tab. Bounded session-scoped leases, exact-page resume, expiry, host checks, and cleanup are covered by tests. Also fixes DSH profile precedence FULL > DECISION > compare and updates wire/test baselines.

Local validation: 284 targeted tests passed; 418 core tests, 498 offline core, and 41 DSH guard tests passed during the change. Ruff, mypy, format, stdout, versions and test-count gates pass. Real Chrome/MCP probes verified same-page state, screenshot metadata <=1440x900, native vision read of a generated code, and graceful shutdown cleanup. CI will verify the final commit.